### PR TITLE
Add MarkdownToDjot converter

### DIFF
--- a/src/Converter/MarkdownToDjot.php
+++ b/src/Converter/MarkdownToDjot.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Converter;
+
+use RuntimeException;
+
+/**
+ * Converts Markdown syntax to Djot syntax
+ *
+ * This performs a source-to-source transformation, not parsing.
+ * It handles common Markdown patterns and converts them to their Djot equivalents.
+ */
+class MarkdownToDjot
+{
+    /**
+     * Convert Markdown text to Djot text
+     */
+    public function convert(string $markdown): string
+    {
+        $lines = explode("\n", $markdown);
+        $result = [];
+        $inCodeBlock = false;
+        $codeFence = '';
+
+        foreach ($lines as $line) {
+            // Track code blocks to avoid converting inside them
+            if (!$inCodeBlock && preg_match('/^(`{3,}|~{3,})/', $line, $matches)) {
+                $inCodeBlock = true;
+                $codeFence = $matches[1][0]; // First char of fence
+                $result[] = $line;
+
+                continue;
+            }
+
+            if ($inCodeBlock) {
+                // Check for closing fence
+                if (preg_match('/^(' . $codeFence . '{3,})\s*$/', $line)) {
+                    $inCodeBlock = false;
+                    $codeFence = '';
+                }
+                $result[] = $line;
+
+                continue;
+            }
+
+            // Convert inline formatting
+            $line = $this->convertInlineFormatting($line);
+            $result[] = $line;
+        }
+
+        return implode("\n", $result);
+    }
+
+    /**
+     * Convert inline Markdown formatting to Djot
+     */
+    protected function convertInlineFormatting(string $line): string
+    {
+        // Protect inline code spans from conversion
+        $protected = [];
+        $line = preg_replace_callback('/`[^`]+`/', function ($match) use (&$protected) {
+            $placeholder = "\x00PROTECTED" . count($protected) . "\x00";
+            $protected[$placeholder] = $match[0];
+
+            return $placeholder;
+        }, $line) ?? $line;
+
+        // Protect existing Djot syntax from double-conversion
+        // Protect {-text-}, {=text=}, {^text^}, {~text~}
+        $line = preg_replace_callback('/\{[-=^~][^}]+[-=^~]\}/', function ($match) use (&$protected) {
+            $placeholder = "\x00PROTECTED" . count($protected) . "\x00";
+            $protected[$placeholder] = $match[0];
+
+            return $placeholder;
+        }, $line) ?? $line;
+
+        // Use placeholder to prevent re-matching
+        $strongPlaceholders = [];
+
+        // Convert ___bold italic___ to *_bold italic_* (Djot)
+        $line = preg_replace_callback('/___(.+?)___/', function ($match) use (&$strongPlaceholders) {
+            $placeholder = "\x00STRONG" . count($strongPlaceholders) . "\x00";
+            $strongPlaceholders[$placeholder] = '*_' . $match[1] . '_*';
+
+            return $placeholder;
+        }, $line) ?? $line;
+
+        // Convert ***bold italic*** to *_bold italic_* (Djot)
+        // Match 3+ asterisks to avoid partial matches
+        $line = preg_replace_callback('/(\*{3,})(.+?)(\*{3,})/', function ($match) use (&$strongPlaceholders) {
+            $placeholder = "\x00STRONG" . count($strongPlaceholders) . "\x00";
+            $strongPlaceholders[$placeholder] = '*_' . $match[2] . '_*';
+
+            return $placeholder;
+        }, $line) ?? $line;
+
+        // Convert **bold with nested content** to *bold* (Djot strong)
+        $line = preg_replace_callback('/\*\*(.+?)\*\*/', function ($match) use (&$strongPlaceholders) {
+            $placeholder = "\x00STRONG" . count($strongPlaceholders) . "\x00";
+            // Recursively convert any *italic* inside to _italic_
+            $inner = preg_replace('/(?<!\*)\*([^*]+)\*(?!\*)/', '_$1_', $match[1]) ?? $match[1];
+            $strongPlaceholders[$placeholder] = '*' . $inner . '*';
+
+            return $placeholder;
+        }, $line) ?? $line;
+
+        // Convert __bold__ to *bold* (Djot strong)
+        $line = preg_replace_callback('/__(.+?)__/', function ($match) use (&$strongPlaceholders) {
+            $placeholder = "\x00STRONG" . count($strongPlaceholders) . "\x00";
+            $strongPlaceholders[$placeholder] = '*' . $match[1] . '*';
+
+            return $placeholder;
+        }, $line) ?? $line;
+
+        // Convert *italic* to _italic_ (Djot emphasis)
+        // Only match single asterisks not preceded/followed by asterisks
+        // Skip if it looks like already-Djot *strong* (single word without spaces surrounded by single *)
+        $line = preg_replace_callback('/(?<!\*)\*([^*]+)\*(?!\*)/', function ($match) {
+            // If this looks like Djot strong (content has no internal formatting markers), leave it
+            // This is a heuristic - can't be perfect without full parsing
+            return '_' . $match[1] . '_';
+        }, $line) ?? $line;
+
+        // Convert ~~strikethrough~~ to {-strikethrough-} (Djot delete)
+        $line = preg_replace('/~~([^~]+)~~/', '{-$1-}', $line) ?? $line;
+
+        // Convert ==highlight== to {=highlight=} (Djot highlight, GFM extension)
+        $line = preg_replace('/==([^=]+)==/', '{=$1=}', $line) ?? $line;
+
+        // Convert ^superscript^ to {^superscript^} (some Markdown extensions)
+        // Only if not already in Djot format
+        $line = preg_replace('/(?<!\{)\^([^^]+)\^(?!\})/', '{^$1^}', $line) ?? $line;
+
+        // Convert ~subscript~ to {~subscript~} (some Markdown extensions)
+        // Only single tildes, not double (strikethrough)
+        $line = preg_replace('/(?<![~{])~([^~}]+)~(?![~}])/', '{~$1~}', $line) ?? $line;
+
+        // Restore strong placeholders
+        foreach ($strongPlaceholders as $placeholder => $content) {
+            $line = str_replace($placeholder, $content, $line);
+        }
+
+        // Restore protected content
+        foreach ($protected as $placeholder => $content) {
+            $line = str_replace($placeholder, $content, $line);
+        }
+
+        return $line;
+    }
+
+    /**
+     * Convert a Markdown file to Djot
+     *
+     * @throws \RuntimeException If file cannot be read
+     */
+    public function convertFile(string $inputPath): string
+    {
+        if (!is_file($inputPath)) {
+            throw new RuntimeException("File not found: {$inputPath}");
+        }
+
+        $content = file_get_contents($inputPath);
+        if ($content === false) {
+            throw new RuntimeException("Failed to read file: {$inputPath}");
+        }
+
+        return $this->convert($content);
+    }
+
+    /**
+     * Convert a Markdown file and save as Djot
+     *
+     * @throws \RuntimeException If file cannot be read or written
+     */
+    public function convertFileAndSave(string $inputPath, ?string $outputPath = null): void
+    {
+        $djot = $this->convertFile($inputPath);
+
+        if ($outputPath === null) {
+            // Replace .md extension with .djot
+            $outputPath = preg_replace('/\.md$/i', '.djot', $inputPath) ?? $inputPath;
+            if ($outputPath === $inputPath) {
+                $outputPath .= '.djot';
+            }
+        }
+
+        $result = file_put_contents($outputPath, $djot);
+        if ($result === false) {
+            throw new RuntimeException("Failed to write file: {$outputPath}");
+        }
+    }
+}

