### PR TITLE
Fix mixed-style ordered list parsing

### DIFF
--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -1544,8 +1544,11 @@ class BlockParser
                     break;
                 }
 
-                // For ordered lists with styles (roman/alpha), also check style matches
-                if (isset($listInfo['style']) && isset($itemInfo['style']) && $itemInfo['style'] !== $listInfo['style']) {
+                // For ordered lists, check if styles match (roman/alpha vs numeric)
+                // If one has a style and the other doesn't, they're different list types
+                $listStyle = $listInfo['style'] ?? null;
+                $itemStyle = $itemInfo['style'] ?? null;
+                if (($listStyle === null) !== ($itemStyle === null) || $listStyle !== $itemStyle) {
                     break;
                 }
             }
@@ -1965,12 +1968,15 @@ class BlockParser
     {
         $marker = $listInfo['marker'];
         $firstMarkerLetter = null;
+        $firstIsLower = null;
 
         // Extract the letter from the first marker for comparison
         if (preg_match('/^([ivxlcdmIVXLCDM])/', $lines[$start], $m)) {
             $firstMarkerLetter = strtolower($m[1]);
+            $firstIsLower = ctype_lower($m[1]);
         } elseif (preg_match('/^\(([ivxlcdmIVXLCDM])\)/', $lines[$start], $m)) {
             $firstMarkerLetter = strtolower($m[1]);
+            $firstIsLower = ctype_lower($m[1]);
         }
 
         $hasMultiCharRoman = false;
@@ -1994,21 +2000,30 @@ class BlockParser
                 break;
             }
 
-            // Extract the marker text
-            $markerText = null;
+            // Extract the marker text (preserve original case for comparison)
+            $markerTextRaw = null;
             if ($marker === '()') {
                 if (preg_match('/^\(([^)]+)\)/', $line, $m)) {
-                    $markerText = strtolower($m[1]);
+                    $markerTextRaw = $m[1];
                 }
             } else {
                 if (preg_match('/^([a-zA-Z]+)[.)]/', $line, $m)) {
-                    $markerText = strtolower($m[1]);
+                    $markerTextRaw = $m[1];
                 }
             }
 
-            if ($markerText === null) {
+            if ($markerTextRaw === null) {
                 break;
             }
+
+            // Check if case matches - different case means different list style
+            // Per djot spec: "Changing ordered list style... will stop one list and start a new one"
+            $itemIsLower = ctype_lower($markerTextRaw[0]);
+            if ($firstIsLower !== null && $itemIsLower !== $firstIsLower) {
+                break;
+            }
+
+            $markerText = strtolower($markerTextRaw);
 
             // Check for multi-character roman numerals
             if (strlen($markerText) > 1 && preg_match('/^[ivxlcdm]+$/', $markerText)) {

--- a/tests/official/lists.test
+++ b/tests/official/lists.test
@@ -501,6 +501,30 @@ d
 </ol>
 ```
 
+Mixed styles start new lists (issue #23).
+
+```
+i. item
+A. item
+1. item
+.
+<ol type="i">
+<li>
+item
+</li>
+</ol>
+<ol type="A">
+<li>
+item
+</li>
+</ol>
+<ol>
+<li>
+item
+</li>
+</ol>
+```
+
 ```
 The civil war ended in
 1865. And this should not start a list.


### PR DESCRIPTION
## Summary

Fixes #23 - Mixed-style ordered lists now correctly produce separate lists per the djot spec.

Per the djot spec: "Changing ordered list style or bullet will stop one list and start a new one."

**Before:**
```
i. item
A. item
1. item
```
Produced:
```html
<ol start="9" type="a">
<li>item</li>
</ol>
<ol type="A">
<li>item</li>
<li>item</li>
</ol>
```

**After:**
```html
<ol type="i">
<li>item</li>
</ol>
<ol type="A">
<li>item</li>
</ol>
<ol>
<li>item</li>
</ol>
```

### Changes

1. **`disambiguateListStyle()`**: When determining if a single-letter marker is roman numeral or alphabetical, the look-ahead now correctly terminates when encountering items with different case (e.g., lowercase `i.` followed by uppercase `A.`), since different case means a different list style.

2. **`tryParseList()`**: The style compatibility check now correctly treats numeric markers (which have no style) as different from styled lists (roman/alpha). Previously, the check only broke when both lists had explicit styles.

## Test plan

- [x] Added test case from the issue to `tests/official/lists.test`
- [x] All 978 tests pass
- [x] No new PHPStan errors introduced