### PR TITLE
Add multiple dd support for definition lists with multiple terms

### DIFF
--- a/docs/enhancements.md
+++ b/docs/enhancements.md
@@ -368,7 +368,7 @@ This fenced syntax is consistent with code fences (`` ``` ``) and div fences (`:
 
 **Status:** Implemented in djot-php
 
-Multiple terms can share a single definition in definition lists:
+Multiple terms can share definitions in definition lists:
 
 ```djot
 : CLI
@@ -398,10 +398,36 @@ Multiple terms can share a single definition in definition lists:
 </dl>
 ```
 
+**Multiple definitions:** When multiple terms share definitions, each indented paragraph block (separated by blank lines) becomes a separate `<dd>`:
+
+```djot
+: color
+: colour
+
+  The visual property of objects.
+
+  Used in art and design.
+```
+
+**Output:**
+```html
+<dl>
+<dt>color</dt>
+<dt>colour</dt>
+<dd>
+<p>The visual property of objects.</p>
+</dd>
+<dd>
+<p>Used in art and design.</p>
+</dd>
+</dl>
+```
+
 **Rules:**
 - Consecutive `: term` lines are grouped as multiple terms
 - Blank lines between terms are allowed
 - Definition follows after blank line with indentation
+- Each paragraph block becomes a separate `<dd>` element
 - Common in dictionaries for synonyms, abbreviations, and alternate spellings
 
 ---

--- a/src/Converter/HtmlToDjot.php
+++ b/src/Converter/HtmlToDjot.php
@@ -401,6 +401,7 @@ class HtmlToDjot
     {
         $output = "\n";
         $lastWasTerm = false;
+        $ddCount = 0;
 
         foreach ($node->childNodes as $child) {
             if ($child instanceof DOMElement) {
@@ -409,9 +410,10 @@ class HtmlToDjot
                     // Term: `: term` format
                     $output .= ': ' . trim($this->processChildren($child)) . "\n";
                     $lastWasTerm = true;
+                    $ddCount = 0;
                 } elseif ($tag === 'dd') {
                     // Definition: indented content after blank line
-                    if ($lastWasTerm) {
+                    if ($lastWasTerm || $ddCount > 0) {
                         $output .= "\n";
                     }
                     $content = trim($this->processChildren($child));
@@ -421,6 +423,7 @@ class HtmlToDjot
                         $output .= '  ' . $line . "\n";
                     }
                     $lastWasTerm = false;
+                    $ddCount++;
                 }
             }
         }

--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -1727,7 +1727,9 @@ class BlockParser
             }
 
             // Now collect definition content (after blank line, 2-space indent)
+            // When multiple terms share definitions, each paragraph block becomes a separate dd
             $defLines = [];
+            $multipleTerms = count($terms) > 1;
 
             // If term started with code fence, add it to definition content
             if ($codeFenceInfo !== null) {
@@ -1758,22 +1760,33 @@ class BlockParser
                 }
             }
 
