### PR TITLE
Add unDenyInline() and unDenyBlock() methods to Profile

### DIFF
--- a/src/Profile.php
+++ b/src/Profile.php
@@ -336,6 +336,36 @@ class Profile
     }
 
     /**
+     * Remove types from the inline deny list
+     *
+     * This allows customizing built-in profiles like article() to enable
+     * specific features that would otherwise be denied.
+     *
+     * @param list<string> $types
+     */
+    public function unDenyInline(array $types): self
+    {
+        $this->deniedInline = array_values(array_diff($this->deniedInline, $types));
+
+        return $this;
+    }
+
+    /**
+     * Remove types from the block deny list
+     *
+     * This allows customizing built-in profiles like article() to enable
+     * specific features that would otherwise be denied.
+     *
+     * @param list<string> $types
+     */
+    public function unDenyBlock(array $types): self
+    {
+        $this->deniedBlock = array_values(array_diff($this->deniedBlock, $types));
+
+        return $this;
+    }
+
+    /**
      * @return list<string>|null
      */
     public function getAllowedInline(): ?array

--- a/tests/TestCase/ProfileTest.php
+++ b/tests/TestCase/ProfileTest.php
@@ -637,6 +637,114 @@ DJOT;
         $this->assertContains(NodeType::HEADING, $denied);
     }
 
+    // ==================== UnDeny Methods Tests ====================
+
+    public function testUnDenyInlineRemovesFromDenyList(): void
+    {
+        $profile = Profile::article();
+
+        // Initially, raw_inline is denied
+        $this->assertContains(NodeType::RAW_INLINE, $profile->getDeniedInline());
+        $this->assertFalse($profile->isInlineAllowed(NodeType::RAW_INLINE));
+
+        // Remove from deny list
+        $profile->unDenyInline([NodeType::RAW_INLINE]);
+
+        // Now it should be allowed
+        $this->assertNotContains(NodeType::RAW_INLINE, $profile->getDeniedInline());
+        $this->assertTrue($profile->isInlineAllowed(NodeType::RAW_INLINE));
+    }
+
+    public function testUnDenyBlockRemovesFromDenyList(): void
+    {
+        $profile = Profile::article();
+
+        // Initially, raw_block is denied
+        $this->assertContains(NodeType::RAW_BLOCK, $profile->getDeniedBlock());
+        $this->assertFalse($profile->isBlockAllowed(NodeType::RAW_BLOCK));
+
+        // Remove from deny list
+        $profile->unDenyBlock([NodeType::RAW_BLOCK]);
+
+        // Now it should be allowed
+        $this->assertNotContains(NodeType::RAW_BLOCK, $profile->getDeniedBlock());
+        $this->assertTrue($profile->isBlockAllowed(NodeType::RAW_BLOCK));
+    }
+
+    public function testUnDenyWithMultipleTypes(): void
+    {
+        $profile = (new Profile())
+            ->denyInline([NodeType::RAW_INLINE, NodeType::LINK, NodeType::IMAGE]);
+
+        $this->assertCount(3, $profile->getDeniedInline());
+
+        // Remove two types
+        $profile->unDenyInline([NodeType::RAW_INLINE, NodeType::IMAGE]);
+
+        $denied = $profile->getDeniedInline();
+        $this->assertCount(1, $denied);
+        $this->assertContains(NodeType::LINK, $denied);
+        $this->assertNotContains(NodeType::RAW_INLINE, $denied);
+        $this->assertNotContains(NodeType::IMAGE, $denied);
+    }
+
+    public function testUnDenyWithNonExistentType(): void
+    {
+        $profile = Profile::article();
+        $originalDenied = $profile->getDeniedInline();
+
+        // Try to remove a type that isn't in the deny list
+        $profile->unDenyInline([NodeType::EMPHASIS]);
+
+        // Should be unchanged
+        $this->assertEquals($originalDenied, $profile->getDeniedInline());
+    }
+
+    public function testUnDenyPreservesIndexing(): void
+    {
+        $profile = (new Profile())
+            ->denyBlock([NodeType::HEADING, NodeType::RAW_BLOCK, NodeType::TABLE]);
+
+        // Remove middle item
+        $profile->unDenyBlock([NodeType::RAW_BLOCK]);
+
+        $denied = $profile->getDeniedBlock();
+
+        // Should be re-indexed (0, 1) not (0, 2)
+        $this->assertCount(2, $denied);
+        $this->assertEquals([NodeType::HEADING, NodeType::TABLE], $denied);
+    }
+
+    public function testArticleProfileWithRawHtmlEnabled(): void
+    {
+        $profile = Profile::article()
+            ->unDenyInline([NodeType::RAW_INLINE])
+            ->unDenyBlock([NodeType::RAW_BLOCK]);
+
+        $converter = new DjotConverter(profile: $profile);
+
+        // Raw HTML should now work
+        $html = $converter->convert('`<b>bold</b>`{=html}');
+        $this->assertStringContainsString('<b>bold</b>', $html);
+
+        // But all other article features should still be available
+        $this->assertTrue($profile->isBlockAllowed(NodeType::HEADING));
+        $this->assertTrue($profile->isBlockAllowed(NodeType::TABLE));
+        $this->assertTrue($profile->isInlineAllowed(NodeType::IMAGE));
+
+        $this->assertFalse($converter->hasProfileViolations());
+    }
+
+    public function testChainedUnDenyCalls(): void
+    {
+        $profile = Profile::article()
+            ->unDenyInline([NodeType::RAW_INLINE])
+            ->unDenyBlock([NodeType::RAW_BLOCK]);
+
+        $this->assertEmpty($profile->getDeniedInline());
+        $this->assertEmpty($profile->getDeniedBlock());
+    }
+
     public function testIsTypeAllowedWithUnknownType(): void
     {
         $profile = Profile::full();


### PR DESCRIPTION
## Summary
- Add `unDenyInline()` method to remove types from the inline deny list
- Add `unDenyBlock()` method to remove types from the block deny list
- Add comprehensive tests for the new methods

## Motivation

Currently, when using built-in profiles like `Profile::article()`, there's no way to selectively enable features that are denied by the profile. The only option is to switch to `Profile::full()`, which removes all restrictions.

This PR adds methods to remove items from deny lists, allowing fine-grained customization of built-in profiles.

## Use Case

Example from WP-Djot WordPress plugin: Allow raw HTML passthrough for trusted content while keeping all other article profile restrictions in place.

```php
// Before: Had to switch to full profile (loses all restrictions)
$profile = Profile::full();

// After: Can customize article profile
$profile = Profile::article()
    ->unDenyInline([NodeType::RAW_INLINE])
    ->unDenyBlock([NodeType::RAW_BLOCK]);
```

## Test Plan
- [x] Test that `unDenyInline()` removes types from inline deny list
- [x] Test that `unDenyBlock()` removes types from block deny list  
- [x] Test with multiple types at once
- [x] Test that non-existent types don't cause issues
- [x] Test array re-indexing after removal
- [x] Test integration with article profile and raw HTML
- [x] Verify full test suite passes (1083 tests)
- [x] Verify PHPStan passes