### PR TITLE
Add table row and cell attributes support

### DIFF
--- a/docs/enhancements.md
+++ b/docs/enhancements.md
@@ -270,6 +270,51 @@ Works with all list types:
 
 ---
 
+### Table Row and Cell Attributes
+
+**Related:** [jgm/djot#250](https://github.com/jgm/djot/issues/250)
+
+**Status:** Implemented in djot-php (issue #18)
+
+Attributes can be added to table rows and cells:
+
+**Row attributes** (after final pipe):
+```djot
+| Name | Age |{.header-row}
+|------|-----|
+| John | 30  |{.highlight}
+```
+
+**Cell attributes** (after opening pipe):
+```djot
+|{.name} Name |{.age} Age |
+|-------------|-----------|
+|{.emphasis} John | 30 |
+```
+
+**Output:**
+```html
+<table>
+<tr class="header-row">
+<th class="name">Name</th>
+<th class="age">Age</th>
+</tr>
+<tr class="highlight">
+<td class="emphasis">John</td>
+<td>30</td>
+</tr>
+</table>
+```
+
+**Rules:**
+- Row attributes: `| cell | cell |{.class}` (after final pipe)
+- Cell attributes: `|{.class} content |` (after opening pipe)
+- Separator row attributes are ignored: `|---|---|{.ignored}`
+- Attributes preserved when rows are converted to headers
+- Works with alignment specifiers
+
+---
+
 ### Boolean Attribute Shorthand
 
 **Related:** [jgm/djot#257](https://github.com/jgm/djot/issues/257)
@@ -463,6 +508,7 @@ vendor/bin/phpunit
 | Feature                   | Upstream PR/Issue                              | Status     |
 |---------------------------|------------------------------------------------|------------|
 | List item attributes      | [#262](https://github.com/jgm/djot/pull/262)   | Open PR    |
+| Table row/cell attributes | [#250](https://github.com/jgm/djot/issues/250) | Open       |
 | Boolean attribute shorthand | [#257](https://github.com/jgm/djot/issues/257) | Open       |
 | Multiple definition terms | -                                              | djot-php   |
 | Fenced comment blocks     | [#67](https://github.com/jgm/djot/issues/67)   | Open       |

--- a/src/Parser/Block/TableParser.php
+++ b/src/Parser/Block/TableParser.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Djot\Parser\Block;
 
 use Djot\Node\Block\TableCell;
+use Djot\Parser\Utility\AttributeParser;
 
 /**
  * Parser for table blocks.
@@ -13,12 +14,14 @@ use Djot\Node\Block\TableCell;
  * - Table rows (| cell | cell |)
  * - Table alignments from separator rows
  * - Table cells with code span awareness
+ * - Row attributes (|...|{.class})
+ * - Cell attributes (|{.class} content |)
  */
 class TableParser
 {
     /**
      * Check if a line could be a table row.
-     * A line must start with | and end with | outside of code spans.
+     * A line must start with | and end with | (optionally followed by row attributes).
      *
      * @param string $line The line to check
      *
@@ -31,13 +34,49 @@ class TableParser
             return false;
         }
 
+        // Strip row attributes if present (|...|{.class})
+        $lineWithoutRowAttrs = $this->stripRowAttributes($line);
+
         // Table rows start and end with |
-        if (!preg_match('/^\|.*\|$/', $line)) {
+        if (!preg_match('/^\|.*\|$/', $lineWithoutRowAttrs)) {
             return false;
         }
 
         // Verify the line truly ends with | outside of code spans
-        return $this->lineEndsWithPipeOutsideCodeSpan($line);
+        return $this->lineEndsWithPipeOutsideCodeSpan($lineWithoutRowAttrs);
+    }
+
+    /**
+     * Strip row attributes from end of line.
+     *
+     * @param string $line The line to process
+     *
+     * @return string Line without trailing row attributes
+     */
+    public function stripRowAttributes(string $line): string
+    {
+        // Row attributes appear after final pipe: |...|{.class}
+        if (preg_match('/^(.*\|)\{([^{}]+)\}\s*$/', $line, $matches)) {
+            return $matches[1];
+        }
+
+        return $line;
+    }
+
+    /**
+     * Extract row attributes from end of line.
+     *
+     * @param string $line The line to process
+     *
+     * @return array<string, mixed> Parsed attributes or empty array
+     */
+    public function extractRowAttributes(string $line): array
+    {
+        if (preg_match('/\|\{([^{}]+)\}\s*$/', $line, $matches)) {
+            return AttributeParser::parse($matches[1]);
+        }
+
+        return [];
     }
 
     /**
@@ -89,6 +128,9 @@ class TableParser
      */
     public function parseTableCells(string $line): array
     {
+        // Strip row attributes first
+        $line = $this->stripRowAttributes($line);
+
         // Remove leading and trailing |
         $line = substr($line, 1, -1);
 
@@ -155,6 +197,44 @@ class TableParser
         $cells[] = $currentCell;
 
         return $cells;
+    }
+
+    /**
+     * Parse table cells with their attributes.
+     * Cell attributes appear at the start: |{.class} content |
+     *
+     * @param string $line The table row line
+     *
+     * @return array<array{content: string, attributes: array<string, mixed>}> Array of cell data
+     */
+    public function parseTableCellsWithAttributes(string $line): array
+    {
+        $cells = $this->parseTableCells($line);
+        $result = [];
+
+        foreach ($cells as $cellContent) {
+            $attributes = [];
+            $content = $cellContent;
+
+            // Check for cell attribute at start: {.class} content
+            // Must be at the very start (after optional whitespace)
+            $trimmed = ltrim($cellContent);
+            if (preg_match('/^\{([^{}]+)\}\s*/', $trimmed, $matches)) {
+                $attributes = AttributeParser::parse($matches[1]);
+                // Remove the attribute from content
+                $content = substr($trimmed, strlen($matches[0]));
+                // Preserve any leading whitespace that was before the attribute
+                $leadingSpace = substr($cellContent, 0, strlen($cellContent) - strlen($trimmed));
+                $content = $leadingSpace . $content;
+            }
+
+            $result[] = [
+                'content' => $content,
+                'attributes' => $attributes,
+            ];
+        }
+
+        return $result;
     }
 
     /**

--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -1927,13 +1927,16 @@ class BlockParser
         while ($i < $count) {
             $currentLine = $lines[$i];
 
-            if (!preg_match('/^\|.*\|$/', $currentLine)) {
+            // Strip row attributes for validation (|...|{.class} → |...|)
+            $lineWithoutRowAttrs = $this->tableParser->stripRowAttributes($currentLine);
+
+            if (!preg_match('/^\|.*\|$/', $lineWithoutRowAttrs)) {
                 break;
             }
 
-            // Check if this is a separator row
-            if ($this->tableParser->isSeparatorRow($currentLine)) {
-                $alignments = $this->tableParser->parseTableAlignments($currentLine);
+            // Check if this is a separator row (attributes ignored on separator rows)
+            if ($this->tableParser->isSeparatorRow($lineWithoutRowAttrs)) {
+                $alignments = $this->tableParser->parseTableAlignments($lineWithoutRowAttrs);
                 $headerFound = true;
 
                 // Mark previous row as header and apply alignments to it
@@ -1943,11 +1946,15 @@ class BlockParser
                     if ($lastRow instanceof TableRow) {
                         // Recreate as header row with alignments
                         $headerRow = new TableRow(true);
+                        // Preserve row attributes from original row
+                        $headerRow->setAttributes($lastRow->getAttributes());
                         $cellIndex = 0;
                         foreach ($lastRow->getChildren() as $cell) {
                             if ($cell instanceof TableCell) {
                                 $alignment = $alignments[$cellIndex] ?? TableCell::ALIGN_DEFAULT;
                                 $headerCell = new TableCell(true, $alignment);
+                                // Preserve cell attributes from original cell
+                                $headerCell->setAttributes($cell->getAttributes());
                                 foreach ($cell->getChildren() as $child) {
                                     $headerCell->appendChild($child);
                                 }
@@ -1964,14 +1971,25 @@ class BlockParser
                 continue;
             }
 
+            // Extract row attributes (|...|{.class})
+            $rowAttributes = $this->tableParser->extractRowAttributes($currentLine);
+
             // Parse regular row
             $row = new TableRow(false);
-            $cells = $this->tableParser->parseTableCells($currentLine);
+            if ($rowAttributes) {
+                $row->setAttributes($rowAttributes);
+            }
 
-            foreach ($cells as $index => $cellContent) {
+            // Parse cells with their attributes
+            $cellsWithAttrs = $this->tableParser->parseTableCellsWithAttributes($currentLine);
+
+            foreach ($cellsWithAttrs as $index => $cellData) {
                 $alignment = $alignments[$index] ?? TableCell::ALIGN_DEFAULT;
                 $cell = new TableCell(false, $alignment);
-                $this->inlineParser->parse($cell, trim($cellContent), $i);
+                if ($cellData['attributes']) {
+                    $cell->setAttributes($cellData['attributes']);
+                }
+                $this->inlineParser->parse($cell, trim($cellData['content']), $i);
                 $row->appendChild($cell);
             }
 

--- a/tests/TestCase/TableAttributesTest.php
+++ b/tests/TestCase/TableAttributesTest.php
@@ -1,0 +1,386 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Test\TestCase;
+
+use Djot\DjotConverter;
+use Djot\Node\Block\Table;
+use Djot\Node\Block\TableCell;
+use Djot\Node\Block\TableRow;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for table row and cell attributes.
+ *
+ * Row attributes: | cell |{.class}
+ * Cell attributes: |{.class} cell |
+ *
+ * @see https://github.com/php-collective/djot-php/issues/18
+ */
+class TableAttributesTest extends TestCase
+{
+    protected DjotConverter $converter;
+
+    protected function setUp(): void
+    {
+        $this->converter = new DjotConverter();
+    }
+
+    public function testRowAttributesAfterFinalPipe(): void
+    {
+        $djot = <<<'DJOT'
+| A | B |{.header}
+|---|---|
+| 1 | 2 |{.highlight}
+| 3 | 4 |
+DJOT;
+
+        $doc = $this->converter->parse($djot);
+
+        /** @var \Djot\Node\Block\Table $table */
+        $table = $doc->getChildren()[0];
+        $this->assertInstanceOf(Table::class, $table);
+
+        $rows = $table->getChildren();
+        $this->assertCount(3, $rows);
+
+        // Header row should have .header class
+        /** @var \Djot\Node\Block\TableRow $headerRow */
+        $headerRow = $rows[0];
+        $this->assertInstanceOf(TableRow::class, $headerRow);
+        $this->assertTrue($headerRow->isHeader());
+        $this->assertSame('header', $headerRow->getAttribute('class'));
+
+        // Second row should have .highlight class
+        /** @var \Djot\Node\Block\TableRow $row2 */
+        $row2 = $rows[1];
+        $this->assertSame('highlight', $row2->getAttribute('class'));
+
+        // Third row should have no attributes
+        /** @var \Djot\Node\Block\TableRow $row3 */
+        $row3 = $rows[2];
+        $this->assertNull($row3->getAttribute('class'));
+    }
+
+    public function testCellAttributesAfterOpeningPipe(): void
+    {
+        $djot = <<<'DJOT'
+|{.name} Name |{.age} Age |
+|---|---|
+|{.emphasis} John | 30 |
+DJOT;
+
+        $doc = $this->converter->parse($djot);
+
+        /** @var \Djot\Node\Block\Table $table */
+        $table = $doc->getChildren()[0];
+
+        $rows = $table->getChildren();
+
+        // Check header cells
+        /** @var \Djot\Node\Block\TableRow $headerRow */
+        $headerRow = $rows[0];
+        $cells = $headerRow->getChildren();
+        $this->assertCount(2, $cells);
+
+        /** @var \Djot\Node\Block\TableCell $cell1 */
+        $cell1 = $cells[0];
+        $this->assertSame('name', $cell1->getAttribute('class'));
+
+        /** @var \Djot\Node\Block\TableCell $cell2 */
+        $cell2 = $cells[1];
+        $this->assertSame('age', $cell2->getAttribute('class'));
+
+        // Check data row cell
+        /** @var \Djot\Node\Block\TableRow $dataRow */
+        $dataRow = $rows[1];
+        $dataCells = $dataRow->getChildren();
+
+        /** @var \Djot\Node\Block\TableCell $dataCell1 */
+        $dataCell1 = $dataCells[0];
+        $this->assertSame('emphasis', $dataCell1->getAttribute('class'));
+
+        /** @var \Djot\Node\Block\TableCell $dataCell2 */
+        $dataCell2 = $dataCells[1];
+        $this->assertNull($dataCell2->getAttribute('class'));
+    }
+
+    public function testCombinedRowAndCellAttributes(): void
+    {
+        $djot = <<<'DJOT'
+|{.name} Name | Age |{.header-row}
+|---|---|
+|{.first} John | 30 |{.highlight}
+DJOT;
+
+        $doc = $this->converter->parse($djot);
+
+        /** @var \Djot\Node\Block\Table $table */
+        $table = $doc->getChildren()[0];
+        $rows = $table->getChildren();
+
+        // Header row
+        /** @var \Djot\Node\Block\TableRow $headerRow */
+        $headerRow = $rows[0];
+        $this->assertSame('header-row', $headerRow->getAttribute('class'));
+
+        $headerCells = $headerRow->getChildren();
+        /** @var \Djot\Node\Block\TableCell $nameCell */
+        $nameCell = $headerCells[0];
+        $this->assertSame('name', $nameCell->getAttribute('class'));
+
+        // Data row
+        /** @var \Djot\Node\Block\TableRow $dataRow */
+        $dataRow = $rows[1];
+        $this->assertSame('highlight', $dataRow->getAttribute('class'));
+
+        $dataCells = $dataRow->getChildren();
+        /** @var \Djot\Node\Block\TableCell $firstCell */
+        $firstCell = $dataCells[0];
+        $this->assertSame('first', $firstCell->getAttribute('class'));
+    }
+
+    public function testSeparatorRowAttributesIgnored(): void
+    {
+        $djot = <<<'DJOT'
+| A | B |
+|---|---|{.ignored}
+| 1 | 2 |
+DJOT;
+
+        $doc = $this->converter->parse($djot);
+
+        /** @var \Djot\Node\Block\Table $table */
+        $table = $doc->getChildren()[0];
+        $rows = $table->getChildren();
+
+        // The .ignored class should not appear anywhere
+        foreach ($rows as $row) {
+            $this->assertNotSame('ignored', $row->getAttribute('class'));
+            foreach ($row->getChildren() as $cell) {
+                $this->assertNotSame('ignored', $cell->getAttribute('class'));
+            }
+        }
+    }
+
+    public function testRowAttributesWithId(): void
+    {
+        $djot = <<<'DJOT'
+| A | B |{#row1 .special}
+|---|---|
+| 1 | 2 |
+DJOT;
+
+        $doc = $this->converter->parse($djot);
+
+        /** @var \Djot\Node\Block\Table $table */
+        $table = $doc->getChildren()[0];
+        $rows = $table->getChildren();
+
+        /** @var \Djot\Node\Block\TableRow $headerRow */
+        $headerRow = $rows[0];
+        $this->assertSame('row1', $headerRow->getAttribute('id'));
+        $this->assertSame('special', $headerRow->getAttribute('class'));
+    }
+
+    public function testCellAttributesWithMultipleClasses(): void
+    {
+        $djot = <<<'DJOT'
+|{.primary .bold} Name | Age |
+|---|---|
+DJOT;
+
+        $doc = $this->converter->parse($djot);
+
+        /** @var \Djot\Node\Block\Table $table */
+        $table = $doc->getChildren()[0];
+        $rows = $table->getChildren();
+
+        /** @var \Djot\Node\Block\TableRow $headerRow */
+        $headerRow = $rows[0];
+        $cells = $headerRow->getChildren();
+
+        /** @var \Djot\Node\Block\TableCell $cell1 */
+        $cell1 = $cells[0];
+        $class = $cell1->getAttribute('class') ?? '';
+        $this->assertStringContainsString('primary', $class);
+        $this->assertStringContainsString('bold', $class);
+    }
+
+    public function testCellAttributesWithDataAttributes(): void
+    {
+        $djot = <<<'DJOT'
+|{data-sort="asc"} Name | Age |
+|---|---|
+DJOT;
+
+        $doc = $this->converter->parse($djot);
+
+        /** @var \Djot\Node\Block\Table $table */
+        $table = $doc->getChildren()[0];
+        $rows = $table->getChildren();
+
+        /** @var \Djot\Node\Block\TableRow $headerRow */
+        $headerRow = $rows[0];
+        $cells = $headerRow->getChildren();
+
+        /** @var \Djot\Node\Block\TableCell $cell1 */
+        $cell1 = $cells[0];
+        $this->assertSame('asc', $cell1->getAttribute('data-sort'));
+    }
+
+    public function testHtmlOutputWithRowAttributes(): void
+    {
+        $djot = <<<'DJOT'
+| Name | Age |{.header}
+|---|---|
+| John | 30 |{.highlight}
+DJOT;
+
+        $html = $this->converter->convert($djot);
+
+        $this->assertStringContainsString('<tr class="header">', $html);
+        $this->assertStringContainsString('<tr class="highlight">', $html);
+    }
+
+    public function testHtmlOutputWithCellAttributes(): void
+    {
+        $djot = <<<'DJOT'
+|{.name} Name | Age |
+|:---|---:|
+|{.emphasis} John | 30 |
+DJOT;
+
+        $html = $this->converter->convert($djot);
+
+        // Header cell with class and alignment
+        $this->assertStringContainsString('<th class="name" style="text-align: left;">Name</th>', $html);
+        // Data cell with class and alignment
+        $this->assertStringContainsString('<td class="emphasis" style="text-align: left;">John</td>', $html);
+    }
+
+    public function testAttributesPreservedWhenConvertingToHeader(): void
+    {
+        // Row attributes should be preserved when a row is converted to header
+        // based on separator row detection
+        $djot = <<<'DJOT'
+|{.col1} A |{.col2} B |{.header-row}
+|---|---|
+| 1 | 2 |
+DJOT;
+
+        $doc = $this->converter->parse($djot);
+
+        /** @var \Djot\Node\Block\Table $table */
+        $table = $doc->getChildren()[0];
+        $rows = $table->getChildren();
+
+        /** @var \Djot\Node\Block\TableRow $headerRow */
+        $headerRow = $rows[0];
+        $this->assertTrue($headerRow->isHeader());
+        $this->assertSame('header-row', $headerRow->getAttribute('class'));
+
+        // Cell attributes should also be preserved
+        $cells = $headerRow->getChildren();
+        /** @var \Djot\Node\Block\TableCell $cell1 */
+        $cell1 = $cells[0];
+        $this->assertSame('col1', $cell1->getAttribute('class'));
+        $this->assertTrue($cell1->isHeader());
+
+        /** @var \Djot\Node\Block\TableCell $cell2 */
+        $cell2 = $cells[1];
+        $this->assertSame('col2', $cell2->getAttribute('class'));
+    }
+
+    public function testRowAttributesWithAlignment(): void
+    {
+        $djot = <<<'DJOT'
+| Left | Center | Right |{.special}
+|:-----|:------:|------:|
+| a    | b      | c     |
+DJOT;
+
+        $doc = $this->converter->parse($djot);
+
+        /** @var \Djot\Node\Block\Table $table */
+        $table = $doc->getChildren()[0];
+        $rows = $table->getChildren();
+
+        /** @var \Djot\Node\Block\TableRow $headerRow */
+        $headerRow = $rows[0];
+        $this->assertSame('special', $headerRow->getAttribute('class'));
+
+        $cells = $headerRow->getChildren();
+        /** @var \Djot\Node\Block\TableCell $cell1 */
+        $cell1 = $cells[0];
+        $this->assertSame(TableCell::ALIGN_LEFT, $cell1->getAlignment());
+
+        /** @var \Djot\Node\Block\TableCell $cell2 */
+        $cell2 = $cells[1];
+        $this->assertSame(TableCell::ALIGN_CENTER, $cell2->getAlignment());
+
+        /** @var \Djot\Node\Block\TableCell $cell3 */
+        $cell3 = $cells[2];
+        $this->assertSame(TableCell::ALIGN_RIGHT, $cell3->getAlignment());
+    }
+
+    public function testTableWithOnlyRowAttributes(): void
+    {
+        // Table with no cell attributes, only row attributes
+        $djot = <<<'DJOT'
+| A | B |{.first}
+| C | D |{.second}
+DJOT;
+
+        $doc = $this->converter->parse($djot);
+
+        /** @var \Djot\Node\Block\Table $table */
+        $table = $doc->getChildren()[0];
+        $rows = $table->getChildren();
+
+        $this->assertCount(2, $rows);
+
+        /** @var \Djot\Node\Block\TableRow $row1 */
+        $row1 = $rows[0];
+        $this->assertSame('first', $row1->getAttribute('class'));
+
+        /** @var \Djot\Node\Block\TableRow $row2 */
+        $row2 = $rows[1];
+        $this->assertSame('second', $row2->getAttribute('class'));
+    }
+
+    public function testTableWithOnlyCellAttributes(): void
+    {
+        // Table with only cell attributes, no row attributes
+        $djot = <<<'DJOT'
+|{.a} A |{.b} B |
+|{.c} C |{.d} D |
+DJOT;
+
+        $doc = $this->converter->parse($djot);
+
+        /** @var \Djot\Node\Block\Table $table */
+        $table = $doc->getChildren()[0];
+        $rows = $table->getChildren();
+
+        /** @var \Djot\Node\Block\TableRow $row1 */
+        $row1 = $rows[0];
+        $cells1 = $row1->getChildren();
+
+        /** @var \Djot\Node\Block\TableCell $cell */
+        $cell = $cells1[0];
+        $this->assertSame('a', $cell->getAttribute('class'));
+        $cell = $cells1[1];
+        $this->assertSame('b', $cell->getAttribute('class'));
+
+        /** @var \Djot\Node\Block\TableRow $row2 */
+        $row2 = $rows[1];
+        $cells2 = $row2->getChildren();
+
+        $cell = $cells2[0];
+        $this->assertSame('c', $cell->getAttribute('class'));
+        $cell = $cells2[1];
+        $this->assertSame('d', $cell->getAttribute('class'));
+    }
+}


### PR DESCRIPTION
## Summary

Implements support for attributes on table rows and cells per [#18](https://github.com/php-collective/djot-php/issues/18).

- Row attributes: `| cell | cell |{.class}` (after final pipe)
- Cell attributes: `|{.class} content |` (after opening pipe)

### Example

```djot
|{.name} Name | Age |{.header-row}
|:------------|----:|
|{.emphasis} John | 30 |{.highlight}
```

Produces:
```html
<table>
<tr class="header-row">
<th class="name" style="text-align: left;">Name</th>
<th style="text-align: right;">Age</th>
</tr>
<tr class="highlight">
<td class="emphasis" style="text-align: left;">John</td>
<td style="text-align: right;">30</td>
</tr>
</table>
```

### Implementation Notes

- Separator row attributes are deliberately ignored (no corresponding HTML element)
- Attributes are preserved when rows are converted to headers based on separator detection
- Works with alignment specifiers

**Related:** [jgm/djot#250](https://github.com/jgm/djot/issues/250)

## Test plan

- [x] Added 13 new tests in `TableAttributesTest.php`
- [x] All 1049 tests pass
- [x] PHPStan passes
- [x] Code style passes