-            // Create definition node
-            $def = new DefinitionDescription();
-            if ($defLines !== []) {
-                // Remove leading blank lines
-                while ($defLines !== [] && $defLines[0] === '') {
-                    array_shift($defLines);
+            // Create definition node(s)
+            if ($multipleTerms && $defLines !== []) {
+                // Split by blank lines - each block becomes a separate dd
+                $blocks = $this->splitByBlankLines($defLines);
+                foreach ($blocks as $block) {
+                    $def = new DefinitionDescription();
+                    $this->parseBlocks($def, $block, 0);
+                    $defList->appendChild($def);
                 }
-                // Remove trailing blank lines
-                $defLineCount = count($defLines);
-                while ($defLineCount > 0 && $defLines[$defLineCount - 1] === '') {
-                    array_pop($defLines);
-                    $defLineCount--;
+            } else {
+                // Single term: all content goes in one dd
+                $def = new DefinitionDescription();
+                if ($defLines !== []) {
+                    // Remove leading blank lines
+                    while ($defLines !== [] && $defLines[0] === '') {
+                        array_shift($defLines);
+                    }
+                    // Remove trailing blank lines
+                    $defLineCount = count($defLines);
+                    while ($defLineCount > 0 && $defLines[$defLineCount - 1] === '') {
+                        array_pop($defLines);
+                        $defLineCount--;
+                    }
+                    $this->parseBlocks($def, $defLines, 0);
                 }
-                $this->parseBlocks($def, $defLines, 0);
+                $defList->appendChild($def);
             }
-            $defList->appendChild($def);
         }
 
         if (count($defList->getChildren()) === 0) {
@@ -1784,6 +1797,42 @@ class BlockParser
         $parent->appendChild($defList);
 
         return $i - $start;
+    }
+
+    /**
+     * Split lines into blocks separated by blank lines
+     *
+     * @param array<string> $lines
+     *
+     * @return array<array<string>>
+     */
+    protected function splitByBlankLines(array $lines): array
+    {
+        $blocks = [];
+        $current = [];
+
+        // Remove leading blank lines
+        while ($lines !== [] && $lines[0] === '') {
+            array_shift($lines);
+        }
+
+        foreach ($lines as $line) {
+            if ($line === '') {
+                if ($current !== []) {
+                    $blocks[] = $current;
+                    $current = [];
+                }
+            } else {
+                $current[] = $line;
+            }
+        }
+
+        // Don't forget the last block
+        if ($current !== []) {
+            $blocks[] = $current;
+        }
+
+        return $blocks;
     }
 
     /**

--- a/tests/TestCase/Converter/HtmlToDjotTest.php
+++ b/tests/TestCase/Converter/HtmlToDjotTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Djot\Test\TestCase\Converter;
 
 use Djot\Converter\HtmlToDjot;
+use Djot\DjotConverter;
 use PHPUnit\Framework\TestCase;
 
 class HtmlToDjotTest extends TestCase
@@ -250,6 +251,18 @@ HTML;
         $this->assertStringContainsString('  The visual property.', $result);
     }
 
+    public function testDefinitionListMultipleDefinitions(): void
+    {
+        // Multiple dd elements under multiple terms become separate indented paragraphs
+        $html = '<dl><dt>color</dt><dt>colour</dt><dd>The visual property.</dd><dd>Used in design.</dd></dl>';
+        $result = $this->converter->convert($html);
+
+        $this->assertStringContainsString(': color', $result);
+        $this->assertStringContainsString(': colour', $result);
+        // Each dd becomes a separate indented block separated by blank line
+        $this->assertStringContainsString("  The visual property.\n\n  Used in design.", $result);
+    }
+
     // ==================== Spans with Attributes ====================
 
     public function testSpanWithClass(): void
@@ -455,5 +468,22 @@ HTML;
 
         // Content lines should not have leading whitespace (except list indentation)
         $this->assertStringNotContainsString("\n Introduction", $result);
+    }
+
+    public function testDefinitionListMultipleDdRoundtrip(): void
+    {
+        // Test that multiple dd elements roundtrip correctly
+        $html = '<dl><dt>color</dt><dt>colour</dt><dd><p>The visual property.</p></dd><dd><p>Used in design.</p></dd></dl>';
+        $djot = $this->converter->convert($html);
+
+        // Convert back to HTML
+        $djotConverter = new DjotConverter();
+        $htmlBack = $djotConverter->convert($djot);
+
+        // Should have 2 dt and 2 dd
+        $this->assertSame(2, substr_count($htmlBack, '<dt>'));
+        $this->assertSame(2, substr_count($htmlBack, '<dd>'));
+        $this->assertStringContainsString('The visual property.', $htmlBack);
+        $this->assertStringContainsString('Used in design.', $htmlBack);
     }
 }

--- a/tests/TestCase/DjotConverterTest.php
+++ b/tests/TestCase/DjotConverterTest.php
@@ -553,6 +553,21 @@ DJOT;
         $this->assertSame(1, substr_count($result, '<dd>'));
     }
 
+    public function testDefinitionListMultipleTermsMultipleDefinitions(): void
+    {
+        // When multiple terms share definitions, each paragraph block becomes a separate dd
+        $djot = ": color\n: colour\n\n  The visual property of objects.\n\n  Used in art and design.";
+
+        $result = $this->converter->convert($djot);
+
+        $this->assertStringContainsString('<dt>color</dt>', $result);
+        $this->assertStringContainsString('<dt>colour</dt>', $result);
+        $this->assertStringContainsString('The visual property', $result);
+        $this->assertStringContainsString('Used in art and design', $result);
+        // Multiple terms with blank-line-separated paragraphs = multiple dd elements
+        $this->assertSame(2, substr_count($result, '<dd>'));
+    }
+
     public function testComment(): void
     {
         $djot = "Before\n\n{% This is a comment %}\n\nAfter";

--- a/tests/TestCase/Renderer/MarkdownRendererTest.php
+++ b/tests/TestCase/Renderer/MarkdownRendererTest.php
@@ -275,6 +275,21 @@ class MarkdownRendererTest extends TestCase
         $this->assertStringContainsString(': Definition', $result);
     }
 
+    public function testDefinitionListMultipleTermsMultipleDefinitions(): void
+    {
+        $djot = ": color\n: colour\n\n  The visual property.\n\n  Used in design.";
+        $document = $this->converter->parse($djot);
+        $result = $this->renderer->render($document);
+
+        // Multiple terms
+        $this->assertStringContainsString('**color**', $result);
+        $this->assertStringContainsString('**colour**', $result);
+        // Multiple definitions
+        $this->assertSame(2, substr_count($result, ': '));
+        $this->assertStringContainsString('The visual property.', $result);
+        $this->assertStringContainsString('Used in design.', $result);
+    }
+
     public function testComplexDocument(): void
     {
         $djot = <<<'DJOT'


### PR DESCRIPTION
## Summary

- When multiple terms share definitions (consecutive `: term` lines), each indented paragraph block separated by blank lines becomes a separate `<dd>` element
- Enables lossless HTML roundtrip for definition lists with multiple definitions per term group
- Add `splitByBlankLines()` helper to BlockParser
- Update HtmlToDjot converter to output paragraph-separated dds
- Add tests for parsing and roundtrip conversion

## Example

**Djot input:**
```djot
: color
: colour

  The visual property of objects.

  Used in art and design.
```

**HTML output:**
```html
<dl>
<dt>color</dt>
<dt>colour</dt>
<dd>
<p>The visual property of objects.</p>
</dd>
<dd>
<p>Used in art and design.</p>
</dd>
</dl>
```

## Test plan

- [x] New tests for multiple dd parsing (`testDefinitionListMultipleTermsMultipleDefinitions`)
- [x] Roundtrip test (`testDefinitionListMultipleDdRoundtrip`)
- [x] Full test suite passes (1035 tests)
- [x] PHPStan passes
- [x] PHPCS passes