### PR TITLE
Fix converter blank line handling between block elements

### DIFF
--- a/src/Converter/HtmlToDjot.php
+++ b/src/Converter/HtmlToDjot.php
@@ -461,9 +461,6 @@ class HtmlToDjot
 
     protected function cleanup(string $djot): string
     {
-        // Normalize multiple blank lines to max 2
-        $djot = preg_replace("/\n{3,}/", "\n\n", $djot) ?? $djot;
-
         // Remove leading whitespace from lines (except in code blocks)
         $lines = explode("\n", $djot);
         $inCodeBlock = false;
@@ -493,6 +490,9 @@ class HtmlToDjot
         }
 
         $djot = implode("\n", $result);
+
+        // Normalize multiple blank lines to max 2 (must run after line processing)
+        $djot = preg_replace("/\n{3,}/", "\n\n", $djot) ?? $djot;
 
         // Remove leading/trailing whitespace
         $djot = trim($djot);

--- a/src/Converter/MarkdownToDjot.php
+++ b/src/Converter/MarkdownToDjot.php
@@ -90,13 +90,13 @@ class MarkdownToDjot
                 $result[] = '';
             }
 
-            // Add blank line before blockquote if previous was regular text
-            if ($isBlockquote && $prevLineType === 'text') {
+            // Add blank line before blockquote if previous was non-blank content
+            if ($isBlockquote && $prevLineType !== 'blank' && $prevLineType !== 'blockquote') {
                 $result[] = '';
             }
 
-            // Add blank line before top-level list if previous was regular text
-            if ($isList && $currentIndent === 0 && $prevLineType === 'text') {
+            // Add blank line before top-level list if previous was non-blank, non-list content
+            if ($isList && $currentIndent === 0 && $prevLineType !== 'blank' && $prevLineType !== 'list') {
                 $result[] = '';
             }
 

--- a/tests/TestCase/Converter/HtmlToDjotTest.php
+++ b/tests/TestCase/Converter/HtmlToDjotTest.php
@@ -315,6 +315,16 @@ HTML;
         $this->assertSame("Multiple spaces and newlines\n", $result);
     }
 
+    public function testExcessiveBlankLinesNormalized(): void
+    {
+        // Multiple block elements should not create more than 2 consecutive newlines
+        $html = '<h1>Title</h1><p>Text</p><hr><h2>Section</h2>';
+        $result = $this->converter->convert($html);
+
+        // Should never have more than 2 consecutive newlines
+        $this->assertDoesNotMatchRegularExpression('/\n{3,}/', $result);
+    }
+
     // ==================== Blank Line Handling for Valid Djot ====================
 
     public function testNestedListWithBlankLine(): void

--- a/tests/TestCase/MarkdownToDjotTest.php
+++ b/tests/TestCase/MarkdownToDjotTest.php
@@ -513,6 +513,24 @@ class MarkdownToDjotTest extends TestCase
         $this->assertSame($expected, $this->converter->convert($markdown));
     }
 
+    public function testBlockquoteFollowedByList(): void
+    {
+        // Blank line required between blockquote and list
+        $markdown = "> Quote\n- List item";
+        $expected = "> Quote\n\n- List item";
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testListFollowedByBlockquote(): void
+    {
+        // Blank line required between list and blockquote
+        $markdown = "- List item\n> Quote";
+        $expected = "- List item\n\n> Quote";
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
     public function testExcessiveBlankLinesNormalized(): void
     {
         // Multiple blank lines should be normalized to max 2


### PR DESCRIPTION
HtmlToDjot:
- Move blank line normalization after line processing in cleanup()
- Fixes excessive newlines (>2) between block elements like hr

MarkdownToDjot:
- Add blank line before blockquote when preceded by any content (not just text)
- Add blank line before list when preceded by any content (not just text)
- Fixes missing blank lines between blockquote<->list transitions