### PR TITLE
Add FIGURE and CAPTION to NodeType for profile support

### DIFF
--- a/src/NodeType.php
+++ b/src/NodeType.php
@@ -105,6 +105,16 @@ final class NodeType
      */
     public const COMMENT = 'comment';
 
+    /**
+     * @var string
+     */
+    public const FIGURE = 'figure';
+
+    /**
+     * @var string
+     */
+    public const CAPTION = 'caption';
+
     // Inline types
     /**
      * @var string
@@ -221,6 +231,8 @@ final class NodeType
             self::SECTION,
             self::LINE_BLOCK,
             self::COMMENT,
+            self::FIGURE,
+            self::CAPTION,
         ];
     }
 

--- a/tests/TestCase/ProfileTest.php
+++ b/tests/TestCase/ProfileTest.php
@@ -204,6 +204,38 @@ class ProfileTest extends TestCase
         $this->assertStringContainsString('<table>', $html);
     }
 
+    public function testArticleProfileAllowsFiguresAndCaptions(): void
+    {
+        $converter = new DjotConverter(profile: Profile::article());
+        $djot = <<<'DJOT'
+![Sunset](sunset.jpg)
+^ A beautiful sunset over the ocean.
+DJOT;
+
+        $html = $converter->convert($djot);
+
+        $this->assertStringContainsString('<figure>', $html);
+        $this->assertStringContainsString('<figcaption>', $html);
+        $this->assertStringContainsString('A beautiful sunset', $html);
+        $this->assertFalse($converter->hasProfileViolations());
+    }
+
+    public function testArticleProfileAllowsBlockquoteCaptions(): void
+    {
+        $converter = new DjotConverter(profile: Profile::article());
+        $djot = <<<'DJOT'
+> Be the change you wish to see in the world.
+^ Mahatma Gandhi
+DJOT;
+
+        $html = $converter->convert($djot);
+
+        $this->assertStringContainsString('<figure>', $html);
+        $this->assertStringContainsString('<blockquote>', $html);
+        $this->assertStringContainsString('<figcaption>', $html);
+        $this->assertStringContainsString('Mahatma Gandhi', $html);
+    }
+
     public function testArticleProfileStripsRawHtml(): void
     {
         $converter = new DjotConverter(profile: Profile::article());


### PR DESCRIPTION
## Summary

- Added `FIGURE` and `CAPTION` constants to `NodeType` class
- Added them to `allBlockTypes()` array so profiles can properly allow/deny these node types
- Added tests verifying figures and captions work with `Profile::article()`

## Problem

When using `Profile::article()` (or any profile), image and blockquote captions were not rendering correctly. Instead of:

```html
<figure><img src="sunset.jpg" alt="Sunset"><figcaption>A beautiful sunset</figcaption></figure>
```

The output was:

```html
[img: Sunset] A beautiful sunset
```

## Root Cause

The `NodeType` class was missing `FIGURE` and `CAPTION` constants, and the `allBlockTypes()` method didn't include them. When `Profile::isTypeAllowed()` checked if a `figure` node was allowed, it returned `false` because the type wasn't in the known types list.

## Test Plan

- [x] Added tests for figure/caption rendering with article profile
- [x] Verified all existing tests still pass (1074 tests)