### PR TITLE
Fix block elements being absorbed into nested lists

### DIFF
--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -1409,7 +1409,10 @@ class BlockParser
                     // Collect all indented content at this new level
                     $subLines = [];
                     $subIndent = $currentIndent;
+                    // Track the maximum content indent we've seen (for detecting drop-back to marker level)
+                    $maxContentIndent = $currentIndent;
                     $sawBlankLine = false;
+                    $brokeForParentContent = false;
                     while ($i < $count) {
                         $subLine = $lines[$i];
                         if (IndentationHelper::isBlankLine($subLine)) {
@@ -1420,29 +1423,50 @@ class BlockParser
                             continue;
                         }
                         $lineIndent = IndentationHelper::getLeadingSpaces($subLine);
+
+                        // If we've seen content at a higher indent level (actual nested content),
+                        // and now we're back at the marker level (subIndent) after a blank line,
+                        // this content belongs to the parent level - break to let parent handle it
+                        if ($lineIndent === $subIndent && $maxContentIndent > $subIndent && $sawBlankLine) {
+                            // Set flags so parent loop handles this as continuation content
+                            $lastItemHadBlankAfter = true;
+                            $brokeForParentContent = true;
+
+                            break;
+                        }
+
                         // Check if line has at least the subIndent level
                         if ($lineIndent >= $subIndent) {
+                            // Track the highest content indent seen
+                            if ($lineIndent > $maxContentIndent) {
+                                $maxContentIndent = $lineIndent;
+                            }
                             // Remove subIndent worth of indentation (handling tabs)
                             $subLines[] = IndentationHelper::stripLeadingIndent($subLine, $subIndent);
                             $sawBlankLine = false;
                             $i++;
-                        } elseif ($lineIndent >= $baseIndent) {
-                            // Check if it's a same-level list item (at base indent)
+                        } elseif ($lineIndent === $baseIndent) {
+                            // Line is at base indent - check if it starts a new block or list item
                             $trimmedLine = ltrim($subLine);
                             $itemInfo = $this->listParser->parseListItemMarker($trimmedLine);
                             $sameStyle = !isset($listInfo['style']) || !isset($itemInfo['style']) || $itemInfo['style'] === $listInfo['style'];
-                            if ($itemInfo !== null && $itemInfo['type'] === $listInfo['type'] && $itemInfo['marker'] === $listInfo['marker'] && $sameStyle && $lineIndent === $baseIndent) {
+                            if ($itemInfo !== null && $itemInfo['type'] === $listInfo['type'] && $itemInfo['marker'] === $listInfo['marker'] && $sameStyle) {
                                 break;
                             }
                             // Content at base indent that's not a matching list marker
-                            // Check if it's a block starter - if so, end list
-                            if ($this->startsNewBlock($trimmedLine)) {
+                            // Check if it's a block element - if so, end list content collection
+                            // Use isBlockElementStart() which detects blocks regardless of mode
+                            if ($this->isBlockElementStart($trimmedLine) || $this->startsNewBlock($trimmedLine)) {
                                 break;
                             }
-                            // Otherwise it's lazy continuation - include in nested content
+                            // Otherwise it's lazy continuation at base level - include in nested content
                             $subLines[] = $trimmedLine;
                             $sawBlankLine = false;
                             $i++;
+                        } elseif ($lineIndent > $baseIndent) {
+                            // Line is at intermediate indent (between base and nested content)
+                            // This content belongs to a parent list level, not current nested content
+                            break;
                         } else {
                             // End of list
                             break;
@@ -1461,7 +1485,10 @@ class BlockParser
                     // In djot, blank lines within nested content don't make the parent list loose
                     // The list is only loose if there's a blank line directly after item content
                     // (before nested content starts), which is already handled elsewhere
-                    $lastItemHadBlankAfter = false;
+                    // Only reset if we didn't break to handle content at parent level
+                    if (!$brokeForParentContent) {
+                        $lastItemHadBlankAfter = false;
+                    }
 
                     continue;
                 }
@@ -2387,6 +2414,76 @@ class BlockParser
 
         // Thematic breaks
         if (preg_match('/^(\*\s*\*\s*\*|\-\s*\-\s*\-)/', $line)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if line starts a block element that should terminate list content collection.
+     *
+     * This is different from startsNewBlock() which is about paragraph interruption.
+     * Block elements at column 0 (or less than list indent) should always break out
+     * of list content collection, regardless of significantNewlines mode.
+     *
+     * @param string $line The trimmed line to check
+     */
+    protected function isBlockElementStart(string $line): bool
+    {
+        // Headings
+        if (preg_match('/^#{1,6}(?: |$)/', $line)) {
+            return true;
+        }
+
+        // Code fences (``` or ~~~)
+        if (preg_match('/^[`~]{3,}/', $line)) {
+            return true;
+        }
+
+        // Fenced divs (::: but not definition list :)
+        if (preg_match('/^:{3,}/', $line)) {
+            return true;
+        }
+
+        // Comment fences (%%%)
+        if (preg_match('/^%{3,}/', $line)) {
+            return true;
+        }
+
+        // Thematic breaks (---, ***, ___)
+        if (preg_match('/^([-*_])[ \t]*\1[ \t]*\1/', $line)) {
+            return true;
+        }
+
+        // Block quotes
+        if (preg_match('/^>/', $line)) {
+            return true;
+        }
+
+        // Tables (starting with |)
+        if (preg_match('/^\|/', $line)) {
+            return true;
+        }
+
+        // Definition list terms (: followed by space or content)
+        if (preg_match('/^: /', $line)) {
+            return true;
+        }
+
+        // List markers - these indicate a new list at this level
+        // Bullet lists: -, *, + followed by space
+        if (preg_match('/^[-*+] /', $line)) {
+            return true;
+        }
+
+        // Ordered lists: digit(s) or letter followed by . or ) and space
+        if (preg_match('/^(\d+|[a-zA-Z])[.)] /', $line)) {
+            return true;
+        }
+
+        // Task lists: - [ ] or - [x]
+        if (preg_match('/^- \[[xX ]\] /', $line)) {
             return true;
         }
 

--- a/tests/TestCase/NestedListEdgeCasesTest.php
+++ b/tests/TestCase/NestedListEdgeCasesTest.php
@@ -1,0 +1,735 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Test\TestCase;
+
+use Djot\DjotConverter;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for nested list edge cases, particularly around block elements
+ * following nested lists and content at parent indent levels.
+ *
+ * These tests cover bugs fixed in the BlockParser where:
+ * 1. Headings after deeply nested lists were absorbed into the list
+ * 2. Content at parent indent level after nested content was absorbed into nested item
+ */
+class NestedListEdgeCasesTest extends TestCase
+{
+    protected DjotConverter $converter;
+
+    protected function setUp(): void
+    {
+        $this->converter = new DjotConverter();
+    }
+
+    // ==================== Headings after nested lists ====================
+
+    public function testHeadingAfterDeeplyNestedList(): void
+    {
+        $djot = <<<'DJOT'
+- Level 1
+
+  - Level 2
+
+    - Level 3
+
+      - Level 4
+
+        - Level 5
+
+### Mixed List Types
+DJOT;
+
+        $result = $this->converter->convert($djot);
+
+        // Heading should be outside the list
+        $this->assertStringContainsString('</ul>', $result);
+        $this->assertStringContainsString('<h3>Mixed List Types</h3>', $result);
+
+        // Heading should come after the list closes
+        $lastUlPos = strrpos($result, '</ul>');
+        $headingPos = strpos($result, '<h3>');
+        $this->assertGreaterThan($lastUlPos, $headingPos, 'Heading should appear after list closes');
+    }
+
+    public function testHeadingAfterTwoLevelNestedList(): void
+    {
+        $djot = <<<'DJOT'
+- Level 1
+
+  - Level 2
+
+### Heading
+DJOT;
+
+        $result = $this->converter->convert($djot);
+
+        $this->assertStringContainsString('</ul>', $result);
+        $this->assertStringContainsString('<h3>Heading</h3>', $result);
+
+        $lastUlPos = strrpos($result, '</ul>');
+        $headingPos = strpos($result, '<h3>');
+        $this->assertGreaterThan($lastUlPos, $headingPos);
+    }
+
+    public function testCodeFenceAfterNestedList(): void
+    {
+        $djot = <<<'DJOT'
+- Level 1
+
+  - Level 2
+
+```php
+code
+```
+DJOT;
+
+        $result = $this->converter->convert($djot);
+
+        // Code block should be outside the list
+        $lastUlPos = strrpos($result, '</ul>');
+        $codePos = strpos($result, '<pre><code');
+        $this->assertGreaterThan($lastUlPos, $codePos);
+    }
+
+    public function testThematicBreakAfterNestedList(): void
+    {
+        $djot = <<<'DJOT'
+- Level 1
+
+  - Level 2
+
+---
+DJOT;
+
+        $result = $this->converter->convert($djot);
+
+        $lastUlPos = strrpos($result, '</ul>');
+        $hrPos = strpos($result, '<hr>');
+        $this->assertGreaterThan($lastUlPos, $hrPos);
+    }
+
+    public function testDivAfterNestedList(): void
+    {
+        $djot = <<<'DJOT'
+- Level 1
+
+  - Level 2
+
+::: note
+Content
+:::
+DJOT;
+
+        $result = $this->converter->convert($djot);
+
+        $lastUlPos = strrpos($result, '</ul>');
+        $divPos = strpos($result, '<div');
+        $this->assertGreaterThan($lastUlPos, $divPos);
+    }
+
+    // ==================== Content at parent indent level ====================
+
+    public function testContentAtParentLevelAfterNestedContent(): void
+    {
+        $djot = <<<'DJOT'
+- A
+
+  - B
+
+    P
+
+  C
+DJOT;
+
+        $result = $this->converter->convert($djot);
+
+        // "C" should be part of list item "A", not "B"
+        // Check structure: <li>A ... <ul><li>B ... P</li></ul> ... C</li>
+        $this->assertStringContainsString('<p>C</p>', $result);
+
+        // The <p>C</p> should be inside the outer <li> but after the inner </ul>
+        preg_match('/<li[^>]*>.*?<p>A<\/p>.*?<ul>.*?<\/ul>(.*?)<\/li>/s', $result, $matches);
+        $this->assertNotEmpty($matches);
+        $this->assertStringContainsString('<p>C</p>', $matches[1]);
+    }
+
+    public function testContentAtParentLevelInDeeperNesting(): void
+    {
+        $djot = <<<'DJOT'
+- Level 1
+
+  - Level 2
+
+    Paragraph in level 2.
+
+  Back at level 1.
+
+- Another top item
+DJOT;
+
+        $result = $this->converter->convert($djot);
+
+        // "Back at level 1." should be part of first top-level item
+        $this->assertStringContainsString('<p>Back at level 1.</p>', $result);
+
+        // "Back at level 1." should NOT be inside the nested list (Level 2)
+        // It should appear after </ul> (the nested list) but before the outer </li>
+        $nestedListEnd = strpos($result, '</ul>');
+        $backAtLevel1Pos = strpos($result, 'Back at level 1.');
+        $this->assertGreaterThan($nestedListEnd, $backAtLevel1Pos);
+    }
+
+    public function testSimpleCaseStillWorks(): void
+    {
+        // Without nested content at higher indent, parent-level content should work
+        $djot = <<<'DJOT'
+- A
+
+  - B
+
+  C
+DJOT;
+
+        $result = $this->converter->convert($djot);
+
+        // "C" should be part of "A"
+        $this->assertStringContainsString('<p>C</p>', $result);
+    }
+
+    // ==================== Tight vs loose list behavior ====================
+
+    public function testTightNestedListWithHeading(): void
+    {
+        $djot = <<<'DJOT'
+- A
+  - B
+    - C
+
+### Heading
+DJOT;
+
+        $result = $this->converter->convert($djot);
+
+        // Should be tight list (no <p> wrappers)
+        $this->assertStringNotContainsString('<li><p>A</p>', $result);
+        $this->assertStringContainsString('<h3>Heading</h3>', $result);
+    }
+
+    public function testLooseNestedListWithHeading(): void
+    {
+        $djot = <<<'DJOT'
+- A
+
+  - B
+
+### Heading
+DJOT;
+
+        $result = $this->converter->convert($djot);
+
+        // Heading should be outside the list
+        $lastUlPos = strrpos($result, '</ul>');
+        $headingPos = strpos($result, '<h3>');
+        $this->assertGreaterThan($lastUlPos, $headingPos);
+    }
+
+    // ==================== Multiple headings and blocks ====================
+
+    public function testMultipleHeadingsAfterNestedList(): void
+    {
+        $djot = <<<'DJOT'
+- Item
+
+  - Nested
+
+## First Heading
+
+Text between.
+
+## Second Heading
+DJOT;
+
+        $result = $this->converter->convert($djot);
+
+        $this->assertStringContainsString('<h2>First Heading</h2>', $result);
+        $this->assertStringContainsString('<h2>Second Heading</h2>', $result);
+
+        // Both headings should be after the list
+        $lastUlPos = strrpos($result, '</ul>');
+        $h1Pos = strpos($result, '<h2>First Heading');
+        $h2Pos = strpos($result, '<h2>Second Heading');
+        $this->assertGreaterThan($lastUlPos, $h1Pos);
+        $this->assertGreaterThan($lastUlPos, $h2Pos);
+    }
+
+    public function testMixedBlocksAfterNestedList(): void
+    {
+        $djot = <<<'DJOT'
+- Item
+
+  - Nested
+
+## Heading
+
+```
+code
+```
+
+> quote
+DJOT;
+
+        $result = $this->converter->convert($djot);
+
+        $lastUlPos = strrpos($result, '</ul>');
+        $headingPos = strpos($result, '<h2>');
+        $codePos = strpos($result, '<pre>');
+        $quotePos = strpos($result, '<blockquote>');
+
+        $this->assertGreaterThan($lastUlPos, $headingPos);
+        $this->assertGreaterThan($lastUlPos, $codePos);
+        $this->assertGreaterThan($lastUlPos, $quotePos);
+    }
+
+    // ==================== Edge cases ====================
+
+    public function testHeadingAtLevel1Only(): void
+    {
+        $djot = <<<'DJOT'
+- Item
+
+# Heading
+DJOT;
+
+        $result = $this->converter->convert($djot);
+
+        $this->assertStringContainsString('</ul>', $result);
+        $this->assertStringContainsString('<h1>Heading</h1>', $result);
+    }
+
+    public function testEmptyNestedListWithHeading(): void
+    {
+        $djot = <<<'DJOT'
+- Item
+
+  -
+
+## Heading
+DJOT;
+
+        $result = $this->converter->convert($djot);
+
+        $lastUlPos = strrpos($result, '</ul>');
+        $headingPos = strpos($result, '<h2>');
+        $this->assertGreaterThan($lastUlPos, $headingPos);
+    }
+
+    public function testNestedListWithBlankLinesAndHeading(): void
+    {
+        $djot = <<<'DJOT'
+- A
+
+  - B
+
+
+## Heading
+DJOT;
+
+        $result = $this->converter->convert($djot);
+
+        $lastUlPos = strrpos($result, '</ul>');
+        $headingPos = strpos($result, '<h2>');
+        $this->assertGreaterThan($lastUlPos, $headingPos);
+    }
+
+    public function testOrderedNestedListWithHeading(): void
+    {
+        $djot = <<<'DJOT'
+1. First
+
+   1. Nested first
+
+   2. Nested second
+
+## Heading
+DJOT;
+
+        $result = $this->converter->convert($djot);
+
+        $this->assertStringContainsString('</ol>', $result);
+        $this->assertStringContainsString('<h2>Heading</h2>', $result);
+
+        $lastOlPos = strrpos($result, '</ol>');
+        $headingPos = strpos($result, '<h2>');
+        $this->assertGreaterThan($lastOlPos, $headingPos);
+    }
+
+    public function testMixedListTypesWithHeading(): void
+    {
+        $djot = <<<'DJOT'
+- Bullet
+
+  1. Ordered nested
+
+## Heading
+DJOT;
+
+        $result = $this->converter->convert($djot);
+
+        $lastUlPos = strrpos($result, '</ul>');
+        $headingPos = strpos($result, '<h2>');
+        $this->assertGreaterThan($lastUlPos, $headingPos);
+    }
+
+    // ==================== Block quotes after nested lists ====================
+
+    public function testBlockQuoteAfterNestedList(): void
+    {
+        $djot = <<<'DJOT'
+- Level 1
+
+  - Level 2
+
+> Quote text
+DJOT;
+
+        $result = $this->converter->convert($djot);
+
+        $lastUlPos = strrpos($result, '</ul>');
+        $quotePos = strpos($result, '<blockquote>');
+        $this->assertGreaterThan($lastUlPos, $quotePos);
+    }
+
+    public function testBlockQuoteAfterDeeplyNestedList(): void
+    {
+        $djot = <<<'DJOT'
+- Level 1
+
+  - Level 2
+
+    - Level 3
+
+> This is a quote
+DJOT;
+
+        $result = $this->converter->convert($djot);
+
+        $lastUlPos = strrpos($result, '</ul>');
+        $quotePos = strpos($result, '<blockquote>');
+        $this->assertGreaterThan($lastUlPos, $quotePos);
+        $this->assertStringContainsString('<p>This is a quote</p>', $result);
+    }
+
+    // ==================== Tables after nested lists ====================
+
+    public function testTableAfterNestedList(): void
+    {
+        $djot = <<<'DJOT'
+- Level 1
+
+  - Level 2
+
+| A | B |
+|---|---|
+| 1 | 2 |
+DJOT;
+
+        $result = $this->converter->convert($djot);
+
+        $lastUlPos = strrpos($result, '</ul>');
+        $tablePos = strpos($result, '<table>');
+        $this->assertGreaterThan($lastUlPos, $tablePos);
+    }
+
+    public function testTableAfterDeeplyNestedList(): void
+    {
+        $djot = <<<'DJOT'
+- Level 1
+
+  - Level 2
+
+    - Level 3
+
+| Col1 | Col2 |
+|------|------|
+| X    | Y    |
+DJOT;
+
+        $result = $this->converter->convert($djot);
+
+        $lastUlPos = strrpos($result, '</ul>');
+        $tablePos = strpos($result, '<table>');
+        $this->assertGreaterThan($lastUlPos, $tablePos);
+    }
+
+    // ==================== List type transitions ====================
+
+    public function testOrderedListAfterUnorderedNestedList(): void
+    {
+        $djot = <<<'DJOT'
+- Bullet 1
+
+  - Nested bullet
+
+1. Ordered item
+DJOT;
+
+        $result = $this->converter->convert($djot);
+
+        $lastUlPos = strrpos($result, '</ul>');
+        $olPos = strpos($result, '<ol>');
+        $this->assertNotFalse($olPos);
+        $this->assertGreaterThan($lastUlPos, $olPos);
+    }
+
+    public function testUnorderedListAfterOrderedNestedList(): void
+    {
+        $djot = <<<'DJOT'
+1. First
+
+   1. Nested ordered
+
+- Bullet item
+DJOT;
+
+        $result = $this->converter->convert($djot);
+
+        $lastOlPos = strrpos($result, '</ol>');
+        $ulPos = strpos($result, '<ul>');
+        $this->assertNotFalse($ulPos);
+        $this->assertGreaterThan($lastOlPos, $ulPos);
+    }
+
+    public function testTaskListAfterNestedList(): void
+    {
+        $djot = <<<'DJOT'
+- Item 1
+
+  - Nested item
+
+- [ ] Task item
+DJOT;
+
+        $result = $this->converter->convert($djot);
+
+        // Task list should be separate from the nested list
+        $this->assertStringContainsString('type="checkbox"', $result);
+    }
+
+    // ==================== Definition lists after nested lists ====================
+
+    public function testDefinitionListAfterNestedList(): void
+    {
+        $djot = <<<'DJOT'
+- Level 1
+
+  - Level 2
+
+: Term
+
+  Definition here
+DJOT;
+
+        $result = $this->converter->convert($djot);
+
+        $lastUlPos = strrpos($result, '</ul>');
+        $dlPos = strpos($result, '<dl>');
+        $this->assertNotFalse($dlPos);
+        $this->assertGreaterThan($lastUlPos, $dlPos);
+    }
+
+    public function testDefinitionListAfterDeeplyNestedList(): void
+    {
+        $djot = <<<'DJOT'
+- Level 1
+
+  - Level 2
+
+    - Level 3
+
+: First term
+
+  First definition
+
+: Second term
+
+  Second definition
+DJOT;
+
+        $result = $this->converter->convert($djot);
+
+        $lastUlPos = strrpos($result, '</ul>');
+        $dlPos = strpos($result, '<dl>');
+        $this->assertNotFalse($dlPos);
+        $this->assertGreaterThan($lastUlPos, $dlPos);
+        $this->assertStringContainsString('<dt>First term</dt>', $result);
+        $this->assertStringContainsString('<dt>Second term</dt>', $result);
+    }
+
+    // ==================== Mixed block elements after nested lists ====================
+
+    public function testMultipleBlockTypesAfterNestedList(): void
+    {
+        $djot = <<<'DJOT'
+- Level 1
+
+  - Level 2
+
+## Heading
+
+> Quote
+
+| A |
+|---|
+| B |
+
+: Term
+
+  Def
+DJOT;
+
+        $result = $this->converter->convert($djot);
+
+        $lastUlPos = strrpos($result, '</ul>');
+
+        // All block elements should appear after the list
+        $this->assertGreaterThan($lastUlPos, strpos($result, '<h2>'));
+        $this->assertGreaterThan($lastUlPos, strpos($result, '<blockquote>'));
+        $this->assertGreaterThan($lastUlPos, strpos($result, '<table>'));
+        $this->assertGreaterThan($lastUlPos, strpos($result, '<dl>'));
+    }
+
+    // ==================== Fenced comments after nested lists ====================
+
+    public function testCommentFenceAfterNestedList(): void
+    {
+        $djot = <<<'DJOT'
+- Level 1
+
+  - Level 2
+
+%%%
+This is a comment
+%%%
+DJOT;
+
+        $result = $this->converter->convert($djot);
+
+        // Comment should not appear in output
+        $this->assertStringNotContainsString('This is a comment', $result);
+        // List should be complete
+        $this->assertStringContainsString('</ul>', $result);
+    }
+
+    // ==================== Different list markers ====================
+
+    public function testPlusMarkerListAfterNestedList(): void
+    {
+        $djot = <<<'DJOT'
+- Dash item
+
+  - Nested dash
+
++ Plus item
+DJOT;
+
+        $result = $this->converter->convert($djot);
+
+        // Should have two separate lists
+        preg_match_all('/<ul>/', $result, $matches);
+        $this->assertGreaterThanOrEqual(2, count($matches[0]));
+    }
+
+    public function testAsteriskMarkerListAfterNestedList(): void
+    {
+        $djot = <<<'DJOT'
+- Dash item
+
+  - Nested dash
+
+* Asterisk item
+DJOT;
+
+        $result = $this->converter->convert($djot);
+
+        // Should have two separate lists
+        preg_match_all('/<ul>/', $result, $matches);
+        $this->assertGreaterThanOrEqual(2, count($matches[0]));
+    }
+
+    public function testLetterOrderedListAfterNestedList(): void
+    {
+        $djot = <<<'DJOT'
+1. Number item
+
+   1. Nested number
+
+a. Letter item
+DJOT;
+
+        $result = $this->converter->convert($djot);
+
+        // Should have ordered lists
+        $this->assertStringContainsString('<ol>', $result);
+    }
+
+    // ==================== Edge cases with blank lines ====================
+
+    public function testMultipleBlankLinesBeforeBlockElement(): void
+    {
+        $djot = <<<'DJOT'
+- Level 1
+
+  - Level 2
+
+
+
+## Heading
+DJOT;
+
+        $result = $this->converter->convert($djot);
+
+        $lastUlPos = strrpos($result, '</ul>');
+        $headingPos = strpos($result, '<h2>');
+        $this->assertGreaterThan($lastUlPos, $headingPos);
+    }
+
+    public function testNoBlankLineBeforeBlockElement(): void
+    {
+        // In standard mode, without blank lines, tight list content continues
+        // Block elements only interrupt after a blank line
+        $djot = <<<'DJOT'
+- Level 1
+  - Level 2
+## Heading
+DJOT;
+
+        $result = $this->converter->convert($djot);
+
+        // Without blank lines, content is absorbed into the list item (expected)
+        // This tests that tight list behavior is preserved
+        $this->assertStringContainsString('<ul>', $result);
+        $this->assertStringContainsString('Level 1', $result);
+    }
+
+    public function testSingleBlankLineAllowsBlockElement(): void
+    {
+        // With a single blank line, block elements correctly break out
+        $djot = <<<'DJOT'
+- Level 1
+  - Level 2
+
+## Heading
+DJOT;
+
+        $result = $this->converter->convert($djot);
+
+        // Heading should be outside the list
+        $lastUlPos = strrpos($result, '</ul>');
+        $headingPos = strpos($result, '<h2>');
+        $this->assertNotFalse($headingPos);
+        $this->assertGreaterThan($lastUlPos, $headingPos);
+    }
+}


### PR DESCRIPTION
Fixed two related bugs in BlockParser where block elements at column 0 after nested lists were incorrectly absorbed into the list:

1. Added isBlockElementStart() method to detect all block element types:
   - Headings, code fences, fenced divs, comment fences
   - Thematic breaks, block quotes, tables
   - Definition lists, all list markers (bullet, ordered, task)

2. Added $maxContentIndent tracking to properly detect when content drops back to parent indent level after higher-indented content.

Added 34 comprehensive tests covering:
- Block quotes/tables/definition lists after nested lists
- List type transitions (ordered/unordered/task)
- Content at parent indent levels
- Various blank line scenarios