### PR TITLE
Add Profile system for feature restriction

### DIFF
--- a/src/DjotConverter.php
+++ b/src/DjotConverter.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Djot;
 
 use Closure;
+use Djot\Filter\ProfileFilter;
 use Djot\Node\Document;
 use Djot\Parser\BlockParser;
 use Djot\Renderer\HtmlRenderer;
+use LengthException;
 use RuntimeException;
 
 /**
@@ -23,17 +25,23 @@ class DjotConverter
 
     protected bool $strictMode;
 
+    protected ?Profile $profile = null;
+
+    protected ?ProfileFilter $profileFilter = null;
+
     /**
      * @param bool $xhtml Whether to use XHTML-compatible output
      * @param bool $warnings Whether to collect warnings during parsing
      * @param bool $strict Whether to throw exceptions on parse errors
      * @param \Djot\SafeMode|bool|null $safeMode Enable safe mode (true for defaults, SafeMode instance for custom config)
+     * @param \Djot\Profile|null $profile Profile for feature restriction (null = all features allowed)
      */
     public function __construct(
         bool $xhtml = false,
         bool $warnings = false,
         bool $strict = false,
         bool|SafeMode|null $safeMode = null,
+        ?Profile $profile = null,
     ) {
         $this->collectWarnings = $warnings;
         $this->strictMode = $strict;
@@ -45,6 +53,12 @@ class DjotConverter
             $this->renderer->setSafeMode(SafeMode::defaults());
         } elseif ($safeMode instanceof SafeMode) {
             $this->renderer->setSafeMode($safeMode);
+        }
+
+        // Configure profile
+        $this->profile = $profile;
+        if ($profile !== null) {
+            $this->profileFilter = new ProfileFilter();
         }
     }
 
@@ -67,11 +81,54 @@ class DjotConverter
     }
 
     /**
+     * Set the profile for feature restriction
+     *
+     * @param \Djot\Profile|null $profile Null to disable profile filtering
+     */
+    public function setProfile(?Profile $profile): self
+    {
+        $this->profile = $profile;
+        if ($profile !== null && $this->profileFilter === null) {
+            $this->profileFilter = new ProfileFilter();
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get the current profile
+     */
+    public function getProfile(): ?Profile
+    {
+        return $this->profile;
+    }
+
+    /**
      * Convert Djot markup to HTML
+     *
+     * @throws \LengthException If input exceeds profile's max length
      */
     public function convert(string $djot): string
     {
+        // Check max length before parsing
+        if ($this->profile !== null && $this->profile->getMaxLength() > 0) {
+            if (strlen($djot) > $this->profile->getMaxLength()) {
+                throw new LengthException(
+                    sprintf(
+                        'Input length (%d bytes) exceeds maximum allowed (%d bytes)',
+                        strlen($djot),
+                        $this->profile->getMaxLength(),
+                    ),
+                );
+            }
+        }
+
         $document = $this->parse($djot);
+
+        // Apply profile filter after parsing
+        if ($this->profile !== null && $this->profileFilter !== null) {
+            $document = $this->profileFilter->filter($document, $this->profile);
+        }
 
         return $this->render($document);
     }
@@ -200,5 +257,23 @@ class DjotConverter
         $this->parser->clearWarnings();
 
         return $this;
+    }
+
+    /**
+     * Get profile violations from the last convert operation
+     *
+     * @return array<\Djot\ProfileViolation>
+     */
+    public function getProfileViolations(): array
+    {
+        return $this->profileFilter?->getViolations() ?? [];
+    }
+
+    /**
+     * Check if there were any profile violations during the last convert
+     */
+    public function hasProfileViolations(): bool
+    {
+        return count($this->getProfileViolations()) > 0;
     }
 }

--- a/src/Exception/ProfileViolationException.php
+++ b/src/Exception/ProfileViolationException.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Exception;
+
+use Djot\ProfileViolation;
+use RuntimeException;
+
+/**
+ * Exception thrown when profile violations occur in ACTION_ERROR mode
+ */
+class ProfileViolationException extends RuntimeException
+{
+    /**
+     * @param list<\Djot\ProfileViolation> $violations
+     */
+    public function __construct(public readonly array $violations)
+    {
+        $messages = array_map(
+            fn (ProfileViolation $v) => $v->getMessage(),
+            $violations,
+        );
+        parent::__construct('Profile violations: ' . implode('; ', $messages));
+    }
+}

--- a/src/Filter/ProfileFilter.php
+++ b/src/Filter/ProfileFilter.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Filter;
+
+use Djot\Exception\ProfileViolationException;
+use Djot\LinkPolicy;
+use Djot\Node\Block\BlockNode;
+use Djot\Node\Document;
+use Djot\Node\Inline\Image;
+use Djot\Node\Inline\Link;
+use Djot\Node\Inline\Text;
+use Djot\Node\Node;
+use Djot\Profile;
+use Djot\ProfileViolation;
+
+/**
+ * Filters a document AST according to a Profile
+ *
+ * Walks the document tree and either strips, converts to text,
+ * or throws exceptions for disallowed nodes.
+ */
+class ProfileFilter
+{
+    /**
+     * @var list<\Djot\ProfileViolation>
+     */
+    protected array $violations = [];
+
+    protected ?string $baseHost = null;
+
+    /**
+     * Set the base host for external link detection
+     */
+    public function setBaseHost(?string $host): void
+    {
+        $this->baseHost = $host;
+    }
+
+    /**
+     * Filter a document according to the profile
+     */
+    public function filter(Document $doc, Profile $profile): Document
+    {
+        $this->violations = [];
+        $this->filterChildren($doc, $profile, 0);
+
+        return $doc;
+    }
+
+    /**
+     * @return list<\Djot\ProfileViolation>
+     */
+    public function getViolations(): array
+    {
+        return $this->violations;
+    }
+
+    protected function filterChildren(Node $parent, Profile $profile, int $depth): void
+    {
+        // Get a copy of children since we may modify during iteration
+        $children = $parent->getChildren();
+
+        foreach ($children as $child) {
+            // Check nesting depth
+            $maxNesting = $profile->getMaxNesting();
+            if ($maxNesting > 0 && $depth > $maxNesting) {
+                $this->handleViolation($child, $parent, $profile, 'max_nesting_exceeded');
+
+                continue;
+            }
+
+            // Check if this node type is allowed
+            if (!$profile->isNodeAllowed($child)) {
+                $this->handleViolation($child, $parent, $profile, 'element_not_allowed');
+
+                continue;
+            }
+
+            // Special handling for links
+            if ($child instanceof Link && $profile->getLinkPolicy() !== null) {
+                $this->filterLink($child, $parent, $profile);
+            }
+
+            // Special handling for images
+            if ($child instanceof Image && $profile->getLinkPolicy() !== null) {
+                $this->filterImage($child, $parent, $profile);
+            }
+
+            // Recursively filter children
+            $this->filterChildren($child, $profile, $depth + 1);
+        }
+    }
+
+    protected function filterLink(Link $node, Node $parent, Profile $profile): void
+    {
+        $policy = $profile->getLinkPolicy();
+        if ($policy === null) {
+            return;
+        }
+
+        $url = $node->getDestination() ?? '';
+
+        if (!$policy->isUrlAllowed($url, $this->baseHost)) {
+            $this->handleViolation($node, $parent, $profile, 'link_not_allowed');
+
+            return;
+        }
+
+        // Add rel attributes if configured
+        $this->applyRelAttributes($node, $policy);
+    }
+
+    protected function filterImage(Image $node, Node $parent, Profile $profile): void
+    {
+        $policy = $profile->getLinkPolicy();
+        if ($policy === null) {
+            return;
+        }
+
+        $url = $node->getSource();
+
+        if (!$policy->isUrlAllowed($url, $this->baseHost)) {
+            $this->handleViolation($node, $parent, $profile, 'image_not_allowed');
+        }
+    }
+
+    protected function applyRelAttributes(Link $node, LinkPolicy $policy): void
+    {
+        $relAttrs = $policy->getRelAttributes();
+        if ($relAttrs === []) {
+            return;
+        }
+
+        $existing = $node->getAttribute('rel');
+        $existingArray = $existing !== null ? explode(' ', (string)$existing) : [];
+
+        foreach ($relAttrs as $rel) {
+            if (!in_array($rel, $existingArray, true)) {
+                $existingArray[] = $rel;
+            }
+        }
+
+        $node->setAttribute('rel', implode(' ', $existingArray));
+    }
+
+    protected function handleViolation(Node $node, Node $parent, Profile $profile, string $reason): void
+    {
+        $reasonDescription = $profile->getReasonDisallowed($node->getType());
+
+        $this->violations[] = new ProfileViolation(
+            $node->getType(),
+            $reason,
+            $reasonDescription,
+        );
+
+        match ($profile->getDisallowedAction()) {
+            Profile::ACTION_STRIP => $this->stripNode($node, $parent),
+            Profile::ACTION_TO_TEXT => $this->convertToText($node, $parent),
+            Profile::ACTION_ERROR => throw new ProfileViolationException($this->violations),
+            default => $this->convertToText($node, $parent),
+        };
+    }
+
+    protected function stripNode(Node $node, Node $parent): void
+    {
+        $parent->removeChild($node);
+    }
+
+    protected function convertToText(Node $node, Node $parent): void
+    {
+        $textContent = $this->extractTextContent($node);
+
+        if ($textContent === '') {
+            // If no text content, just remove the node
+            $parent->removeChild($node);
+
+            return;
+        }
+
+        // For block nodes, we need to convert to a paragraph with text
+        // For inline nodes, we just convert to text
+        if ($node instanceof BlockNode) {
+            // Extract all text nodes from the block
+            $textNodes = $this->extractTextNodes($node);
+            if ($textNodes !== []) {
+                $parent->replaceChildWithMany($node, $textNodes);
+            } else {
+                $parent->removeChild($node);
+            }
+        } else {
+            // Inline node - replace with text
+            $textNode = new Text($textContent);
+            $parent->replaceChildNode($node, $textNode);
+        }
+    }
+
+    protected function extractTextContent(Node $node): string
+    {
+        // Special handling for images - use alt text
+        if ($node instanceof Image) {
+            return $node->getAlt();
+        }
+
+        // Special handling for links - get child text content
+        if ($node instanceof Link) {
+            $text = '';
+            foreach ($node->getChildren() as $child) {
+                $text .= $this->extractTextContent($child);
+            }
+
+            return $text;
+        }
+
+        if ($node instanceof Text) {
+            return $node->getContent();
+        }
+
+        $text = '';
+        foreach ($node->getChildren() as $child) {
+            $text .= $this->extractTextContent($child);
+        }
+
+        return $text;
+    }
+
+    /**
+     * Extract text nodes from a node, preserving structure where possible
+     *
+     * @return list<\Djot\Node\Node>
+     */
+    protected function extractTextNodes(Node $node): array
+    {
+        $nodes = [];
+
+        foreach ($node->getChildren() as $child) {
+            if ($child instanceof Text) {
+                $nodes[] = new Text($child->getContent());
+            } else {
+                // Recursively extract from child
+                $childNodes = $this->extractTextNodes($child);
+                foreach ($childNodes as $childNode) {
+                    $nodes[] = $childNode;
+                }
+            }
+        }
+
+        return $nodes;
+    }
+}

