### PR TITLE
Fix HtmlToDjot definition list conversion

### DIFF
--- a/src/Converter/HtmlToDjot.php
+++ b/src/Converter/HtmlToDjot.php
@@ -400,14 +400,27 @@ class HtmlToDjot
     protected function processDefinitionList(DOMElement $node): string
     {
         $output = "\n";
+        $lastWasTerm = false;
 
         foreach ($node->childNodes as $child) {
             if ($child instanceof DOMElement) {
                 $tag = strtolower($child->tagName);
                 if ($tag === 'dt') {
-                    $output .= trim($this->processChildren($child)) . "\n";
-                } elseif ($tag === 'dd') {
+                    // Term: `: term` format
                     $output .= ': ' . trim($this->processChildren($child)) . "\n";
+                    $lastWasTerm = true;
+                } elseif ($tag === 'dd') {
+                    // Definition: indented content after blank line
+                    if ($lastWasTerm) {
+                        $output .= "\n";
+                    }
+                    $content = trim($this->processChildren($child));
+                    // Indent definition content
+                    $lines = explode("\n", $content);
+                    foreach ($lines as $line) {
+                        $output .= '  ' . $line . "\n";
+                    }
+                    $lastWasTerm = false;
                 }
             }
         }
@@ -461,9 +474,10 @@ class HtmlToDjot
 
     protected function cleanup(string $djot): string
     {
-        // Remove leading whitespace from lines (except in code blocks)
+        // Remove leading whitespace from lines (except in code blocks and indented content)
         $lines = explode("\n", $djot);
         $inCodeBlock = false;
+        $inDefinitionList = false;
         $result = [];
 
         foreach ($lines as $line) {
@@ -477,16 +491,43 @@ class HtmlToDjot
 
             if ($inCodeBlock) {
                 $result[] = $line;
-            } else {
-                // Preserve indentation for list items, trim other leading whitespace
-                if (preg_match('/^(\s*)([-*+]|\d+\.)\s/', $line, $m)) {
-                    // It's a list item - preserve indentation
-                    $result[] = $line;
-                } else {
-                    // Regular line - trim leading whitespace
-                    $result[] = ltrim($line);
-                }
+
+                continue;
             }
+
+            // Track definition lists (`: term` starts one)
+            if (preg_match('/^: /', $line)) {
+                $inDefinitionList = true;
+                $result[] = $line;
+
+                continue;
+            }
+
+            // Preserve indentation for list items
+            if (preg_match('/^(\s*)([-*+]|\d+\.)\s/', $line, $m)) {
+                $result[] = $line;
+                $inDefinitionList = false;
+
+                continue;
+            }
+
+            // Preserve indentation for definition content (indented lines after `: term`)
+            if ($inDefinitionList && preg_match('/^  /', $line)) {
+                $result[] = $line;
+
+                continue;
+            }
+
+            // Blank line ends definition list context
+            if (trim($line) === '') {
+                $result[] = $line;
+
+                continue;
+            }
+
+            // Regular line - trim leading whitespace and reset definition list context
+            $result[] = ltrim($line);
+            $inDefinitionList = false;
         }
 
         $djot = implode("\n", $result);

--- a/tests/TestCase/Converter/HtmlToDjotTest.php
+++ b/tests/TestCase/Converter/HtmlToDjotTest.php
@@ -234,8 +234,20 @@ HTML;
         $html = '<dl><dt>Term</dt><dd>Definition</dd></dl>';
         $result = $this->converter->convert($html);
 
-        $this->assertStringContainsString('Term', $result);
-        $this->assertStringContainsString(': Definition', $result);
+        // Djot format: `: term` for term, indented content for definition
+        $this->assertStringContainsString(': Term', $result);
+        $this->assertStringContainsString('  Definition', $result);
+    }
+
+    public function testDefinitionListMultipleTerms(): void
+    {
+        $html = '<dl><dt>color</dt><dt>colour</dt><dd>The visual property.</dd></dl>';
+        $result = $this->converter->convert($html);
+
+        // Multiple terms share one definition
+        $this->assertStringContainsString(': color', $result);
+        $this->assertStringContainsString(': colour', $result);
+        $this->assertStringContainsString('  The visual property.', $result);
     }
 
     // ==================== Spans with Attributes ====================


### PR DESCRIPTION
## Summary

Fixes HtmlToDjot to output valid Djot syntax for definition lists that can roundtrip correctly.

### Before (broken)
```html
<dl><dt>Term</dt><dd>Definition</dd></dl>
```
Converted to:
```
Term
: Definition
```
This is **not valid Djot** - the term needs `: ` prefix and definition needs indentation.

### After (fixed)
```djot
: Term

  Definition
```
This roundtrips correctly back to:
```html
<dl><dt>Term</dt><dd><p>Definition</p></dd></dl>
```

### Multiple terms support
```html
<dl><dt>color</dt><dt>colour</dt><dd>The visual property.</dd></dl>
```
Converts to:
```djot
: color
: colour

  The visual property.
```

## Test plan
- [x] Single term + definition roundtrips
- [x] Multiple terms sharing one definition roundtrips  
- [x] All existing tests pass (1032 tests)