### PR TITLE
Improve MarkdownToDjot round-trip conversion with HTML tag support

### DIFF
--- a/src/Converter/MarkdownToDjot.php
+++ b/src/Converter/MarkdownToDjot.php
@@ -137,6 +137,50 @@ class MarkdownToDjot
         // Only single tildes, not double (strikethrough)
         $line = preg_replace('/(?<![~{])~([^~}]+)~(?![~}])/', '{~$1~}', $line) ?? $line;
 
+        // Convert HTML tags to Djot equivalents (for round-trip support)
+        // These run AFTER Markdown extension conversions to avoid double-processing
+
+        // <mark>text</mark> → {=text=}
+        $line = preg_replace('/<mark>([^<]+)<\/mark>/i', '{=$1=}', $line) ?? $line;
+
+        // <ins>text</ins> → {+text+}
+        $line = preg_replace('/<ins>([^<]+)<\/ins>/i', '{+$1+}', $line) ?? $line;
+
+        // <del>text</del> → {-text-} (alternative to ~~)
+        $line = preg_replace('/<del>([^<]+)<\/del>/i', '{-$1-}', $line) ?? $line;
+
+        // <sup>text</sup> → ^text^
+        $line = preg_replace('/<sup>([^<]+)<\/sup>/i', '^$1^', $line) ?? $line;
+
+        // <sub>text</sub> → ~text~
+        $line = preg_replace('/<sub>([^<]+)<\/sub>/i', '~$1~', $line) ?? $line;
+
+        // <em>text</em> → _text_
+        $line = preg_replace('/<em>([^<]+)<\/em>/i', '_$1_', $line) ?? $line;
+
+        // <strong>text</strong> → *text*
+        $line = preg_replace('/<strong>([^<]+)<\/strong>/i', '*$1*', $line) ?? $line;
+
+        // <b>text</b> → *text*
+        $line = preg_replace('/<b>([^<]+)<\/b>/i', '*$1*', $line) ?? $line;
+
+        // <i>text</i> → _text_
+        $line = preg_replace('/<i>([^<]+)<\/i>/i', '_$1_', $line) ?? $line;
+
+        // <code>text</code> → `text`
+        $line = preg_replace('/<code>([^<]+)<\/code>/i', '`$1`', $line) ?? $line;
+
+        // Convert $math$ to $`math` (Djot inline math)
+        // Only match $...$ that looks like math (not currency)
+        $line = preg_replace_callback('/\$([^$\s][^$]*[^$\s]|\S)\$/', function ($match) {
+            // Skip if it looks like currency ($5, $100)
+            if (preg_match('/^\d/', $match[1])) {
+                return $match[0];
+            }
+
+            return '$`' . $match[1] . '`';
+        }, $line) ?? $line;
+
         // Restore strong placeholders
         foreach ($strongPlaceholders as $placeholder => $content) {
             $line = str_replace($placeholder, $content, $line);

--- a/tests/TestCase/MarkdownToDjotTest.php
+++ b/tests/TestCase/MarkdownToDjotTest.php
@@ -280,4 +280,144 @@ DJOT;
 
         $this->assertSame($expected, $this->converter->convert($markdown));
     }
