### PR TITLE
Add SafeMode for XSS protection

### DIFF
--- a/src/DjotConverter.php
+++ b/src/DjotConverter.php
@@ -27,13 +27,43 @@ class DjotConverter
      * @param bool $xhtml Whether to use XHTML-compatible output
      * @param bool $warnings Whether to collect warnings during parsing
      * @param bool $strict Whether to throw exceptions on parse errors
+     * @param \Djot\SafeMode|bool|null $safeMode Enable safe mode (true for defaults, SafeMode instance for custom config)
      */
-    public function __construct(bool $xhtml = false, bool $warnings = false, bool $strict = false)
-    {
+    public function __construct(
+        bool $xhtml = false,
+        bool $warnings = false,
+        bool $strict = false,
+        bool|SafeMode|null $safeMode = null,
+    ) {
         $this->collectWarnings = $warnings;
         $this->strictMode = $strict;
         $this->parser = new BlockParser($warnings, $strict);
         $this->renderer = new HtmlRenderer($xhtml);
+
+        // Configure safe mode
+        if ($safeMode === true) {
+            $this->renderer->setSafeMode(SafeMode::defaults());
+        } elseif ($safeMode instanceof SafeMode) {
+            $this->renderer->setSafeMode($safeMode);
+        }
+    }
+
+    /**
+     * Enable or disable safe mode
+     *
+     * @param \Djot\SafeMode|bool|null $safeMode True for defaults, SafeMode for custom, null/false to disable
+     */
+    public function setSafeMode(bool|SafeMode|null $safeMode): self
+    {
+        if ($safeMode === true) {
+            $this->renderer->setSafeMode(SafeMode::defaults());
+        } elseif ($safeMode instanceof SafeMode) {
+            $this->renderer->setSafeMode($safeMode);
+        } else {
+            $this->renderer->setSafeMode(null);
+        }
+
+        return $this;
     }
 
     /**

--- a/src/Renderer/HtmlRenderer.php
+++ b/src/Renderer/HtmlRenderer.php
@@ -44,6 +44,7 @@ use Djot\Node\Inline\Superscript;
 use Djot\Node\Inline\Symbol;
 use Djot\Node\Inline\Text;
 use Djot\Node\Node;
+use Djot\SafeMode;
 
 /**
  * Renders AST to HTML
@@ -51,6 +52,11 @@ use Djot\Node\Node;
 class HtmlRenderer
 {
     protected bool $softBreakAsNewline = true;
+
+    /**
+     * Safe mode configuration (null = disabled)
+     */
+    protected ?SafeMode $safeMode = null;
 
     /**
      * @var array<string, array<\Closure(\Djot\Event\RenderEvent): void>>
@@ -97,6 +103,32 @@ class HtmlRenderer
 
     public function __construct(protected bool $xhtml = false)
     {
+    }
+
+    /**
+     * Enable safe mode with the given configuration
+     */
+    public function setSafeMode(?SafeMode $safeMode): self
+    {
+        $this->safeMode = $safeMode;
+
+        return $this;
+    }
+
+    /**
+     * Get the current safe mode configuration
+     */
+    public function getSafeMode(): ?SafeMode
+    {
+        return $this->safeMode;
+    }
+
+    /**
+     * Check if safe mode is enabled
+     */
+    public function isSafeModeEnabled(): bool
+    {
+        return $this->safeMode !== null;
     }
 
     public function setSoftBreakAsNewline(bool $value): void
@@ -310,6 +342,11 @@ class HtmlRenderer
         $attrs = array_diff_key($attrs, array_flip($exclude));
         if (!$attrs) {
             return '';
+        }
+
+        // Filter dangerous attributes in safe mode
+        if ($this->safeMode !== null) {
+            $attrs = $this->safeMode->filterAttributes($attrs);
         }
 
         // Sort attributes: id first, then others in source order
@@ -625,6 +662,11 @@ class HtmlRenderer
         $href = $node->getDestination();
         $title = $node->getTitle();
 
+        // Sanitize URL in safe mode
+        if ($this->safeMode !== null && $href !== null) {
+            $href = $this->safeMode->sanitizeUrl($href);
+        }
+
         $html = '<a';
         // Only output href if destination is set (even if empty)
         if ($href !== null) {
@@ -642,10 +684,15 @@ class HtmlRenderer
     {
         $attrs = $this->renderAttributes($node);
         $alt = $this->escape($node->getAlt());
-        $src = $this->escape($node->getSource());
+        $src = $node->getSource();
         $title = $node->getTitle();
 
-        $html = '<img alt="' . $alt . '" src="' . $src . '"';
+        // Sanitize URL in safe mode
+        if ($this->safeMode !== null) {
+            $src = $this->safeMode->sanitizeUrl($src);
+        }
+
+        $html = '<img alt="' . $alt . '" src="' . $this->escape($src) . '"';
         if ($title !== null) {
             $html .= ' title="' . $this->escape($title) . '"';
         }
@@ -720,6 +767,11 @@ class HtmlRenderer
             return '';
         }
 
+        // Filter dangerous attributes in safe mode
+        if ($this->safeMode !== null) {
+            $attrs = $this->safeMode->filterAttributes($attrs);
+        }
+
         // Sort attributes: id first, then others in source order
         uksort($attrs, function (string $a, string $b): int {
             if ($a === 'id') {
@@ -768,21 +820,47 @@ class HtmlRenderer
     protected function renderRawBlock(RawBlock $node): string
     {
         // Only output if format is HTML
-        if ($node->getFormat() === 'html') {
-            return $node->getContent() . "\n";
+        if ($node->getFormat() !== 'html') {
+            return '';
         }
 
-        return '';
+        $content = $node->getContent();
+
+        // Handle raw HTML according to safe mode
+        if ($this->safeMode !== null) {
+            $mode = $this->safeMode->getRawHtmlMode();
+            if ($mode === SafeMode::RAW_HTML_STRIP) {
+                return '';
+            }
+            if ($mode === SafeMode::RAW_HTML_ESCAPE) {
+                return $this->escape($content) . "\n";
+            }
+        }
+
+        return $content . "\n";
     }
 
     protected function renderRawInline(RawInline $node): string
     {
         // Only output if format is HTML
-        if ($node->getFormat() === 'html') {
-            return $node->getContent();
+        if ($node->getFormat() !== 'html') {
+            return '';
         }
 
-        return '';
+        $content = $node->getContent();
+
+        // Handle raw HTML according to safe mode
+        if ($this->safeMode !== null) {
+            $mode = $this->safeMode->getRawHtmlMode();
+            if ($mode === SafeMode::RAW_HTML_STRIP) {
+                return '';
+            }
+            if ($mode === SafeMode::RAW_HTML_ESCAPE) {
+                return $this->escape($content);
+            }
+        }
+
+        return $content;
     }
 
     protected function renderDefinitionList(DefinitionList $node): string

--- a/src/SafeMode.php
+++ b/src/SafeMode.php
@@ -1,0 +1,284 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot;
+
+/**
+ * Configuration for safe mode rendering
+ *
+ * Safe mode helps prevent XSS attacks by sanitizing URLs,
+ * filtering dangerous attributes, and controlling raw HTML output.
+ */
+class SafeMode
+{
+    /**
+     * Strip raw HTML completely
+     *
+     * @var string
+     */
+    public const RAW_HTML_STRIP = 'strip';
+
+    /**
+     * Escape raw HTML as text
+     *
+     * @var string
+     */
+    public const RAW_HTML_ESCAPE = 'escape';
+
+    /**
+     * Allow raw HTML (not recommended in safe mode)
+     *
+     * @var string
+     */
+    public const RAW_HTML_ALLOW = 'allow';
+
+    /**
+     * Dangerous URL schemes that should be blocked
+     *
+     * @var array<string>
+     */
+    protected array $dangerousSchemes = [
+        'javascript',
+        'vbscript',
+        'data',
+        'file',
+    ];
+
+    /**
+     * Allowed URL schemes (if set, only these are allowed)
+     *
+     * @var array<string>|null
+     */
+    protected ?array $allowedSchemes = null;
+
+    /**
+     * Attribute prefixes to block (e.g., 'on' blocks onclick, onload, etc.)
+     *
+     * @var array<string>
+     */
+    protected array $blockedAttributePrefixes = ['on'];
+
+    /**
+     * Specific attributes to block
+     *
+     * @var array<string>
+     */
+    protected array $blockedAttributes = ['srcdoc', 'formaction'];
+
+    /**
+     * How to handle raw HTML blocks and inline
+     */
+    protected string $rawHtmlMode = self::RAW_HTML_ESCAPE;
+
+    /**
+     * Create a safe mode configuration with sensible defaults
+     */
+    public static function defaults(): self
+    {
+        return new self();
+    }
+
+    /**
+     * Create a strict safe mode (strips raw HTML completely)
+     */
+    public static function strict(): self
+    {
+        return (new self())->setRawHtmlMode(self::RAW_HTML_STRIP);
+    }
+
+    /**
+     * Get dangerous URL schemes
+     *
+     * @return array<string>
+     */
+    public function getDangerousSchemes(): array
+    {
+        return $this->dangerousSchemes;
+    }
+
+    /**
+     * Set dangerous URL schemes to block
+     *
+     * @param array<string> $schemes
+     */
+    public function setDangerousSchemes(array $schemes): self
+    {
+        $this->dangerousSchemes = $schemes;
+
+        return $this;
+    }
+
+    /**
+     * Add a dangerous URL scheme
+     */
+    public function addDangerousScheme(string $scheme): self
+    {
+        $this->dangerousSchemes[] = strtolower($scheme);
+
+        return $this;
+    }
+
+    /**
+     * Get allowed URL schemes (null means all non-dangerous schemes allowed)
+     *
+     * @return array<string>|null
+     */
+    public function getAllowedSchemes(): ?array
+    {
+        return $this->allowedSchemes;
+    }
+
+    /**
+     * Set allowed URL schemes (whitelist approach)
+     *
+     * @param array<string>|null $schemes Null to allow all non-dangerous schemes
+     */
+    public function setAllowedSchemes(?array $schemes): self
+    {
+        $this->allowedSchemes = $schemes;
+
+        return $this;
+    }
+
+    /**
+     * Get blocked attribute prefixes
+     *
+     * @return array<string>
+     */
+    public function getBlockedAttributePrefixes(): array
+    {
+        return $this->blockedAttributePrefixes;
+    }
+
+    /**
+     * Set blocked attribute prefixes
+     *
+     * @param array<string> $prefixes
+     */
+    public function setBlockedAttributePrefixes(array $prefixes): self
+    {
+        $this->blockedAttributePrefixes = $prefixes;
+
+        return $this;
+    }
+
+    /**
+     * Get blocked attributes
+     *
+     * @return array<string>
+     */
+    public function getBlockedAttributes(): array
+    {
+        return $this->blockedAttributes;
+    }
+
+    /**
+     * Set blocked attributes
+     *
+     * @param array<string> $attributes
+     */
+    public function setBlockedAttributes(array $attributes): self
+    {
+        $this->blockedAttributes = $attributes;
+
+        return $this;
+    }
+
+    /**
+     * Get raw HTML handling mode
+     */
+    public function getRawHtmlMode(): string
+    {
+        return $this->rawHtmlMode;
+    }
+
+    /**
+     * Set raw HTML handling mode
+     *
+     * @param string $mode One of RAW_HTML_STRIP, RAW_HTML_ESCAPE, RAW_HTML_ALLOW
+     */
+    public function setRawHtmlMode(string $mode): self
+    {
+        $this->rawHtmlMode = $mode;
+
+        return $this;
+    }
+
+    /**
+     * Check if a URL is safe
+     */
+    public function isUrlSafe(string $url): bool
+    {
+        $url = trim($url);
+
+        // Empty URLs are safe
+        if ($url === '') {
+            return true;
+        }
+
+        // Check for dangerous schemes
+        $colonPos = strpos($url, ':');
+        if ($colonPos !== false) {
+            $scheme = strtolower(substr($url, 0, $colonPos));
+
+            // Check against dangerous schemes
+            if (in_array($scheme, $this->dangerousSchemes, true)) {
+                return false;
+            }
+
+            // If we have an allowlist, check against it
+            if ($this->allowedSchemes !== null) {
+                return in_array($scheme, $this->allowedSchemes, true);
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Sanitize a URL, returning empty string if unsafe
+     */
+    public function sanitizeUrl(string $url): string
+    {
+        return $this->isUrlSafe($url) ? $url : '';
+    }
+
+    /**
+     * Check if an attribute name is safe
+     */
+    public function isAttributeSafe(string $name): bool
+    {
+        $nameLower = strtolower($name);
+
+        // Check blocked attributes
+        if (in_array($nameLower, $this->blockedAttributes, true)) {
+            return false;
+        }
+
+        // Check blocked prefixes
+        foreach ($this->blockedAttributePrefixes as $prefix) {
+            if (str_starts_with($nameLower, strtolower($prefix))) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Filter attributes, removing unsafe ones
+     *
+     * @param array<string, mixed> $attributes
+     *
+     * @return array<string, mixed>
+     */
+    public function filterAttributes(array $attributes): array
+    {
+        return array_filter(
+            $attributes,
+            fn (string $key) => $this->isAttributeSafe($key),
+            ARRAY_FILTER_USE_KEY,
+        );
+    }
+}

--- a/tests/TestCase/SafeModeTest.php
+++ b/tests/TestCase/SafeModeTest.php
@@ -1,0 +1,305 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Test\TestCase;
+
+use Djot\DjotConverter;
+use Djot\SafeMode;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for safe mode XSS protection
+ */
+class SafeModeTest extends TestCase
+{
+    // ==================== URL Sanitization ====================
+
+    public function testJavascriptUrlInLinkIsBlocked(): void
+    {
+        $converter = new DjotConverter(safeMode: true);
+        $djot = '[click me](javascript:alert(1))';
+        $result = $converter->convert($djot);
+
+        $this->assertStringContainsString('href=""', $result);
+        $this->assertStringNotContainsString('javascript:', $result);
+    }
+
+    public function testJavascriptUrlInImageIsBlocked(): void
+    {
+        $converter = new DjotConverter(safeMode: true);
+        $djot = '![alt](javascript:alert(1))';
+        $result = $converter->convert($djot);
+
+        $this->assertStringContainsString('src=""', $result);
+        $this->assertStringNotContainsString('javascript:', $result);
+    }
+
+    public function testDataUrlIsBlocked(): void
+    {
+        $converter = new DjotConverter(safeMode: true);
+        $djot = '![img](data:text/html,<script>alert(1)</script>)';
+        $result = $converter->convert($djot);
+
+        $this->assertStringContainsString('src=""', $result);
+        $this->assertStringNotContainsString('data:', $result);
+    }
+
+    public function testVbscriptUrlIsBlocked(): void
+    {
+        $converter = new DjotConverter(safeMode: true);
+        $djot = '[click](vbscript:msgbox(1))';
+        $result = $converter->convert($djot);
+
+        $this->assertStringContainsString('href=""', $result);
+        $this->assertStringNotContainsString('vbscript:', $result);
+    }
+
+    public function testFileUrlIsBlocked(): void
+    {
+        $converter = new DjotConverter(safeMode: true);
+        $djot = '[secret](file:///etc/passwd)';
+        $result = $converter->convert($djot);
+
+        $this->assertStringContainsString('href=""', $result);
+        $this->assertStringNotContainsString('file:', $result);
+    }
+
+    public function testHttpUrlIsAllowed(): void
+    {
+        $converter = new DjotConverter(safeMode: true);
+        $djot = '[link](https://example.com)';
+        $result = $converter->convert($djot);
+
+        $this->assertStringContainsString('href="https://example.com"', $result);
+    }
+
+    public function testRelativeUrlIsAllowed(): void
+    {
+        $converter = new DjotConverter(safeMode: true);
+        $djot = '[link](/path/to/page)';
+        $result = $converter->convert($djot);
+
+        $this->assertStringContainsString('href="/path/to/page"', $result);
+    }
+
+    public function testMailtoUrlIsAllowed(): void
+    {
+        $converter = new DjotConverter(safeMode: true);
+        $djot = '[email](mailto:test@example.com)';
+        $result = $converter->convert($djot);
+
+        $this->assertStringContainsString('href="mailto:test@example.com"', $result);
+    }
+
+    // ==================== Attribute Filtering ====================
+
+    public function testOnclickAttributeIsFiltered(): void
+    {
+        $converter = new DjotConverter(safeMode: true);
+        $djot = '[text]{onclick="alert(1)"}';
+        $result = $converter->convert($djot);
+
+        $this->assertStringNotContainsString('onclick', $result);
+    }
+
+    public function testOnloadAttributeIsFiltered(): void
+    {
+        $converter = new DjotConverter(safeMode: true);
+        $djot = '![img](image.png){onload="alert(1)"}';
+        $result = $converter->convert($djot);
+
+        $this->assertStringNotContainsString('onload', $result);
+    }
+
+    public function testOnerrorAttributeIsFiltered(): void
+    {
+        $converter = new DjotConverter(safeMode: true);
+        $djot = '![img](x){onerror="alert(1)"}';
+        $result = $converter->convert($djot);
+
+        $this->assertStringNotContainsString('onerror', $result);
+    }
+
+    public function testOnmouseoverAttributeIsFiltered(): void
+    {
+        $converter = new DjotConverter(safeMode: true);
+        $djot = '[hover me]{onmouseover="alert(1)"}';
+        $result = $converter->convert($djot);
+
+        $this->assertStringNotContainsString('onmouseover', $result);
+    }
+
+    public function testClassAttributeIsAllowed(): void
+    {
+        $converter = new DjotConverter(safeMode: true);
+        $djot = '[text]{.highlight}';
+        $result = $converter->convert($djot);
+
+        $this->assertStringContainsString('class="highlight"', $result);
+    }
+
+    public function testIdAttributeIsAllowed(): void
+    {
+        $converter = new DjotConverter(safeMode: true);
+        $djot = '[text]{#myid}';
+        $result = $converter->convert($djot);
+
+        $this->assertStringContainsString('id="myid"', $result);
+    }
+
+    public function testDataAttributeIsAllowed(): void
+    {
+        $converter = new DjotConverter(safeMode: true);
+        $djot = '[text]{data-value="123"}';
+        $result = $converter->convert($djot);
+
+        $this->assertStringContainsString('data-value="123"', $result);
+    }
+
+    // ==================== Raw HTML Handling ====================
+
+    public function testRawHtmlIsEscapedByDefault(): void
+    {
+        $converter = new DjotConverter(safeMode: true);
+        $djot = '`<script>alert(1)</script>`{=html}';
+        $result = $converter->convert($djot);
+
+        $this->assertStringContainsString('&lt;script&gt;', $result);
+        $this->assertStringNotContainsString('<script>', $result);
+    }
+
+    public function testRawHtmlBlockIsEscapedByDefault(): void
+    {
+        $converter = new DjotConverter(safeMode: true);
+        $djot = "``` =html\n<script>alert(1)</script>\n```";
+        $result = $converter->convert($djot);
+
+        $this->assertStringContainsString('&lt;script&gt;', $result);
+        $this->assertStringNotContainsString('<script>', $result);
+    }
+
+    public function testRawHtmlIsStrippedInStrictMode(): void
+    {
+        $converter = new DjotConverter(safeMode: SafeMode::strict());
+        $djot = '`<script>alert(1)</script>`{=html}';
+        $result = $converter->convert($djot);
+
+        $this->assertStringNotContainsString('script', $result);
+    }
+
+    public function testRawHtmlAllowedWhenConfigured(): void
+    {
+        $safeMode = SafeMode::defaults()->setRawHtmlMode(SafeMode::RAW_HTML_ALLOW);
+        $converter = new DjotConverter(safeMode: $safeMode);
+        $djot = '`<b>bold</b>`{=html}';
+        $result = $converter->convert($djot);
+
+        $this->assertStringContainsString('<b>bold</b>', $result);
+    }
+
+    // ==================== Safe Mode Configuration ====================
+
+    public function testSafeModeDisabledByDefault(): void
+    {
+        $converter = new DjotConverter();
+        $djot = '[click](javascript:alert(1))';
+        $result = $converter->convert($djot);
+
+        // Without safe mode, dangerous URLs are allowed
+        $this->assertStringContainsString('javascript:alert(1)', $result);
+    }
+
+    public function testSafeModeCanBeEnabledAfterConstruction(): void
+    {
+        $converter = new DjotConverter();
+        $converter->setSafeMode(true);
+
+        $djot = '[click](javascript:alert(1))';
+        $result = $converter->convert($djot);
+
+        $this->assertStringNotContainsString('javascript:', $result);
+    }
+
+    public function testSafeModeCanBeDisabledAfterConstruction(): void
+    {
+        $converter = new DjotConverter(safeMode: true);
+        $converter->setSafeMode(false);
+
+        $djot = '[click](javascript:alert(1))';
+        $result = $converter->convert($djot);
+
+        $this->assertStringContainsString('javascript:alert(1)', $result);
+    }
+
+    public function testCustomSafeModeConfiguration(): void
+    {
+        // Create safe mode that also blocks mailto:
+        $safeMode = SafeMode::defaults()->addDangerousScheme('mailto');
+        $converter = new DjotConverter(safeMode: $safeMode);
+
+        $djot = '[email](mailto:test@example.com)';
+        $result = $converter->convert($djot);
+
+        $this->assertStringContainsString('href=""', $result);
+    }
+
+    public function testAllowedSchemesWhitelist(): void
+    {
+        // Only allow https
+        $safeMode = SafeMode::defaults()->setAllowedSchemes(['https']);
+        $converter = new DjotConverter(safeMode: $safeMode);
+
+        $djot1 = '[link](https://example.com)';
+        $result1 = $converter->convert($djot1);
+        $this->assertStringContainsString('href="https://example.com"', $result1);
+
+        $djot2 = '[link](http://example.com)';
+        $result2 = $converter->convert($djot2);
+        $this->assertStringContainsString('href=""', $result2);
+    }
+
+    // ==================== SafeMode Class Tests ====================
+
+    public function testSafeModeIsUrlSafe(): void
+    {
+        $safeMode = SafeMode::defaults();
+
+        $this->assertTrue($safeMode->isUrlSafe('https://example.com'));
+        $this->assertTrue($safeMode->isUrlSafe('/relative/path'));
+        $this->assertTrue($safeMode->isUrlSafe('mailto:test@example.com'));
+        $this->assertFalse($safeMode->isUrlSafe('javascript:alert(1)'));
+        $this->assertFalse($safeMode->isUrlSafe('data:text/html,<script>'));
+    }
+
+    public function testSafeModeIsAttributeSafe(): void
+    {
+        $safeMode = SafeMode::defaults();
+
+        $this->assertTrue($safeMode->isAttributeSafe('class'));
+        $this->assertTrue($safeMode->isAttributeSafe('id'));
+        $this->assertTrue($safeMode->isAttributeSafe('data-value'));
+        $this->assertFalse($safeMode->isAttributeSafe('onclick'));
+        $this->assertFalse($safeMode->isAttributeSafe('onload'));
+        $this->assertFalse($safeMode->isAttributeSafe('ONCLICK')); // Case insensitive
+    }
+
+    public function testSafeModeFilterAttributes(): void
+    {
+        $safeMode = SafeMode::defaults();
+
+        $attrs = [
+            'class' => 'highlight',
+            'onclick' => 'alert(1)',
+            'id' => 'myid',
+            'onmouseover' => 'hack()',
+        ];
+
+        $filtered = $safeMode->filterAttributes($attrs);
+
+        $this->assertArrayHasKey('class', $filtered);
+        $this->assertArrayHasKey('id', $filtered);
+        $this->assertArrayNotHasKey('onclick', $filtered);
+        $this->assertArrayNotHasKey('onmouseover', $filtered);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `SafeMode` configuration class for XSS protection
- Blocks dangerous URL schemes (`javascript:`, `vbscript:`, `data:`, `file:`)
- Filters event handler attributes (`onclick`, `onload`, `onerror`, etc.)
- Handles raw HTML with three modes: escape (default), strip, or allow
- Adds `safeMode` option to `DjotConverter` constructor

## Usage

```php
// Enable with defaults
$converter = new DjotConverter(safeMode: true);

// Enable strict mode (strips raw HTML completely)
$converter = new DjotConverter(safeMode: SafeMode::strict());

// Custom configuration
$safeMode = SafeMode::defaults()
    ->addDangerousScheme('mailto')
    ->setAllowedSchemes(['https'])
    ->setRawHtmlMode(SafeMode::RAW_HTML_STRIP);
$converter = new DjotConverter(safeMode: $safeMode);
```

## Test plan

- [x] 27 new tests covering all safe mode functionality
- [x] All existing tests pass (689 tests, 2130 assertions)
- [x] phpcs and phpstan pass

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)