### PR TITLE
Change PlainTextRenderer table separator default to pipe

### DIFF
--- a/src/Renderer/PlainTextRenderer.php
+++ b/src/Renderer/PlainTextRenderer.php
@@ -48,7 +48,7 @@ class PlainTextRenderer
 
     protected string $orderedListItemPrefix = '. ';
 
-    protected string $tableCellSeparator = "\t";
+    protected string $tableCellSeparator = ' | ';
 
     protected string $blockQuotePrefix = '"';
 

--- a/tests/TestCase/Renderer/PlainTextRendererTest.php
+++ b/tests/TestCase/Renderer/PlainTextRendererTest.php
@@ -117,7 +117,7 @@ class PlainTextRendererTest extends TestCase
         $djot = "| Name | Age |\n|------|-----|\n| Alice | 30 |\n| Bob | 25 |";
         $document = $this->converter->parse($djot);
 
-        $expected = "Name\tAge\nAlice\t30\nBob\t25\n";
+        $expected = "Name | Age\nAlice | 30\nBob | 25\n";
         $this->assertSame($expected, $this->renderer->render($document));
     }
 
@@ -126,7 +126,7 @@ class PlainTextRendererTest extends TestCase
         $djot = "| A | B |\n|---|---|\n| 1 | 2 |\n^ User data";
         $document = $this->converter->parse($djot);
 
-        $expected = "A\tB\n1\t2\nUser data\n";
+        $expected = "A | B\n1 | 2\nUser data\n";
         $this->assertSame($expected, $this->renderer->render($document));
     }
 
@@ -250,11 +250,11 @@ class PlainTextRendererTest extends TestCase
 
     public function testCustomTableSeparator(): void
     {
-        $this->renderer->setTableCellSeparator(' | ');
+        $this->renderer->setTableCellSeparator("\t");
         $djot = "| A | B |\n|---|---|\n| 1 | 2 |";
         $document = $this->converter->parse($djot);
 
-        $expected = "A | B\n1 | 2\n";
+        $expected = "A\tB\n1\t2\n";
         $this->assertSame($expected, $this->renderer->render($document));
     }
 


### PR DESCRIPTION
## Summary

- Changes default table cell separator from `\t` (tab) to ` | ` (pipe with spaces)
- Tab was problematic because display width varies by terminal/editor
- Pipe separator provides consistent, visually clear column separation
- Customization still available via `setTableCellSeparator()`

## Example

Before:
```
Name	Age
Alice	30
Bob	25
```

After:
```
Name | Age
Alice | 30
Bob | 25
```

## Test plan

- [x] Updated table tests to expect pipe separator
- [x] Updated custom separator test to use tab (verifying customization works)
- [x] All 28 PlainTextRenderer tests pass