+
+    // HTML tag to Djot conversion tests (for round-trip support)
+
+    public function testHtmlMarkToHighlight(): void
+    {
+        $html = 'This is <mark>highlighted</mark> text';
+        $expected = 'This is {=highlighted=} text';
+
+        $this->assertSame($expected, $this->converter->convert($html));
+    }
+
+    public function testHtmlInsToInsert(): void
+    {
+        $html = 'This is <ins>inserted</ins> text';
+        $expected = 'This is {+inserted+} text';
+
+        $this->assertSame($expected, $this->converter->convert($html));
+    }
+
+    public function testHtmlDelToDelete(): void
+    {
+        $html = 'This is <del>deleted</del> text';
+        $expected = 'This is {-deleted-} text';
+
+        $this->assertSame($expected, $this->converter->convert($html));
+    }
+
+    public function testHtmlSupToSuperscript(): void
+    {
+        $html = 'E=mc<sup>2</sup>';
+        $expected = 'E=mc^2^';
+
+        $this->assertSame($expected, $this->converter->convert($html));
+    }
+
+    public function testHtmlSubToSubscript(): void
+    {
+        $html = 'H<sub>2</sub>O';
+        $expected = 'H~2~O';
+
+        $this->assertSame($expected, $this->converter->convert($html));
+    }
+
+    public function testHtmlEmToEmphasis(): void
+    {
+        $html = 'This is <em>emphasis</em> text';
+        $expected = 'This is _emphasis_ text';
+
+        $this->assertSame($expected, $this->converter->convert($html));
+    }
+
+    public function testHtmlStrongToStrong(): void
+    {
+        $html = 'This is <strong>strong</strong> text';
+        $expected = 'This is *strong* text';
+
+        $this->assertSame($expected, $this->converter->convert($html));
+    }
+
+    public function testHtmlBToBold(): void
+    {
+        $html = 'This is <b>bold</b> text';
+        $expected = 'This is *bold* text';
+
+        $this->assertSame($expected, $this->converter->convert($html));
+    }
+
+    public function testHtmlIToItalic(): void
+    {
+        $html = 'This is <i>italic</i> text';
+        $expected = 'This is _italic_ text';
+
+        $this->assertSame($expected, $this->converter->convert($html));
+    }
+
+    public function testHtmlCodeToCode(): void
+    {
+        $html = 'Use the <code>convert</code> method';
+        $expected = 'Use the `convert` method';
+
+        $this->assertSame($expected, $this->converter->convert($html));
+    }
+
+    public function testHtmlTagsCaseInsensitive(): void
+    {
+        $html = '<MARK>highlight</MARK> and <SUP>super</SUP>';
+        $expected = '{=highlight=} and ^super^';
+
+        $this->assertSame($expected, $this->converter->convert($html));
+    }
+
+    public function testMathDollarToBacktick(): void
+    {
+        $markdown = 'Inline $E=mc^2$ math';
+        $expected = 'Inline $`E=mc^2` math';
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testMathDollarNotCurrency(): void
+    {
+        // Currency like $5 should not be converted
+        $markdown = 'It costs $5 or $100';
+        $expected = 'It costs $5 or $100';
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testMathDollarComplexExpression(): void
+    {
+        $markdown = 'The formula $\\sum_{i=0}^{n} i$ works';
+        $expected = 'The formula $`\\sum_{i=0}^{n} i` works';
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testMixedHtmlAndMarkdown(): void
+    {
+        $mixed = '**bold** and <mark>highlight</mark> and *italic*';
+        $expected = '*bold* and {=highlight=} and _italic_';
+
+        $this->assertSame($expected, $this->converter->convert($mixed));
+    }
+
+    public function testRoundTripHighlight(): void
+    {
+        // Simulates djot -> markdown -> djot conversion
+        $html = '<mark>text</mark>';
+        $djot = $this->converter->convert($html);
+
+        $this->assertSame('{=text=}', $djot);
+    }
+
+    public function testRoundTripSuperSubscript(): void
+    {
+        $html = 'H<sub>2</sub>O and E=mc<sup>2</sup>';
+        $djot = $this->converter->convert($html);
+
+        $this->assertSame('H~2~O and E=mc^2^', $djot);
+    }
 }


### PR DESCRIPTION
## Summary

Adds HTML tag to Djot conversion in `MarkdownToDjot` to enable better round-trip conversion between Djot and Markdown formats.

## Problem

When converting Djot → Markdown → Djot, certain Djot-specific features were lost because the MarkdownRenderer outputs HTML tags that weren't converted back:

| Djot | Markdown Output | Back to Djot (before) | Back to Djot (after) |
|------|-----------------|----------------------|---------------------|
| `{=text=}` | `<mark>text</mark>` | `<mark>text</mark>` | `{=text=}` |
| `{+text+}` | `<ins>text</ins>` | `<ins>text</ins>` | `{+text+}` |
| `^text^` | `<sup>text</sup>` | `<sup>text</sup>` | `^text^` |
| `~text~` | `<sub>text</sub>` | `<sub>text</sub>` | `~text~` |
| `$\`E=mc^2\`` | `$E=mc^2$` | `$E=mc^2$` | `$\`E=mc^2\`` |

## Changes

### HTML Tags Converted
- `<mark>` → `{=text=}` (highlight)
- `<ins>` → `{+text+}` (insert)
- `<del>` → `{-text-}` (delete)
- `<sup>` → `^text^` (superscript)
- `<sub>` → `~text~` (subscript)
- `<em>`/`<i>` → `_text_` (emphasis)
- `<strong>`/`<b>` → `*text*` (strong)
- `<code>` → `` `text` `` (code)

### Math Syntax
- `$math$` → `$\`math\`` (inline math, skips currency like $5)

## Tests

Added 17 new tests covering:
- Each HTML tag conversion
- Case insensitivity (`<MARK>` works)
- Math conversion (with currency exception)
- Mixed HTML and Markdown
- Round-trip scenarios

## Test Plan

- [x] All 936 tests pass
- [x] PHPCS passes
- [x] Round-trip conversion verified for highlight, insert, super/subscript, math