--- a/tests/TestCase/MarkdownToDjotTest.php
+++ b/tests/TestCase/MarkdownToDjotTest.php
@@ -1,0 +1,283 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Test\TestCase;
+
+use Djot\Converter\MarkdownToDjot;
+use PHPUnit\Framework\TestCase;
+
+class MarkdownToDjotTest extends TestCase
+{
+    protected MarkdownToDjot $converter;
+
+    protected function setUp(): void
+    {
+        $this->converter = new MarkdownToDjot();
+    }
+
+    public function testBoldDoubleAsterisk(): void
+    {
+        $markdown = 'This is **bold** text';
+        $expected = 'This is *bold* text';
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testBoldDoubleUnderscore(): void
+    {
+        $markdown = 'This is __bold__ text';
+        $expected = 'This is *bold* text';
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testItalicSingleAsterisk(): void
+    {
+        $markdown = 'This is *italic* text';
+        $expected = 'This is _italic_ text';
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testStrikethrough(): void
+    {
+        $markdown = 'This is ~~deleted~~ text';
+        $expected = 'This is {-deleted-} text';
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testHighlight(): void
+    {
+        $markdown = 'This is ==highlighted== text';
+        $expected = 'This is {=highlighted=} text';
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testSuperscript(): void
+    {
+        $markdown = 'E=mc^2^';
+        $expected = 'E=mc{^2^}';
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testSubscript(): void
+    {
+        $markdown = 'H~2~O';
+        $expected = 'H{~2~}O';
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testMixedFormatting(): void
+    {
+        $markdown = 'This has **bold** and *italic* and ~~strike~~';
+        $expected = 'This has *bold* and _italic_ and {-strike-}';
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testCodeSpanPreserved(): void
+    {
+        $markdown = 'Use `**not bold**` in code';
+        $expected = 'Use `**not bold**` in code';
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testCodeBlockPreserved(): void
+    {
+        $markdown = "Normal **bold**\n```\n**not bold**\n```\nNormal **bold**";
+        $expected = "Normal *bold*\n```\n**not bold**\n```\nNormal *bold*";
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testCodeBlockWithLanguage(): void
+    {
+        $markdown = "```php\n\$x = **value**;\n```";
+        $expected = "```php\n\$x = **value**;\n```";
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testTildeFencedCodeBlock(): void
+    {
+        $markdown = "~~~\n**not bold**\n~~~";
+        $expected = "~~~\n**not bold**\n~~~";
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testHeadingsUnchanged(): void
+    {
+        $markdown = "# Heading 1\n## Heading 2\n### Heading 3";
+        $expected = "# Heading 1\n## Heading 2\n### Heading 3";
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testLinksUnchanged(): void
+    {
+        $markdown = '[link text](https://example.com)';
+        $expected = '[link text](https://example.com)';
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testImagesUnchanged(): void
+    {
+        $markdown = '![alt text](image.png)';
+        $expected = '![alt text](image.png)';
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testListsUnchanged(): void
+    {
+        $markdown = "- item 1\n- item 2\n- item 3";
+        $expected = "- item 1\n- item 2\n- item 3";
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testNumberedListsUnchanged(): void
+    {
+        $markdown = "1. first\n2. second\n3. third";
+        $expected = "1. first\n2. second\n3. third";
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testBlockquotesUnchanged(): void
+    {
+        $markdown = "> This is a quote\n> with multiple lines";
+        $expected = "> This is a quote\n> with multiple lines";
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testThematicBreakUnchanged(): void
+    {
+        $markdown = "Before\n\n---\n\nAfter";
+        $expected = "Before\n\n---\n\nAfter";
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testBoldAndItalicCombined(): void
+    {
+        $markdown = 'This is ***bold and italic*** text';
+        // **bold** becomes *bold*, then remaining *italic* becomes _italic_
+        $expected = 'This is *_bold and italic_* text';
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testNestedFormatting(): void
+    {
+        $markdown = '**bold with *italic* inside**';
+        $expected = '*bold with _italic_ inside*';
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testDjotBracedSyntaxUnchanged(): void
+    {
+        // Braced Djot syntax should remain unchanged
+        $djot = 'This is {-delete-} and {=highlight=} and {^super^} and {~sub~}';
+
+        $this->assertSame($djot, $this->converter->convert($djot));
+    }
+
+    public function testDjotSuperscriptUnchanged(): void
+    {
+        // Already in Djot format should not be double-wrapped
+        $djot = 'E=mc{^2^}';
+
+        $this->assertSame($djot, $this->converter->convert($djot));
+    }
+
+    public function testDjotSubscriptUnchanged(): void
+    {
+        // Already in Djot format should not be double-wrapped
+        $djot = 'H{~2~}O';
+
+        $this->assertSame($djot, $this->converter->convert($djot));
+    }
+
+    public function testComplexDocument(): void
+    {
+        $markdown = <<<'MD'
+# Welcome
+
+This is a **bold** statement with *emphasis*.
+
+## Features
+
+- Item with ~~strikethrough~~
+- Item with ==highlight==
+- Item with `code`
+
+```php
+$bold = "**not converted**";
+```
+
+> A quote with **bold** text
+
+[Link](https://example.com) and ![Image](img.png)
+MD;
+
+        $expected = <<<'DJOT'
+# Welcome
+
+This is a *bold* statement with _emphasis_.
+
+## Features
+
+- Item with {-strikethrough-}
+- Item with {=highlight=}
+- Item with `code`
+
+```php
+$bold = "**not converted**";
+```
+
+> A quote with *bold* text
+
+[Link](https://example.com) and ![Image](img.png)
+DJOT;
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testEmptyString(): void
+    {
+        $this->assertSame('', $this->converter->convert(''));
+    }
+
+    public function testWhitespaceOnly(): void
+    {
+        $markdown = "   \n\n   ";
+        $this->assertSame($markdown, $this->converter->convert($markdown));
+    }
+
+    public function testMultipleCodeSpans(): void
+    {
+        $markdown = 'Use `**bold**` and `*italic*` in code';
+        $expected = 'Use `**bold**` and `*italic*` in code';
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testInlineCodeNextToFormatting(): void
+    {
+        $markdown = '**bold** then `code` then *italic*';
+        $expected = '*bold* then `code` then _italic_';
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+}


### PR DESCRIPTION
## Summary

Adds a source-to-source converter to transform Markdown syntax to Djot syntax.

**Conversions supported:**
- `**bold**` / `__bold__` → `*bold*`
- `*italic*` → `_italic_`  
- `***bold italic***` / `___bold italic___` → `*_bold italic_*`
- `~~strikethrough~~` → `{-strikethrough-}`
- `==highlight==` → `{=highlight=}`
- `^superscript^` → `{^superscript^}`
- `~subscript~` → `{~subscript~}`

**Preserved content:**
- Code blocks (fenced with ``` or ~~~)
- Inline code spans
- Existing Djot braced syntax `{-...-}`, `{=...=}`, etc.

**Usage:**
```php
use Djot\Converter\MarkdownToDjot;

$converter = new MarkdownToDjot();
$djot = $converter->convert($markdown);

// Or convert files
$djot = $converter->convertFile('input.md');
$converter->convertFileAndSave('input.md', 'output.djot');
```

## Test plan

- [x] 29 unit tests covering all conversion patterns
- [x] Tests for code block/span preservation
- [x] Tests for nested formatting
- [x] PHPStan level 8 passes
- [x] Code style passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)