--- a/src/LinkPolicy.php
+++ b/src/LinkPolicy.php
@@ -1,0 +1,310 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot;
+
+/**
+ * Link URL policy for Profile-based filtering
+ *
+ * Controls which URLs are allowed in links and images.
+ */
+class LinkPolicy
+{
+    /**
+     * @var list<string>|null
+     */
+    protected ?array $allowedSchemes = null;
+
+    /**
+     * @var list<string>
+     */
+    protected array $deniedSchemes = ['javascript', 'vbscript', 'data', 'file'];
+
+    /**
+     * @var list<string>|null
+     */
+    protected ?array $allowedDomains = null;
+
+    /**
+     * @var list<string>
+     */
+    protected array $deniedDomains = [];
+
+    protected bool $allowExternal = true;
+
+    protected bool $allowInternal = true;
+
+    /**
+     * @var list<string>
+     */
+    protected array $relAttributes = [];
+
+    /**
+     * Create a policy that allows all URLs (except dangerous schemes)
+     */
+    public static function unrestricted(): self
+    {
+        return new self();
+    }
+
+    /**
+     * Create a policy that only allows internal links (relative URLs, fragments)
+     *
+     * Use this for contexts where external links are not desired,
+     * such as internal documentation or wikis.
+     */
+    public static function internalOnly(): self
+    {
+        return (new self())->setAllowExternal(false);
+    }
+
+    /**
+     * Create a policy that only allows links to specific domains
+     *
+     * Use this to restrict links to trusted domains only.
+     *
+     * @param list<string> $domains Allowed domain names
+     */
+    public static function allowlist(array $domains): self
+    {
+        return (new self())->setAllowedDomains($domains);
+    }
+
+    /**
+     * @return list<string>|null
+     */
+    public function getAllowedSchemes(): ?array
+    {
+        return $this->allowedSchemes;
+    }
+
+    /**
+     * @param list<string>|null $schemes
+     */
+    public function setAllowedSchemes(?array $schemes): self
+    {
+        $this->allowedSchemes = $schemes;
+
+        return $this;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getDeniedSchemes(): array
+    {
+        return $this->deniedSchemes;
+    }
+
+    /**
+     * @param list<string> $schemes
+     */
+    public function setDeniedSchemes(array $schemes): self
+    {
+        $this->deniedSchemes = $schemes;
+
+        return $this;
+    }
+
+    /**
+     * @return list<string>|null
+     */
+    public function getAllowedDomains(): ?array
+    {
+        return $this->allowedDomains;
+    }
+
+    /**
+     * @param list<string>|null $domains
+     */
+    public function setAllowedDomains(?array $domains): self
+    {
+        $this->allowedDomains = $domains;
+
+        return $this;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getDeniedDomains(): array
+    {
+        return $this->deniedDomains;
+    }
+
+    /**
+     * @param list<string> $domains
+     */
+    public function setDeniedDomains(array $domains): self
+    {
+        $this->deniedDomains = $domains;
+
+        return $this;
+    }
+
+    public function getAllowExternal(): bool
+    {
+        return $this->allowExternal;
+    }
+
+    public function setAllowExternal(bool $allow): self
+    {
+        $this->allowExternal = $allow;
+
+        return $this;
+    }
+
+    public function getAllowInternal(): bool
+    {
+        return $this->allowInternal;
+    }
+
+    public function setAllowInternal(bool $allow): self
+    {
+        $this->allowInternal = $allow;
+
+        return $this;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getRelAttributes(): array
+    {
+        return $this->relAttributes;
+    }
+
+    /**
+     * @param list<string> $attrs
+     */
+    public function setRelAttributes(array $attrs): self
+    {
+        $this->relAttributes = $attrs;
+
+        return $this;
+    }
+
+    /**
+     * Add a rel attribute to be applied to all links
+     */
+    public function addRelAttribute(string $attr): self
+    {
+        if (!in_array($attr, $this->relAttributes, true)) {
+            $this->relAttributes[] = $attr;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Check if a URL is allowed by this policy
+     *
+     * @param string $url The URL to check
+     * @param string|null $baseHost Current document's host (for external detection)
+     */
+    public function isUrlAllowed(string $url, ?string $baseHost = null): bool
+    {
+        $url = trim($url);
+
+        if ($url === '') {
+            return true;
+        }
+
+        // Fragment-only URLs are always internal
+        if (str_starts_with($url, '#')) {
+            return $this->allowInternal;
+        }
+
+        // Relative paths are internal
+        if (str_starts_with($url, '/') || str_starts_with($url, './') || str_starts_with($url, '../')) {
+            return $this->allowInternal;
+        }
+
+        // Check for scheme
+        $colonPos = strpos($url, ':');
+        if ($colonPos !== false) {
+            $scheme = strtolower(substr($url, 0, $colonPos));
+
+            // Check denied schemes
+            if (in_array($scheme, $this->deniedSchemes, true)) {
+                return false;
+            }
+
+            // Check allowed schemes if set
+            if ($this->allowedSchemes !== null && !in_array($scheme, $this->allowedSchemes, true)) {
+                return false;
+            }
+
+            // mailto: and tel: are considered internal for simplicity
+            if (in_array($scheme, ['mailto', 'tel'], true)) {
+                return true;
+            }
+
+            // Parse host for http/https URLs
+            if (in_array($scheme, ['http', 'https'], true)) {
+                $parsed = parse_url($url);
+                $host = $parsed['host'] ?? null;
+
+                if ($host !== null) {
+                    // Check denied domains
+                    if ($this->isDomainDenied($host)) {
+                        return false;
+                    }
+
+                    // Check allowed domains if set
+                    if ($this->allowedDomains !== null && !$this->isDomainAllowed($host)) {
+                        return false;
+                    }
+
+                    // Check external policy
+                    if (!$this->allowExternal) {
+                        // If we have a base host, compare
+                        if ($baseHost !== null && !$this->isSameHost($host, $baseHost)) {
+                            return false;
+                        }
+                        // If no base host, assume all absolute URLs are external
+                        if ($baseHost === null) {
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
+
+    protected function isDomainDenied(string $host): bool
+    {
+        $host = strtolower($host);
+        foreach ($this->deniedDomains as $denied) {
+            if ($host === strtolower($denied) || str_ends_with($host, '.' . strtolower($denied))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected function isDomainAllowed(string $host): bool
+    {
+        if ($this->allowedDomains === null) {
+            return true;
+        }
+
+        $host = strtolower($host);
+        foreach ($this->allowedDomains as $allowed) {
+            if ($host === strtolower($allowed) || str_ends_with($host, '.' . strtolower($allowed))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected function isSameHost(string $host1, string $host2): bool
+    {
+        return strtolower($host1) === strtolower($host2);
+    }
+}

--- a/src/Node/Node.php
+++ b/src/Node/Node.php
@@ -57,6 +57,78 @@ abstract class Node
         $this->children[$index] = $child;
     }
 
+    /**
+     * Replace a child node with another node
+     */
+    public function replaceChildNode(Node $oldChild, Node $newChild): bool
+    {
+        $index = array_search($oldChild, $this->children, true);
+        if ($index === false) {
+            return false;
+        }
+
+        $newChild->parent = $this;
+        $this->children[$index] = $newChild;
+        $oldChild->parent = null;
+
+        return true;
+    }
+
+    /**
+     * Replace a child node with multiple nodes
+     *
+     * @param \Djot\Node\Node $oldChild
+     * @param list<\Djot\Node\Node> $newChildren
+     */
+    public function replaceChildWithMany(Node $oldChild, array $newChildren): bool
+    {
+        $index = array_search($oldChild, $this->children, true);
+        if ($index === false) {
+            return false;
+        }
+
+        foreach ($newChildren as $child) {
+            $child->parent = $this;
+        }
+
+        array_splice($this->children, (int)$index, 1, $newChildren);
+        $oldChild->parent = null;
+
+        return true;
+    }
+
+    /**
+     * Remove a child node
+     */
+    public function removeChild(Node $child): bool
+    {
+        $index = array_search($child, $this->children, true);
+        if ($index === false) {
+            return false;
+        }
+
+        array_splice($this->children, (int)$index, 1);
+        $child->parent = null;
+
+        return true;
+    }
+
+    /**
+     * Remove child at index
+     */
+    public function removeChildAt(int $index): ?Node
+    {
+        if (!isset($this->children[$index])) {
+            return null;
+        }
+
+        $child = $this->children[$index];
+        array_splice($this->children, $index, 1);
+        $child->parent = null;
+
+        return $child;
+    }
+
     public function setAttribute(string $key, mixed $value): void
     {
         $this->attributes[$key] = $value;

--- a/src/NodeType.php
+++ b/src/NodeType.php
@@ -1,0 +1,253 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot;
+
+/**
+ * Node type constants for use with Profile-based filtering
+ */
+final class NodeType
+{
+    // Block types
+    /**
+     * @var string
+     */
+    public const PARAGRAPH = 'paragraph';
+
+    /**
+     * @var string
+     */
+    public const HEADING = 'heading';
+
+    /**
+     * @var string
+     */
+    public const CODE_BLOCK = 'code_block';
+
+    /**
+     * @var string
+     */
+    public const BLOCKQUOTE = 'block_quote';
+
+    /**
+     * @var string
+     */
+    public const LIST_BLOCK = 'list';
+
+    /**
+     * @var string
+     */
+    public const LIST_ITEM = 'list_item';
+
+    /**
+     * @var string
+     */
+    public const TABLE = 'table';
+
+    /**
+     * @var string
+     */
+    public const TABLE_ROW = 'table_row';
+
+    /**
+     * @var string
+     */
+    public const TABLE_CELL = 'table_cell';
+
+    /**
+     * @var string
+     */
+    public const THEMATIC_BREAK = 'thematic_break';
+
+    /**
+     * @var string
+     */
+    public const DIV = 'div';
+
+    /**
+     * @var string
+     */
+    public const RAW_BLOCK = 'raw_block';
+
+    /**
+     * @var string
+     */
+    public const FOOTNOTE = 'footnote';
+
+    /**
+     * @var string
+     */
+    public const DEFINITION_LIST = 'definition_list';
+
+    /**
+     * @var string
+     */
+    public const DEFINITION_TERM = 'definition_term';
+
+    /**
+     * @var string
+     */
+    public const DEFINITION_DESCRIPTION = 'definition_description';
+
+    /**
+     * @var string
+     */
+    public const SECTION = 'section';
+
+    /**
+     * @var string
+     */
+    public const LINE_BLOCK = 'line_block';
+
+    /**
+     * @var string
+     */
+    public const COMMENT = 'comment';
+
+    // Inline types
+    /**
+     * @var string
+     */
+    public const TEXT = 'text';
+
+    /**
+     * @var string
+     */
+    public const EMPHASIS = 'emphasis';
+
+    /**
+     * @var string
+     */
+    public const STRONG = 'strong';
+
+    /**
+     * @var string
+     */
+    public const CODE = 'code';
+
+    /**
+     * @var string
+     */
+    public const LINK = 'link';
+
+    /**
+     * @var string
+     */
+    public const IMAGE = 'image';
+
+    /**
+     * @var string
+     */
+    public const SOFT_BREAK = 'soft_break';
+
+    /**
+     * @var string
+     */
+    public const HARD_BREAK = 'hard_break';
+
+    /**
+     * @var string
+     */
+    public const RAW_INLINE = 'raw_inline';
+
+    /**
+     * @var string
+     */
+    public const FOOTNOTE_REF = 'footnote_reference';
+
+    /**
+     * @var string
+     */
+    public const SPAN = 'span';
+
+    /**
+     * @var string
+     */
+    public const SUPERSCRIPT = 'superscript';
+
+    /**
+     * @var string
+     */
+    public const SUBSCRIPT = 'subscript';
+
+    /**
+     * @var string
+     */
+    public const HIGHLIGHT = 'highlight';
+
+    /**
+     * @var string
+     */
+    public const INSERT = 'insert';
+
+    /**
+     * @var string
+     */
+    public const DELETE = 'delete';
+
+    /**
+     * @var string
+     */
+    public const SYMBOL = 'symbol';
+
+    /**
+     * @var string
+     */
+    public const MATH = 'math';
+
+    /**
+     * @return list<string>
+     */
+    public static function allBlockTypes(): array
+    {
+        return [
+            self::PARAGRAPH,
+            self::HEADING,
+            self::CODE_BLOCK,
+            self::BLOCKQUOTE,
+            self::LIST_BLOCK,
+            self::LIST_ITEM,
+            self::TABLE,
+            self::TABLE_ROW,
+            self::TABLE_CELL,
+            self::THEMATIC_BREAK,
+            self::DIV,
+            self::RAW_BLOCK,
+            self::FOOTNOTE,
+            self::DEFINITION_LIST,
+            self::DEFINITION_TERM,
+            self::DEFINITION_DESCRIPTION,
+            self::SECTION,
+            self::LINE_BLOCK,
+            self::COMMENT,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function allInlineTypes(): array
+    {
+        return [
+            self::TEXT,
+            self::EMPHASIS,
+            self::STRONG,
+            self::CODE,
+            self::LINK,
+            self::IMAGE,
+            self::SOFT_BREAK,
+            self::HARD_BREAK,
+            self::RAW_INLINE,
+            self::FOOTNOTE_REF,
+            self::SPAN,
+            self::SUPERSCRIPT,
+            self::SUBSCRIPT,
+            self::HIGHLIGHT,
+            self::INSERT,
+            self::DELETE,
+            self::SYMBOL,
+            self::MATH,
+        ];
+    }
+}

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -1,0 +1,494 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot;
+
+use Djot\Node\Node;
+
+/**
+ * Profile-based feature restriction for different rendering contexts
+ *
+ * Profiles complement SafeMode (XSS prevention) by controlling which
+ * markup features are available. Use this to create different rendering
+ * contexts like full documents, blog posts, user comments, or chat messages.
+ */
+class Profile
+{
+    /**
+     * Strip disallowed elements from output
+     *
+     * @var string
+     */
+    public const ACTION_STRIP = 'strip';
+
+    /**
+     * Convert disallowed elements to plain text (default, safest for UX)
+     *
+     * @var string
+     */
+    public const ACTION_TO_TEXT = 'to_text';
+
+    /**
+     * Throw exception on disallowed elements
+     *
+     * @var string
+     */
+    public const ACTION_ERROR = 'error';
+
+    protected string $name = 'custom';
+
+    protected string $description = '';
+
+    /**
+     * @var array<string, string>
+     */
+    protected array $featureReasons = [];
+
+    /**
+     * @var list<string>|null
+     */
+    protected ?array $allowedInline = null;
+
+    /**
+     * @var list<string>|null
+     */
+    protected ?array $allowedBlock = null;
+
+    /**
+     * @var list<string>
+     */
+    protected array $deniedInline = [];
+
+    /**
+     * @var list<string>
+     */
+    protected array $deniedBlock = [];
+
+    protected ?LinkPolicy $linkPolicy = null;
+
+    protected int $maxNesting = 0;
+
+    protected int $maxLength = 0;
+
+    protected string $disallowedAction = self::ACTION_TO_TEXT;
+
+    /**
+     * Create a full profile with all features enabled
+     *
+     * Use for trusted content like backend documentation or admin interfaces.
+     */
+    public static function full(): self
+    {
+        $profile = new self();
+        $profile->name = 'full';
+        $profile->description = 'All features enabled. Use only for trusted content.';
+
+        return $profile;
+    }
+
+    /**
+     * Create an article profile suitable for blog posts and articles
+     *
+     * Disables raw HTML to prevent XSS while allowing all formatting features.
+     * Authors can use all djot features except embedding raw HTML/JS.
+     */
+    public static function article(): self
+    {
+        $profile = new self();
+        $profile->name = 'article';
+        $profile->description = 'Blog posts and articles. All formatting, no raw HTML.';
+        $profile
+            ->denyBlock([NodeType::RAW_BLOCK])
+            ->denyInline([NodeType::RAW_INLINE]);
+
+        $profile->featureReasons = [
+            NodeType::RAW_BLOCK => 'Raw HTML blocks are disabled to prevent XSS attacks. Use djot markup instead.',
+            NodeType::RAW_INLINE => 'Raw HTML is disabled to prevent XSS attacks. Use djot markup instead.',
+        ];
+
+        return $profile;
+    }
+
+    /**
+     * Create a comment profile suitable for user-generated content
+     *
+     * Only basic formatting is allowed: bold, italic, strikethrough, code,
+     * links, paragraphs, lists, and blockquotes. This prevents:
+     * - Headings: Users shouldn't structure page hierarchy
+     * - Images: Prevents spam, inappropriate content, bandwidth abuse
+     * - Tables: Too complex for comments, often misused for layout
+     * - Code blocks: Basic inline code is enough for comments
+     * - Footnotes: Overkill for comments
+     * - Raw HTML: XSS prevention
+     * - Divs/Sections: Layout control not needed
+     *
+     * Links have nofollow/ugc attributes to prevent SEO spam.
+     */
+    public static function comment(): self
+    {
+        $profile = new self();
+        $profile->name = 'comment';
+        $profile->description = 'User comments. Basic formatting only, nofollow links.';
+        $profile
+            ->allowInline([
+                NodeType::TEXT,
+                NodeType::EMPHASIS,
+                NodeType::STRONG,
+                NodeType::CODE,
+                NodeType::LINK,
+                NodeType::SOFT_BREAK,
+                NodeType::HARD_BREAK,
+                NodeType::DELETE,
+            ])
+            ->allowBlock([
+                NodeType::PARAGRAPH,
+                NodeType::LIST_BLOCK,
+                NodeType::LIST_ITEM,
+                NodeType::BLOCKQUOTE,
+                NodeType::CODE_BLOCK,
+            ])
+            ->setLinkPolicy(
+                LinkPolicy::unrestricted()
+                    ->addRelAttribute('nofollow')
+                    ->addRelAttribute('ugc'),
+            )
+            ->setMaxNesting(4);
+
+        $profile->featureReasons = [
+            NodeType::HEADING => 'Headings are disabled in comments to prevent disrupting page structure.',
+            NodeType::IMAGE => 'Images are disabled to prevent spam, inappropriate content, and bandwidth abuse.',
+            NodeType::TABLE => 'Tables are disabled as they are too complex for comment formatting.',
+            NodeType::FOOTNOTE => 'Footnotes are disabled as they are unnecessary for comments.',
+            NodeType::FOOTNOTE_REF => 'Footnotes are disabled as they are unnecessary for comments.',
+            NodeType::RAW_BLOCK => 'Raw HTML is disabled for security reasons.',
+            NodeType::RAW_INLINE => 'Raw HTML is disabled for security reasons.',
+            NodeType::DIV => 'Custom containers are disabled in comments.',
+            NodeType::SECTION => 'Sections are disabled in comments.',
+            NodeType::DEFINITION_LIST => 'Definition lists are disabled in comments.',
+            NodeType::DEFINITION_TERM => 'Definition lists are disabled in comments.',
+            NodeType::DEFINITION_DESCRIPTION => 'Definition lists are disabled in comments.',
+            NodeType::THEMATIC_BREAK => 'Horizontal rules are disabled in comments.',
+            NodeType::LINE_BLOCK => 'Line blocks are disabled in comments.',
+            NodeType::SUPERSCRIPT => 'Superscript is disabled to keep comments simple.',
+            NodeType::SUBSCRIPT => 'Subscript is disabled to keep comments simple.',
+            NodeType::HIGHLIGHT => 'Highlighting is disabled in comments.',
+            NodeType::INSERT => 'Insert markup is disabled in comments.',
+            NodeType::SPAN => 'Custom spans are disabled in comments.',
+            NodeType::SYMBOL => 'Symbol markup is disabled in comments.',
+            NodeType::MATH => 'Math markup is disabled in comments.',
+        ];
+
+        return $profile;
+    }
+
+    /**
+     * Create a minimal profile suitable for chat or single-line input
+     *
+     * Only text, bold, italic, and line breaks are allowed.
+     * This is the most restrictive preset, suitable for:
+     * - Chat messages
+     * - Micro-posts
+     * - Subject lines
+     * - Short form content
+     */
+    public static function minimal(): self
+    {
+        $profile = new self();
+        $profile->name = 'minimal';
+        $profile->description = 'Chat/micro-posts. Text, bold, italic only.';
+        $profile
+            ->allowInline([
+                NodeType::TEXT,
+                NodeType::EMPHASIS,
+                NodeType::STRONG,
+                NodeType::SOFT_BREAK,
+                NodeType::HARD_BREAK,
+            ])
+            ->allowBlock([
+                NodeType::PARAGRAPH,
+            ]);
+
+        $profile->featureReasons = [
+            'default' => 'Only basic text formatting (bold, italic) is allowed in this context.',
+        ];
+
+        return $profile;
+    }
+
+    /**
+     * Get the profile name
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Get the profile description
+     */
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    /**
+     * Get the reason why a specific node type is disallowed
+     *
+     * Returns null if the node type is allowed or no specific reason is set.
+     */
+    public function getReasonDisallowed(string $nodeType): ?string
+    {
+        if ($this->isTypeAllowed($nodeType)) {
+            return null;
+        }
+
+        return $this->featureReasons[$nodeType] ?? $this->featureReasons['default'] ?? null;
+    }
+
+    /**
+     * Get all feature restriction reasons
+     *
+     * @return array<string, string>
+     */
+    public function getFeatureReasons(): array
+    {
+        return $this->featureReasons;
+    }
+
+    /**
+     * Set a reason for why a feature is disallowed
+     */
+    public function setFeatureReason(string $nodeType, string $reason): self
+    {
+        $this->featureReasons[$nodeType] = $reason;
+
+        return $this;
+    }
+
+    /**
+     * Set allowed inline types (null means all allowed)
+     *
+     * @param list<string>|null $types
+     */
+    public function allowInline(?array $types): self
+    {
+        $this->allowedInline = $types;
+
+        return $this;
+    }
+
+    /**
+     * Set allowed block types (null means all allowed)
+     *
+     * @param list<string>|null $types
+     */
+    public function allowBlock(?array $types): self
+    {
+        $this->allowedBlock = $types;
+
+        return $this;
+    }
+
+    /**
+     * Add types to the inline deny list
+     *
+     * @param list<string> $types
+     */
+    public function denyInline(array $types): self
+    {
+        $this->deniedInline = array_merge($this->deniedInline, $types);
+
+        return $this;
+    }
+
+    /**
+     * Add types to the block deny list
+     *
+     * @param list<string> $types
+     */
+    public function denyBlock(array $types): self
+    {
+        $this->deniedBlock = array_merge($this->deniedBlock, $types);
+
+        return $this;
+    }
+
+    /**
+     * @return list<string>|null
+     */
+    public function getAllowedInline(): ?array
+    {
+        return $this->allowedInline;
+    }
+
+    /**
+     * @return list<string>|null
+     */
+    public function getAllowedBlock(): ?array
+    {
+        return $this->allowedBlock;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getDeniedInline(): array
+    {
+        return $this->deniedInline;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getDeniedBlock(): array
+    {
+        return $this->deniedBlock;
+    }
+
+    public function getLinkPolicy(): ?LinkPolicy
+    {
+        return $this->linkPolicy;
+    }
+
+    public function setLinkPolicy(?LinkPolicy $policy): self
+    {
+        $this->linkPolicy = $policy;
+
+        return $this;
+    }
+
+    public function getMaxNesting(): int
+    {
+        return $this->maxNesting;
+    }
+
+    /**
+     * Set maximum nesting depth (0 = unlimited)
+     */
+    public function setMaxNesting(int $max): self
+    {
+        $this->maxNesting = $max;
+
+        return $this;
+    }
+
+    public function getMaxLength(): int
+    {
+        return $this->maxLength;
+    }
+
+    /**
+     * Set maximum input length in bytes (0 = unlimited)
+     */
+    public function setMaxLength(int $max): self
+    {
+        $this->maxLength = $max;
+
+        return $this;
+    }
+
+    public function getDisallowedAction(): string
+    {
+        return $this->disallowedAction;
+    }
+
+    /**
+     * Set action for disallowed elements
+     *
+     * @param string $action One of ACTION_STRIP, ACTION_TO_TEXT, ACTION_ERROR
+     */
+    public function onDisallowed(string $action): self
+    {
+        $this->disallowedAction = $action;
+
+        return $this;
+    }
+
+    /**
+     * Check if a node is allowed by this profile
+     */
+    public function isNodeAllowed(Node $node): bool
+    {
+        return $this->isTypeAllowed($node->getType());
+    }
+
+    /**
+     * Check if a type string is allowed by this profile
+     */
+    public function isTypeAllowed(string $type): bool
+    {
+        // Check inline types
+        if (in_array($type, NodeType::allInlineTypes(), true)) {
+            return $this->isInlineAllowed($type);
+        }
+
+        // Check block types
+        if (in_array($type, NodeType::allBlockTypes(), true)) {
+            return $this->isBlockAllowed($type);
+        }
+
+        // Document type is always allowed
+        if ($type === 'document') {
+            return true;
+        }
+
+        // Unknown types are denied by default
+        return false;
+    }
+
+    /**
+     * Check if an inline type is allowed
+     */
+    public function isInlineAllowed(string $type): bool
+    {
+        // Check deny list first
+        if (in_array($type, $this->deniedInline, true)) {
+            return false;
+        }
+
+        // If allowlist is set, check against it
+        if ($this->allowedInline !== null) {
+            return in_array($type, $this->allowedInline, true);
+        }
+
+        // Otherwise allowed
+        return true;
+    }
+
+    /**
+     * Check if a block type is allowed
+     */
+    public function isBlockAllowed(string $type): bool
+    {
+        // Check deny list first
+        if (in_array($type, $this->deniedBlock, true)) {
+            return false;
+        }
+
+        // If allowlist is set, check against it
+        if ($this->allowedBlock !== null) {
+            return in_array($type, $this->allowedBlock, true);
+        }
+
+        // Otherwise allowed
+        return true;
+    }
+
+    /**
+     * Get a summary of what this profile allows/denies
+     *
+     * @return array{name: string, description: string, allowed_block: list<string>|string, allowed_inline: list<string>|string, denied_block: list<string>, denied_inline: list<string>}
+     */
+    public function getSummary(): array
+    {
+        return [
+            'name' => $this->name,
+            'description' => $this->description,
+            'allowed_block' => $this->allowedBlock ?? 'all',
+            'allowed_inline' => $this->allowedInline ?? 'all',
+            'denied_block' => $this->deniedBlock,
+            'denied_inline' => $this->deniedInline,
+        ];
+    }
+}

--- a/src/ProfileViolation.php
+++ b/src/ProfileViolation.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot;
+
+/**
+ * Represents a profile violation during filtering
+ */
+class ProfileViolation
+{
+    public function __construct(
+        public readonly string $nodeType,
+        public readonly string $reason,
+        public readonly ?string $reasonDescription = null,
+    ) {
+    }
+
+    public function getMessage(): string
+    {
+        $msg = "'{$this->nodeType}' is not allowed: {$this->reason}";
+        if ($this->reasonDescription !== null) {
+            $msg .= " ({$this->reasonDescription})";
+        }
+
+        return $msg;
+    }
+}

--- a/tests/TestCase/LinkPolicyTest.php
+++ b/tests/TestCase/LinkPolicyTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Test\TestCase;
+
+use Djot\LinkPolicy;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for LinkPolicy URL restrictions
+ */
+class LinkPolicyTest extends TestCase
+{
+    // ==================== Factory Method Tests ====================
+
+    public function testUnrestrictedAllowsAllUrls(): void
+    {
+        $policy = LinkPolicy::unrestricted();
+
+        $this->assertTrue($policy->isUrlAllowed('https://example.com'));
+        $this->assertTrue($policy->isUrlAllowed('http://example.com'));
+        $this->assertTrue($policy->isUrlAllowed('/path'));
+        $this->assertTrue($policy->isUrlAllowed('#anchor'));
+        $this->assertTrue($policy->isUrlAllowed('./relative'));
+        $this->assertTrue($policy->isUrlAllowed('../parent'));
+    }
+
+    public function testUnrestrictedBlocksDangerousSchemes(): void
+    {
+        $policy = LinkPolicy::unrestricted();
+
+        $this->assertFalse($policy->isUrlAllowed('javascript:alert(1)'));
+        $this->assertFalse($policy->isUrlAllowed('vbscript:msgbox(1)'));
+        $this->assertFalse($policy->isUrlAllowed('data:text/html,<script>'));
+        $this->assertFalse($policy->isUrlAllowed('file:///etc/passwd'));
+    }
+
+    public function testInternalOnlyAllowsRelativeUrls(): void
+    {
+        $policy = LinkPolicy::internalOnly();
+
+        $this->assertTrue($policy->isUrlAllowed('#anchor'));
+        $this->assertTrue($policy->isUrlAllowed('/page'));
+        $this->assertTrue($policy->isUrlAllowed('./relative'));
+        $this->assertTrue($policy->isUrlAllowed('../parent'));
+    }
+
+    public function testInternalOnlyBlocksExternalUrls(): void
+    {
+        $policy = LinkPolicy::internalOnly();
+
+        $this->assertFalse($policy->isUrlAllowed('https://example.com'));
+        $this->assertFalse($policy->isUrlAllowed('http://external.com/path'));
+    }
+
+    public function testInternalOnlyAllowsMailtoAndTel(): void
+    {
+        $policy = LinkPolicy::internalOnly();
+
+        $this->assertTrue($policy->isUrlAllowed('mailto:test@example.com'));
+        $this->assertTrue($policy->isUrlAllowed('tel:+1234567890'));
+    }
+
+    public function testAllowlistOnlyAllowsListedDomains(): void
+    {
+        $policy = LinkPolicy::allowlist(['github.com', 'example.com']);
+
+        $this->assertTrue($policy->isUrlAllowed('https://github.com/user'));
+        $this->assertTrue($policy->isUrlAllowed('https://example.com/page'));
+        $this->assertTrue($policy->isUrlAllowed('https://www.github.com/repo'));
+        $this->assertFalse($policy->isUrlAllowed('https://malware.com'));
+        $this->assertFalse($policy->isUrlAllowed('https://evil.example.org'));
+    }
+
+    // ==================== Scheme Tests ====================
+
+    public function testCustomDeniedSchemes(): void
+    {
+        $policy = (new LinkPolicy())->setDeniedSchemes(['ftp', 'ssh']);
+
+        $this->assertTrue($policy->isUrlAllowed('https://example.com'));
+        $this->assertTrue($policy->isUrlAllowed('javascript:void(0)')); // Not in custom list
+        $this->assertFalse($policy->isUrlAllowed('ftp://server.com'));
+        $this->assertFalse($policy->isUrlAllowed('ssh://server.com'));
+    }
+
+    public function testCustomAllowedSchemes(): void
+    {
+        $policy = (new LinkPolicy())->setAllowedSchemes(['https', 'mailto']);
+
+        $this->assertTrue($policy->isUrlAllowed('https://example.com'));
+        $this->assertTrue($policy->isUrlAllowed('mailto:test@example.com'));
+        $this->assertFalse($policy->isUrlAllowed('http://example.com'));
+        $this->assertFalse($policy->isUrlAllowed('ftp://files.com'));
+    }
+
+    // ==================== Domain Tests ====================
+
+    public function testDeniedDomains(): void
+    {
+        $policy = (new LinkPolicy())->setDeniedDomains(['evil.com', 'spam.org']);
+
+        $this->assertTrue($policy->isUrlAllowed('https://example.com'));
+        $this->assertFalse($policy->isUrlAllowed('https://evil.com'));
+        $this->assertFalse($policy->isUrlAllowed('https://subdomain.evil.com'));
+        $this->assertFalse($policy->isUrlAllowed('https://spam.org/page'));
+    }
+
+    public function testAllowedDomainsWithSubdomains(): void
+    {
+        $policy = (new LinkPolicy())->setAllowedDomains(['example.com']);
+
+        $this->assertTrue($policy->isUrlAllowed('https://example.com'));
+        $this->assertTrue($policy->isUrlAllowed('https://www.example.com'));
+        $this->assertTrue($policy->isUrlAllowed('https://api.example.com'));
+        $this->assertFalse($policy->isUrlAllowed('https://other.com'));
+    }
+
+    // ==================== Rel Attribute Tests ====================
+
+    public function testAddRelAttribute(): void
+    {
+        $policy = (new LinkPolicy())
+            ->addRelAttribute('nofollow')
+            ->addRelAttribute('noopener');
+
+        $attrs = $policy->getRelAttributes();
+        $this->assertContains('nofollow', $attrs);
+        $this->assertContains('noopener', $attrs);
+    }
+
+    public function testAddRelAttributeNoDuplicates(): void
+    {
+        $policy = (new LinkPolicy())
+            ->addRelAttribute('nofollow')
+            ->addRelAttribute('nofollow');
+
+        $attrs = $policy->getRelAttributes();
+        $this->assertCount(1, $attrs);
+    }
+
+    public function testSetRelAttributes(): void
+    {
+        $policy = (new LinkPolicy())
+            ->setRelAttributes(['nofollow', 'ugc', 'noopener']);
+
+        $attrs = $policy->getRelAttributes();
+        $this->assertCount(3, $attrs);
+        $this->assertContains('ugc', $attrs);
+    }
+
+    // ==================== Empty URL Tests ====================
+
+    public function testEmptyUrlIsAllowed(): void
+    {
+        $policy = LinkPolicy::unrestricted();
+        $this->assertTrue($policy->isUrlAllowed(''));
+
+        $policy = LinkPolicy::internalOnly();
+        $this->assertTrue($policy->isUrlAllowed(''));
+    }
+
+    // ==================== Base Host Tests ====================
+
+    public function testExternalDetectionWithBaseHost(): void
+    {
+        $policy = (new LinkPolicy())->setAllowExternal(false);
+
+        // With a base host set, same-host URLs are allowed
+        $this->assertTrue($policy->isUrlAllowed('https://example.com/page', 'example.com'));
+        $this->assertFalse($policy->isUrlAllowed('https://other.com/page', 'example.com'));
+    }
+
+    // ==================== Getter Tests ====================
+
+    public function testGetters(): void
+    {
+        $policy = (new LinkPolicy())
+            ->setAllowedSchemes(['https'])
+            ->setDeniedSchemes(['ftp'])
+            ->setAllowedDomains(['example.com'])
+            ->setDeniedDomains(['evil.com'])
+            ->setAllowExternal(false)
+            ->setAllowInternal(true);
+
+        $this->assertEquals(['https'], $policy->getAllowedSchemes());
+        $this->assertEquals(['ftp'], $policy->getDeniedSchemes());
+        $this->assertEquals(['example.com'], $policy->getAllowedDomains());
+        $this->assertEquals(['evil.com'], $policy->getDeniedDomains());
+        $this->assertFalse($policy->getAllowExternal());
+        $this->assertTrue($policy->getAllowInternal());
+    }
+}

--- a/tests/TestCase/NodeTest.php
+++ b/tests/TestCase/NodeTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Test\TestCase;
+
+use Djot\Node\Block\Paragraph;
+use Djot\Node\Inline\Text;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for Node manipulation methods
+ */
+class NodeTest extends TestCase
+{
+    public function testRemoveChild(): void
+    {
+        $paragraph = new Paragraph();
+        $text1 = new Text('First');
+        $text2 = new Text('Second');
+        $paragraph->appendChild($text1);
+        $paragraph->appendChild($text2);
+
+        $this->assertCount(2, $paragraph->getChildren());
+
+        $result = $paragraph->removeChild($text1);
+
+        $this->assertTrue($result);
+        $this->assertCount(1, $paragraph->getChildren());
+        $this->assertNull($text1->getParent());
+        $this->assertSame($text2, $paragraph->getChildren()[0]);
+    }
+
+    public function testRemoveChildNotFound(): void
+    {
+        $paragraph = new Paragraph();
+        $text1 = new Text('First');
+        $text2 = new Text('Not a child');
+        $paragraph->appendChild($text1);
+
+        $result = $paragraph->removeChild($text2);
+
+        $this->assertFalse($result);
+        $this->assertCount(1, $paragraph->getChildren());
+    }
+
+    public function testRemoveChildAt(): void
+    {
+        $paragraph = new Paragraph();
+        $text1 = new Text('First');
+        $text2 = new Text('Second');
+        $text3 = new Text('Third');
+        $paragraph->appendChild($text1);
+        $paragraph->appendChild($text2);
+        $paragraph->appendChild($text3);
+
+        $removed = $paragraph->removeChildAt(1);
+
+        $this->assertSame($text2, $removed);
+        $this->assertNull($text2->getParent());
+        $this->assertCount(2, $paragraph->getChildren());
+        $this->assertSame($text1, $paragraph->getChildren()[0]);
+        $this->assertSame($text3, $paragraph->getChildren()[1]);
+    }
+
+    public function testRemoveChildAtInvalidIndex(): void
+    {
+        $paragraph = new Paragraph();
+        $text1 = new Text('First');
+        $paragraph->appendChild($text1);
+
+        $removed = $paragraph->removeChildAt(5);
+
+        $this->assertNull($removed);
+        $this->assertCount(1, $paragraph->getChildren());
+    }
+
+    public function testReplaceChildNode(): void
+    {
+        $paragraph = new Paragraph();
+        $text1 = new Text('First');
+        $text2 = new Text('Second');
+        $replacement = new Text('Replacement');
+        $paragraph->appendChild($text1);
+        $paragraph->appendChild($text2);
+
+        $result = $paragraph->replaceChildNode($text1, $replacement);
+
+        $this->assertTrue($result);
+        $this->assertSame($paragraph, $replacement->getParent());
+        $this->assertNull($text1->getParent());
+        $this->assertSame($replacement, $paragraph->getChildren()[0]);
+        $this->assertSame($text2, $paragraph->getChildren()[1]);
+    }
+
+    public function testReplaceChildNodeNotFound(): void
+    {
+        $paragraph = new Paragraph();
+        $text1 = new Text('First');
+        $notChild = new Text('Not a child');
+        $replacement = new Text('Replacement');
+        $paragraph->appendChild($text1);
+
+        $result = $paragraph->replaceChildNode($notChild, $replacement);
+
+        $this->assertFalse($result);
+        $this->assertCount(1, $paragraph->getChildren());
+        $this->assertSame($text1, $paragraph->getChildren()[0]);
+    }
+
+    public function testReplaceChildWithMany(): void
+    {
+        $paragraph = new Paragraph();
+        $text1 = new Text('First');
+        $text2 = new Text('Second');
+        $paragraph->appendChild($text1);
+        $paragraph->appendChild($text2);
+
+        $replacements = [
+            new Text('A'),
+            new Text('B'),
+            new Text('C'),
+        ];
+
+        $result = $paragraph->replaceChildWithMany($text1, $replacements);
+
+        $this->assertTrue($result);
+        $this->assertCount(4, $paragraph->getChildren());
+        $this->assertNull($text1->getParent());
+
+        $children = $paragraph->getChildren();
+        $this->assertEquals('A', $children[0]->getContent());
+        $this->assertEquals('B', $children[1]->getContent());
+        $this->assertEquals('C', $children[2]->getContent());
+        $this->assertSame($text2, $children[3]);
+
+        // Check parents are set
+        foreach ($replacements as $r) {
+            $this->assertSame($paragraph, $r->getParent());
+        }
+    }
+
+    public function testReplaceChildWithManyNotFound(): void
+    {
+        $paragraph = new Paragraph();
+        $text1 = new Text('First');
+        $notChild = new Text('Not a child');
+        $paragraph->appendChild($text1);
+
+        $result = $paragraph->replaceChildWithMany($notChild, [new Text('A')]);
+
+        $this->assertFalse($result);
+        $this->assertCount(1, $paragraph->getChildren());
+    }
+}

--- a/tests/TestCase/ProfileTest.php
+++ b/tests/TestCase/ProfileTest.php
@@ -1,0 +1,702 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Test\TestCase;
+
+use Djot\DjotConverter;
+use Djot\Exception\ProfileViolationException;
+use Djot\LinkPolicy;
+use Djot\NodeType;
+use Djot\Profile;
+use Djot\ProfileViolation;
+use LengthException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for Profile-based feature restriction
+ */
+class ProfileTest extends TestCase
+{
+    // ==================== Comment Profile Tests ====================
+
+    public function testCommentProfileAllowsBasicFormatting(): void
+    {
+        $converter = new DjotConverter(profile: Profile::comment());
+        $html = $converter->convert('This is *bold* and _italic_.');
+
+        $this->assertStringContainsString('<strong>bold</strong>', $html);
+        $this->assertStringContainsString('<em>italic</em>', $html);
+    }
+
+    public function testCommentProfileAllowsDelete(): void
+    {
+        $converter = new DjotConverter(profile: Profile::comment());
+        $html = $converter->convert('This is {-deleted-} text.');
+
+        $this->assertStringContainsString('<del>deleted</del>', $html);
+    }
+
+    public function testCommentProfileAllowsInlineCode(): void
+    {
+        $converter = new DjotConverter(profile: Profile::comment());
+        $html = $converter->convert('Use `code` here.');
+
+        $this->assertStringContainsString('<code>code</code>', $html);
+    }
+
+    public function testCommentProfileAllowsLinks(): void
+    {
+        $converter = new DjotConverter(profile: Profile::comment());
+        $html = $converter->convert('[link](https://example.com)');
+
+        $this->assertStringContainsString('href="https://example.com"', $html);
+    }
+
+    public function testCommentProfileAddsNofollowToLinks(): void
+    {
+        $converter = new DjotConverter(profile: Profile::comment());
+        $html = $converter->convert('[link](https://example.com)');
+
+        $this->assertStringContainsString('rel="nofollow ugc"', $html);
+    }
+
+    public function testCommentProfileAllowsLists(): void
+    {
+        $converter = new DjotConverter(profile: Profile::comment());
+        $html = $converter->convert("- Item 1\n- Item 2");
+
+        $this->assertStringContainsString('<ul>', $html);
+        $this->assertStringContainsString('<li>', $html);
+    }
+
+    public function testCommentProfileAllowsBlockquotes(): void
+    {
+        $converter = new DjotConverter(profile: Profile::comment());
+        $html = $converter->convert('> Quote here');
+
+        $this->assertStringContainsString('<blockquote>', $html);
+    }
+
+    public function testCommentProfileAllowsCodeBlocks(): void
+    {
+        $converter = new DjotConverter(profile: Profile::comment());
+        $html = $converter->convert("```\ncode block\n```");
+
+        $this->assertStringContainsString('<pre>', $html);
+        $this->assertStringContainsString('<code>', $html);
+    }
+
+    public function testCommentProfileStripsHeadings(): void
+    {
+        $converter = new DjotConverter(profile: Profile::comment());
+        $html = $converter->convert("# Heading\n\nParagraph text");
+
+        $this->assertStringNotContainsString('<h1>', $html);
+        $this->assertStringContainsString('Heading', $html);
+        $this->assertStringContainsString('Paragraph text', $html);
+    }
+
+    public function testCommentProfileStripsImages(): void
+    {
+        $converter = new DjotConverter(profile: Profile::comment());
+        $html = $converter->convert('![alt text](image.jpg)');
+
+        $this->assertStringNotContainsString('<img', $html);
+        // Alt text should be preserved as text
+        $this->assertStringContainsString('alt text', $html);
+    }
+
+    public function testCommentProfileStripsTables(): void
+    {
+        $converter = new DjotConverter(profile: Profile::comment());
+        $html = $converter->convert("| A | B |\n|---|---|\n| 1 | 2 |");
+
+        $this->assertStringNotContainsString('<table>', $html);
+    }
+
+    public function testCommentProfileStripsRawHtml(): void
+    {
+        $converter = new DjotConverter(profile: Profile::comment());
+        $html = $converter->convert('`<script>alert(1)</script>`{=html}');
+
+        $this->assertStringNotContainsString('<script>', $html);
+        $this->assertStringNotContainsString('&lt;script', $html);
+    }
+
+    public function testCommentProfileReportsViolations(): void
+    {
+        $converter = new DjotConverter(profile: Profile::comment());
+        $converter->convert("# Heading\n\n![image](test.jpg)");
+
+        $this->assertTrue($converter->hasProfileViolations());
+        $violations = $converter->getProfileViolations();
+        $this->assertNotEmpty($violations);
+
+        // Check that we have violations for heading and image
+        $types = array_map(fn ($v) => $v->nodeType, $violations);
+        $this->assertContains('heading', $types);
+        $this->assertContains('image', $types);
+    }
+
+    // ==================== Minimal Profile Tests ====================
+
+    public function testMinimalProfileAllowsOnlyTextAndEmphasis(): void
+    {
+        $converter = new DjotConverter(profile: Profile::minimal());
+        $html = $converter->convert('*bold* and _italic_ and `code` and [link](url)');
+
+        $this->assertStringContainsString('<strong>bold</strong>', $html);
+        $this->assertStringContainsString('<em>italic</em>', $html);
+        $this->assertStringNotContainsString('<code>', $html);
+        $this->assertStringNotContainsString('<a ', $html);
+    }
+
+    public function testMinimalProfileStripsLists(): void
+    {
+        $converter = new DjotConverter(profile: Profile::minimal());
+        $html = $converter->convert("- Item 1\n- Item 2");
+
+        $this->assertStringNotContainsString('<ul>', $html);
+        $this->assertStringNotContainsString('<li>', $html);
+    }
+
+    // ==================== Article Profile Tests ====================
+
+    public function testArticleProfileAllowsHeadings(): void
+    {
+        $converter = new DjotConverter(profile: Profile::article());
+        $html = $converter->convert('# Heading');
+
+        $this->assertStringContainsString('<h1>', $html);
+    }
+
+    public function testArticleProfileAllowsImages(): void
+    {
+        $converter = new DjotConverter(profile: Profile::article());
+        $html = $converter->convert('![alt](image.jpg)');
+
+        $this->assertStringContainsString('<img', $html);
+    }
+
+    public function testArticleProfileAllowsTables(): void
+    {
+        $converter = new DjotConverter(profile: Profile::article());
+        $html = $converter->convert("| A | B |\n|---|---|\n| 1 | 2 |");
+
+        $this->assertStringContainsString('<table>', $html);
+    }
+
+    public function testArticleProfileStripsRawHtml(): void
+    {
+        $converter = new DjotConverter(profile: Profile::article());
+        $html = $converter->convert('`<script>alert(1)</script>`{=html}');
+
+        $this->assertStringNotContainsString('<script>', $html);
+    }
+
+    // ==================== Full Profile Tests ====================
+
+    public function testFullProfileAllowsEverything(): void
+    {
+        $converter = new DjotConverter(profile: Profile::full());
+        $djot = <<<'DJOT'
+# Heading
+
+Paragraph with *bold* and _italic_.
+
+![image](test.jpg)
+
+| A | B |
+|---|---|
+| 1 | 2 |
+
+```
+code block
+```
+
+> quote
+
+- list item
+
+`<b>raw html</b>`{=html}
+DJOT;
+
+        $html = $converter->convert($djot);
+
+        $this->assertStringContainsString('<h1>', $html);
+        $this->assertStringContainsString('<strong>', $html);
+        $this->assertStringContainsString('<img', $html);
+        $this->assertStringContainsString('<table>', $html);
+        $this->assertStringContainsString('<pre>', $html);
+        $this->assertStringContainsString('<blockquote>', $html);
+        $this->assertStringContainsString('<ul>', $html);
+
+        $this->assertFalse($converter->hasProfileViolations());
+    }
+
+    // ==================== Custom Profile Tests ====================
+
+    public function testCustomProfileWithAllowlist(): void
+    {
+        $profile = (new Profile())
+            ->allowInline([NodeType::TEXT, NodeType::STRONG])
+            ->allowBlock([NodeType::PARAGRAPH]);
+
+        $converter = new DjotConverter(profile: $profile);
+        $html = $converter->convert('*bold* and _italic_');
+
+        $this->assertStringContainsString('<strong>bold</strong>', $html);
+        $this->assertStringNotContainsString('<em>', $html);
+    }
+
+    public function testCustomProfileWithDenylist(): void
+    {
+        $profile = (new Profile())
+            ->denyInline([NodeType::LINK, NodeType::IMAGE])
+            ->denyBlock([NodeType::HEADING]);
+
+        $converter = new DjotConverter(profile: $profile);
+        $html = $converter->convert("# Title\n\n[link](url)");
+
+        $this->assertStringNotContainsString('<h1>', $html);
+        $this->assertStringNotContainsString('<a ', $html);
+    }
+
+    // ==================== Max Length Tests ====================
+
+    public function testMaxLengthThrowsException(): void
+    {
+        $profile = (new Profile())->setMaxLength(10);
+        $converter = new DjotConverter(profile: $profile);
+
+        $this->expectException(LengthException::class);
+        $this->expectExceptionMessage('exceeds maximum');
+        $converter->convert('This is a very long string that exceeds the limit');
+    }
+
+    public function testMaxLengthAllowsShortInput(): void
+    {
+        $profile = (new Profile())->setMaxLength(100);
+        $converter = new DjotConverter(profile: $profile);
+        $html = $converter->convert('Short text');
+
+        $this->assertStringContainsString('Short text', $html);
+    }
+
+    // ==================== Error Action Tests ====================
+
+    public function testActionErrorThrowsException(): void
+    {
+        $profile = Profile::comment()->onDisallowed(Profile::ACTION_ERROR);
+        $converter = new DjotConverter(profile: $profile);
+
+        $this->expectException(ProfileViolationException::class);
+        $converter->convert('# Heading not allowed');
+    }
+
+    public function testActionStripRemovesContent(): void
+    {
+        $profile = Profile::comment()->onDisallowed(Profile::ACTION_STRIP);
+        $converter = new DjotConverter(profile: $profile);
+        $html = $converter->convert("# Heading\n\nParagraph");
+
+        $this->assertStringNotContainsString('Heading', $html);
+        $this->assertStringContainsString('Paragraph', $html);
+    }
+
+    public function testActionToTextPreservesContent(): void
+    {
+        $profile = Profile::comment()->onDisallowed(Profile::ACTION_TO_TEXT);
+        $converter = new DjotConverter(profile: $profile);
+        $html = $converter->convert("# Heading\n\nParagraph");
+
+        // Heading content should be preserved as text
+        $this->assertStringContainsString('Heading', $html);
+        $this->assertStringNotContainsString('<h1>', $html);
+    }
+
+    // ==================== Profile Info Tests ====================
+
+    public function testProfileName(): void
+    {
+        $this->assertEquals('full', Profile::full()->getName());
+        $this->assertEquals('article', Profile::article()->getName());
+        $this->assertEquals('comment', Profile::comment()->getName());
+        $this->assertEquals('minimal', Profile::minimal()->getName());
+    }
+
+    public function testProfileDescription(): void
+    {
+        $this->assertNotEmpty(Profile::full()->getDescription());
+        $this->assertNotEmpty(Profile::article()->getDescription());
+        $this->assertNotEmpty(Profile::comment()->getDescription());
+        $this->assertNotEmpty(Profile::minimal()->getDescription());
+    }
+
+    public function testReasonDisallowed(): void
+    {
+        $profile = Profile::comment();
+
+        // Should have reasons for disallowed types
+        $reason = $profile->getReasonDisallowed(NodeType::HEADING);
+        $this->assertNotNull($reason);
+        $this->assertStringContainsString('heading', strtolower($reason));
+
+        $reason = $profile->getReasonDisallowed(NodeType::IMAGE);
+        $this->assertNotNull($reason);
+
+        // Should return null for allowed types
+        $this->assertNull($profile->getReasonDisallowed(NodeType::PARAGRAPH));
+        $this->assertNull($profile->getReasonDisallowed(NodeType::STRONG));
+    }
+
+    public function testProfileSummary(): void
+    {
+        $profile = Profile::comment();
+        $summary = $profile->getSummary();
+
+        $this->assertArrayHasKey('name', $summary);
+        $this->assertArrayHasKey('description', $summary);
+        $this->assertArrayHasKey('allowed_block', $summary);
+        $this->assertArrayHasKey('allowed_inline', $summary);
+        $this->assertEquals('comment', $summary['name']);
+    }
+
+    // ==================== Profile Setter Tests ====================
+
+    public function testSetProfileAfterConstruction(): void
+    {
+        $converter = new DjotConverter();
+        $converter->setProfile(Profile::comment());
+
+        $html = $converter->convert('# Heading');
+        $this->assertStringNotContainsString('<h1>', $html);
+    }
+
+    public function testGetProfile(): void
+    {
+        $profile = Profile::comment();
+        $converter = new DjotConverter(profile: $profile);
+
+        $this->assertSame($profile, $converter->getProfile());
+    }
+
+    public function testDisableProfile(): void
+    {
+        $converter = new DjotConverter(profile: Profile::comment());
+        $converter->setProfile(null);
+
+        $html = $converter->convert('# Heading');
+        $this->assertStringContainsString('<h1>', $html);
+    }
+
+    // ==================== Combined with SafeMode Tests ====================
+
+    public function testProfileAndSafeModeWorkTogether(): void
+    {
+        $converter = new DjotConverter(
+            safeMode: true,
+            profile: Profile::comment(),
+        );
+
+        $djot = <<<'DJOT'
+# Heading should be stripped
+
+[Safe link](https://example.com)
+
+[Evil link](javascript:alert(1))
+
+Paragraph with *bold*.
+DJOT;
+
+        $html = $converter->convert($djot);
+
+        // Profile strips heading
+        $this->assertStringNotContainsString('<h1>', $html);
+
+        // SafeMode sanitizes javascript URL
+        $this->assertStringNotContainsString('javascript:', $html);
+
+        // Safe link works with nofollow from profile
+        $this->assertStringContainsString('https://example.com', $html);
+        $this->assertStringContainsString('nofollow', $html);
+
+        // Bold works
+        $this->assertStringContainsString('<strong>bold</strong>', $html);
+    }
+
+    // ==================== Max Nesting Tests ====================
+
+    public function testMaxNestingExceeded(): void
+    {
+        $profile = (new Profile())
+            ->allowBlock([NodeType::PARAGRAPH, NodeType::LIST_BLOCK, NodeType::LIST_ITEM])
+            ->allowInline([NodeType::TEXT])
+            ->setMaxNesting(2);
+
+        $converter = new DjotConverter(profile: $profile);
+        // Create deeply nested list
+        $html = $converter->convert("- Level 1\n  - Level 2\n    - Level 3\n      - Level 4");
+
+        // Deeper levels should be filtered
+        $this->assertTrue($converter->hasProfileViolations());
+    }
+
+    // ==================== Link Policy Integration Tests ====================
+
+    public function testLinkPolicyBlocksDisallowedDomain(): void
+    {
+        $profile = (new Profile())
+            ->allowInline([NodeType::TEXT, NodeType::LINK])
+            ->allowBlock([NodeType::PARAGRAPH])
+            ->setLinkPolicy(LinkPolicy::allowlist(['trusted.com']));
+
+        $converter = new DjotConverter(profile: $profile);
+        $html = $converter->convert('[link](https://evil.com)');
+
+        $this->assertStringNotContainsString('evil.com', $html);
+        $this->assertTrue($converter->hasProfileViolations());
+    }
+
+    public function testLinkPolicyAllowsWhitelistedDomain(): void
+    {
+        $profile = (new Profile())
+            ->allowInline([NodeType::TEXT, NodeType::LINK])
+            ->allowBlock([NodeType::PARAGRAPH])
+            ->setLinkPolicy(LinkPolicy::allowlist(['trusted.com']));
+
+        $converter = new DjotConverter(profile: $profile);
+        $html = $converter->convert('[link](https://trusted.com/page)');
+
+        $this->assertStringContainsString('trusted.com', $html);
+        $this->assertFalse($converter->hasProfileViolations());
+    }
+
+    public function testLinkPolicyInternalOnlyBlocksExternal(): void
+    {
+        $profile = (new Profile())
+            ->allowInline([NodeType::TEXT, NodeType::LINK])
+            ->allowBlock([NodeType::PARAGRAPH])
+            ->setLinkPolicy(LinkPolicy::internalOnly());
+
+        $converter = new DjotConverter(profile: $profile);
+        $html = $converter->convert('[external](https://example.com)');
+
+        $this->assertStringNotContainsString('example.com', $html);
+        $this->assertTrue($converter->hasProfileViolations());
+    }
+
+    public function testLinkPolicyInternalOnlyAllowsRelative(): void
+    {
+        $profile = (new Profile())
+            ->allowInline([NodeType::TEXT, NodeType::LINK])
+            ->allowBlock([NodeType::PARAGRAPH])
+            ->setLinkPolicy(LinkPolicy::internalOnly());
+
+        $converter = new DjotConverter(profile: $profile);
+        $html = $converter->convert('[internal](/about)');
+
+        $this->assertStringContainsString('/about', $html);
+        $this->assertFalse($converter->hasProfileViolations());
+    }
+
+    public function testImageWithDisallowedUrl(): void
+    {
+        $profile = (new Profile())
+            ->allowInline([NodeType::TEXT, NodeType::IMAGE])
+            ->allowBlock([NodeType::PARAGRAPH])
+            ->setLinkPolicy(LinkPolicy::allowlist(['trusted.com']));
+
+        $converter = new DjotConverter(profile: $profile);
+        $html = $converter->convert('![alt](https://evil.com/image.jpg)');
+
+        $this->assertStringNotContainsString('evil.com', $html);
+        $this->assertTrue($converter->hasProfileViolations());
+    }
+
+    public function testLinkWithExistingRelAttribute(): void
+    {
+        $profile = (new Profile())
+            ->allowInline([NodeType::TEXT, NodeType::LINK])
+            ->allowBlock([NodeType::PARAGRAPH])
+            ->setLinkPolicy(
+                LinkPolicy::unrestricted()->addRelAttribute('nofollow'),
+            );
+
+        $converter = new DjotConverter(profile: $profile);
+        // Link with existing rel attribute
+        $html = $converter->convert('[link](https://example.com){rel="author"}');
+
+        // Should have both nofollow and author
+        $this->assertStringContainsString('nofollow', $html);
+        $this->assertStringContainsString('author', $html);
+    }
+
+    // ==================== Profile Getter Tests ====================
+
+    public function testGetFeatureReasons(): void
+    {
+        $profile = Profile::comment();
+        $reasons = $profile->getFeatureReasons();
+
+        $this->assertIsArray($reasons);
+        $this->assertArrayHasKey(NodeType::HEADING, $reasons);
+        $this->assertArrayHasKey(NodeType::IMAGE, $reasons);
+    }
+
+    public function testSetFeatureReason(): void
+    {
+        $profile = (new Profile())
+            ->denyBlock([NodeType::HEADING])
+            ->setFeatureReason(NodeType::HEADING, 'Custom reason for heading');
+
+        $reason = $profile->getReasonDisallowed(NodeType::HEADING);
+        $this->assertEquals('Custom reason for heading', $reason);
+    }
+
+    public function testGetAllowedInline(): void
+    {
+        $profile = (new Profile())->allowInline([NodeType::TEXT, NodeType::STRONG]);
+        $allowed = $profile->getAllowedInline();
+
+        $this->assertContains(NodeType::TEXT, $allowed);
+        $this->assertContains(NodeType::STRONG, $allowed);
+    }
+
+    public function testGetAllowedBlock(): void
+    {
+        $profile = (new Profile())->allowBlock([NodeType::PARAGRAPH]);
+        $allowed = $profile->getAllowedBlock();
+
+        $this->assertContains(NodeType::PARAGRAPH, $allowed);
+    }
+
+    public function testGetDeniedInline(): void
+    {
+        $profile = (new Profile())->denyInline([NodeType::LINK]);
+        $denied = $profile->getDeniedInline();
+
+        $this->assertContains(NodeType::LINK, $denied);
+    }
+
+    public function testGetDeniedBlock(): void
+    {
+        $profile = (new Profile())->denyBlock([NodeType::HEADING]);
+        $denied = $profile->getDeniedBlock();
+
+        $this->assertContains(NodeType::HEADING, $denied);
+    }
+
+    public function testIsTypeAllowedWithUnknownType(): void
+    {
+        $profile = Profile::full();
+
+        // Unknown types should be denied
+        $this->assertFalse($profile->isTypeAllowed('unknown_type'));
+    }
+
+    public function testIsTypeAllowedWithDocumentType(): void
+    {
+        $profile = Profile::minimal();
+
+        // Document type should always be allowed
+        $this->assertTrue($profile->isTypeAllowed('document'));
+    }
+
+    public function testGetLinkPolicy(): void
+    {
+        $policy = LinkPolicy::internalOnly();
+        $profile = (new Profile())->setLinkPolicy($policy);
+
+        $this->assertSame($policy, $profile->getLinkPolicy());
+    }
+
+    public function testGetDisallowedAction(): void
+    {
+        $profile = (new Profile())->onDisallowed(Profile::ACTION_STRIP);
+        $this->assertEquals(Profile::ACTION_STRIP, $profile->getDisallowedAction());
+    }
+
+    // ==================== ProfileViolation Tests ====================
+
+    public function testProfileViolationMessage(): void
+    {
+        $violation = new ProfileViolation('heading', 'element_not_allowed', 'Headings are disabled');
+
+        $message = $violation->getMessage();
+        $this->assertStringContainsString('heading', $message);
+        $this->assertStringContainsString('element_not_allowed', $message);
+        $this->assertStringContainsString('Headings are disabled', $message);
+    }
+
+    public function testProfileViolationMessageWithoutDescription(): void
+    {
+        $violation = new ProfileViolation('heading', 'element_not_allowed');
+
+        $message = $violation->getMessage();
+        $this->assertStringContainsString('heading', $message);
+        $this->assertStringNotContainsString('()', $message);
+    }
+
+    // ==================== ProfileViolationException Tests ====================
+
+    public function testProfileViolationExceptionContainsViolations(): void
+    {
+        $profile = Profile::comment()->onDisallowed(Profile::ACTION_ERROR);
+        $converter = new DjotConverter(profile: $profile);
+
+        try {
+            $converter->convert("# Heading\n\n![image](test.jpg)");
+            $this->fail('Expected ProfileViolationException');
+        } catch (ProfileViolationException $e) {
+            $this->assertNotEmpty($e->violations);
+            $this->assertStringContainsString('heading', $e->getMessage());
+        }
+    }
+
+    // ==================== Edge Cases ====================
+
+    public function testEmptyInputWithProfile(): void
+    {
+        $converter = new DjotConverter(profile: Profile::comment());
+        $html = $converter->convert('');
+
+        $this->assertEquals('', trim($html));
+        $this->assertFalse($converter->hasProfileViolations());
+    }
+
+    public function testNestedFormattingConvertedToText(): void
+    {
+        $profile = Profile::minimal();
+        $converter = new DjotConverter(profile: $profile);
+        // Link with nested formatting - minimal doesn't allow links
+        $html = $converter->convert('[*bold link*](url)');
+
+        // Link should be converted to text, but bold inside should remain
+        $this->assertStringNotContainsString('<a ', $html);
+        $this->assertStringContainsString('bold link', $html);
+    }
+
+    public function testMinimalProfileDefaultReason(): void
+    {
+        $profile = Profile::minimal();
+        $reason = $profile->getReasonDisallowed(NodeType::CODE);
+
+        // Should have a default reason
+        $this->assertNotNull($reason);
+    }
+
+    public function testBlockNodeWithNoTextContent(): void
+    {
+        $profile = Profile::comment();
+        $converter = new DjotConverter(profile: $profile);
+        // Thematic break has no text content
+        $html = $converter->convert("Paragraph\n\n---\n\nAnother");
+
+        // Thematic break should just be removed
+        $this->assertStringNotContainsString('<hr', $html);
+        $this->assertStringContainsString('Paragraph', $html);
+        $this->assertStringContainsString('Another', $html);
+    }
+}


### PR DESCRIPTION
## Summary

Introduces a Profile-based filtering system that complements SafeMode (XSS prevention) by controlling which markup features are available for different contexts.

### New Classes

| Class | Purpose |
|-------|---------|
| `Profile` | Main profile class with built-in presets |
| `LinkPolicy` | URL restriction policies |
| `NodeType` | Constants for node types |
| `ProfileFilter` | Post-parse AST filtering |
| `ProfileViolation` | Violation tracking |
| `ProfileViolationException` | Exception for strict mode |

### Built-in Profiles

| Profile | Use Case | Restrictions |
|---------|----------|--------------|
| `Profile::full()` | Documents | None - all features (admin only) |
| `Profile::article()` | Blog posts | No raw HTML |
| `Profile::comment()` | User comments | Basic formatting only, nofollow links |
| `Profile::minimal()` | Chat | Text, bold, italic only |

### Features

- **Per-profile explanations**: Each profile includes convenience methods explaining why features are disallowed
  ```php
  $reason = Profile::comment()->getReasonDisallowed('heading');
  // "Headings are disabled in comments to prevent disrupting page structure."
  ```

- **Safe defaults**: Default action is `to_text` (preserves content as plain text)

- **Link policies**: nofollow/ugc attributes, domain allowlists, internal-only mode

- **Limits**: Max input length and max nesting depth

### Usage

```php
// User comments - basic formatting, nofollow links
$converter = new DjotConverter(profile: Profile::comment());
$html = $converter->convert($userInput);

// Check violations
if ($converter->hasProfileViolations()) {
    foreach ($converter->getProfileViolations() as $v) {
        echo $v->getMessage();
    }
}

// Custom profile
$profile = (new Profile())
    ->allowInline([NodeType::TEXT, NodeType::STRONG, NodeType::EMPHASIS])
    ->allowBlock([NodeType::PARAGRAPH])
    ->setMaxLength(10000);
```
