### PR TITLE
Add highlight.js language definition for Djot syntax highlighting

### DIFF
--- a/docs/assets/README.md
+++ b/docs/assets/README.md
@@ -1,0 +1,101 @@
+# Djot Syntax Highlighting
+
+This folder contains syntax highlighting support for Djot markup.
+
+## highlight.js
+
+The `hljs-djot.js` file provides a language definition for [highlight.js](https://highlightjs.org/).
+
+### Usage
+
+```html
+<!-- Load highlight.js -->
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+
+<!-- Load the Djot language definition -->
+<script src="path/to/hljs-djot.js"></script>
+
+<!-- Mark your code blocks -->
+<pre><code class="language-djot">
+# Hello World
+
+This is *strong* and _emphasized_ text.
+</code></pre>
+
+<!-- Initialize highlighting -->
+<script>
+document.querySelectorAll('pre code.language-djot').forEach(el => {
+    hljs.highlightElement(el);
+});
+</script>
+```
+
+### Supported Syntax
+
+The language definition supports the full Djot specification plus djot-php enhancements:
+
+#### Block Elements
+- **Headings** (`# Title` through `###### Title`)
+- **Code fences** (`` ``` `` with optional language)
+- **Div blocks** (`:::` with optional class)
+- **Blockquotes** (`> text`)
+- **Lists** (bullets `-`, `*`, `+` and numbered `1.`, `1)`)
+- **Task lists** (`- [ ]`, `- [x]`)
+- **Definition lists** (`: term`)
+- **Tables** (`| cell | cell |` with separator rows)
+- **Line blocks** (`| text` for poetry/addresses)
+- **Horizontal rules** (`---`, `***`, `___`)
+- **Block attributes** (`{.class #id key=value}`)
+
+#### Inline Elements
+- **Strong** (`*bold*`)
+- **Emphasis** (`_italic_`)
+- **Highlight** (`{=text=}`)
+- **Insert** (`{+text+}`)
+- **Delete** (`{-text-}`)
+- **Superscript** (`^text^`)
+- **Subscript** (`~text~`)
+- **Inline code** (`` `code` ``)
+- **Links** (`[text](url)`)
+- **Images** (`![alt](url)`)
+- **Reference links** (`[text][ref]`)
+- **Autolinks** (`<https://...>`, `<user@example.com>`)
+- **Footnotes** (`[^note]` and `[^note]: definition`)
+- **Math** (`$`code`$` and `$$`code`$$`)
+- **Symbols** (`:name:`)
+- **Spans with attributes** (`[text]{.class}`)
+- **Raw format markers** (`` `code`{=html} ``)
+- **Escape sequences** (`\*`, `\[`, etc.)
+- **Hard line breaks** (`\` at end of line)
+
+#### djot-php Extensions
+- **Captions** (`^ caption text` for images, tables, blockquotes)
+- **Fenced comments** (`%%%` blocks that can contain blank lines)
+- **Inline comments** (`{% comment %}`)
+- **Table row/cell attributes** (`| cell |{.class}`)
+
+### CSS Classes Used
+
+The highlighter uses standard highlight.js CSS classes:
+
+| Element | CSS Class |
+|---------|-----------|
+| Headings | `hljs-section` |
+| Strong | `hljs-strong` |
+| Emphasis | `hljs-emphasis` |
+| Highlight/Insert | `hljs-addition` |
+| Delete | `hljs-deletion` |
+| Code | `hljs-code` |
+| Links/Images | `hljs-link` |
+| URLs | `hljs-string` |
+| Footnotes/References | `hljs-symbol` |
+| Lists | `hljs-bullet` |
+| Blockquotes | `hljs-quote` |
+| Attributes | `hljs-attr` |
+| Comments | `hljs-comment` |
+| Math | `hljs-formula` |
+| Meta (rules, breaks) | `hljs-meta` |
+| Titles (captions, terms) | `hljs-title` |
+| Keywords (languages) | `hljs-keyword` |
+| Sub/Superscript | `hljs-built_in` |

--- a/docs/assets/hljs-djot.js
+++ b/docs/assets/hljs-djot.js
@@ -1,0 +1,377 @@
+/**
+ * Djot language definition for highlight.js
+ *
+ * Supports the full Djot specification plus djot-php enhancements.
+ * @see https://djot.net for Djot specification
+ * @see https://github.com/php-collective/djot-php for enhancements
+ */
+(function() {
+    function djot(hljs) {
+        // Block attributes: {.class #id key=value} or boolean {reversed}
+        // Excludes special syntax like {= {+ {- {%
+        const ATTRIBUTE = {
+            className: 'attr',
+            begin: /\{(?![=+\-%])[^}]+\}/,
+            relevance: 5,
+        };
+
+        // Headings: # to ######
+        const HEADING = {
+            className: 'section',
+            begin: /^#{1,6}\s/,
+            end: /$/,
+            relevance: 10,
+        };
+
+        // Strong: *text*
+        const STRONG = {
+            className: 'strong',
+            begin: /\*(?!\s)/,
+            end: /\*/,
+            relevance: 0,
+        };
+
+        // Emphasis: _text_
+        const EMPHASIS = {
+            className: 'emphasis',
+            begin: /_(?!\s)/,
+            end: /_/,
+            relevance: 0,
+        };
+
+        // Highlight: {=text=}
+        const HIGHLIGHT = {
+            className: 'addition',
+            begin: /\{=/,
+            end: /=\}/,
+            relevance: 5,
+        };
+
+        // Insert: {+text+}
+        const INSERT = {
+            className: 'addition',
+            begin: /\{\+/,
+            end: /\+\}/,
+            relevance: 5,
+        };
+
+        // Delete: {-text-}
+        const DELETE = {
+            className: 'deletion',
+            begin: /\{-/,
+            end: /-\}/,
+            relevance: 5,
+        };
+
+        // Superscript: ^text^
+        const SUPERSCRIPT = {
+            className: 'built_in',
+            begin: /\^(?!\s)/,
+            end: /\^/,
+            relevance: 2,
+        };
+
+        // Subscript: ~text~
+        const SUBSCRIPT = {
+            className: 'built_in',
+            begin: /~(?!\s)/,
+            end: /~/,
+            relevance: 2,
+        };
+
+        // Inline code: `code` or ``code``
+        const INLINE_CODE = {
+            className: 'code',
+            begin: /`+/,
+            end: /`+/,
+            relevance: 0,
+        };
+
+        // Inline links: [text](url) with optional trailing attributes
+        const LINK = {
+            className: 'link',
+            begin: /\[[^\]]*\]\([^)]*\)(\{[^}]+\})?/,
+            relevance: 5,
+        };
+
+        // Autolinks: <https://...> or <mailto:...>
+        const AUTOLINK = {
+            className: 'link',
+            begin: /<https?:\/\/[^>]+>/,
+            relevance: 5,
+        };
+
+        // Email autolinks: <user@example.com>
+        const EMAIL_AUTOLINK = {
+            className: 'link',
+            begin: /<[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}>/,
+            relevance: 5,
+        };
+
+        // Images: ![alt](url) with optional trailing attributes
+        const IMAGE = {
+            className: 'link',
+            begin: /!\[[^\]]*\]\([^)]*\)(\{[^}]+\})?/,
+            relevance: 5,
+        };
+
+        // Reference links: [text][ref] with optional trailing attributes
+        const REFERENCE_LINK = {
+            className: 'link',
+            begin: /\[[^\]]+\]\[[^\]]*\](\{[^}]+\})?/,
+            relevance: 5,
+        };
+
+        // Spans with attributes: [text]{.class} or [text]{#id}
+        const SPAN = {
+            className: 'string',
+            begin: /\[[^\]]+\]\{[^}]+\}/,
+            relevance: 5,
+        };
+
+        // Reference definitions: [ref]: url
+        const REFERENCE_DEF = {
+            className: 'symbol',
+            begin: /^\[[^\]^\]]+\]:/,
+            end: /$/,
+            relevance: 10,
+        };
+
+        // Footnote references: [^note]
+        const FOOTNOTE_REF = {
+            className: 'symbol',
+            begin: /\[\^[^\]]+\]/,
+            relevance: 5,
+        };
+
+        // Footnote definitions: [^note]: content
+        const FOOTNOTE_DEF = {
+            className: 'symbol',
+            begin: /^\[\^[^\]]+\]:/,
+            end: /$/,
+            relevance: 10,
+        };
+
+        // Blockquotes: > text
+        const BLOCKQUOTE = {
+            className: 'quote',
+            begin: /^>/,
+            end: /$/,
+            relevance: 0,
+        };
+
+        // Horizontal rules: --- or *** or ___
+        const HORIZONTAL_RULE = {
+            className: 'meta',
+            begin: /^(-{3,}|\*{3,}|_{3,})$/,
+            relevance: 10,
+        };
+
+        // Bullet list items: - or * or +
+        const LIST_BULLET = {
+            className: 'bullet',
+            begin: /^[ \t]*[-*+](?=\s)/,
+            relevance: 0,
+        };
+
+        // Numbered list items: 1. or 1)
+        const LIST_NUMBER = {
+            className: 'bullet',
+            begin: /^[ \t]*\d+[.)](?=\s)/,
+            relevance: 0,
+        };
+
+        // Task list items: - [ ] or - [x]
+        const TASK_LIST = {
+            className: 'bullet',
+            begin: /^[ \t]*[-*+]\s\[[ xX]\]/,
+            relevance: 5,
+        };
+
+        // Definition list terms: : term (at start of line with content after colon+space)
+        const DEFINITION_TERM = {
+            className: 'title',
+            begin: /^: /,
+            end: /$/,
+            relevance: 5,
+        };
+
+        // Code fences: ``` with optional language
+        const CODE_FENCE = {
+            className: 'code',
+            begin: /^`{3,}/,
+            end: /^`{3,}/,
+            relevance: 10,
+            contains: [
+                {
+                    className: 'keyword',
+                    begin: /^`{3,}\s*=?\w*/,
+                    end: /$/,
+                },
+            ],
+        };
+
+        // Div blocks: ::: with optional class
+        const DIV_BLOCK = {
+            className: 'section',
+            begin: /^:{3,}/,
+            end: /^:{3,}/,
+            relevance: 10,
+            contains: [
+                {
+                    className: 'keyword',
+                    begin: /^:{3,}\s*\w*/,
+                    end: /$/,
+                },
+            ],
+        };
+
+        // Fenced comments (djot-php extension): %%%
+        const FENCED_COMMENT = {
+            className: 'comment',
+            begin: /^%{3,}/,
+            end: /^%{3,}/,
+            relevance: 10,
+        };
+
+        // Inline comments: {% comment %}
+        const INLINE_COMMENT = {
+            className: 'comment',
+            begin: /\{%/,
+            end: /%\}/,
+            relevance: 5,
+        };
+
+        // Table rows: | cell | cell |
+        const TABLE_ROW = {
+            className: 'string',
+            begin: /^\|/,
+            end: /\|(\{[^}]*\})?$/,
+            relevance: 2,
+        };
+
+        // Table separator: |---|---|
+        const TABLE_SEPARATOR = {
+            className: 'meta',
+            begin: /^\|[-:| ]+\|$/,
+            relevance: 5,
+        };
+
+        // Line blocks: | text (for poetry)
+        const LINE_BLOCK = {
+            className: 'string',
+            begin: /^\| /,
+            end: /$/,
+            relevance: 3,
+        };
+
+        // Captions (djot-php extension): ^ caption text
+        const CAPTION = {
+            className: 'title',
+            begin: /^\^ /,
+            end: /$/,
+            relevance: 5,
+        };
+
+        // Symbols: :name:
+        const SYMBOL = {
+            className: 'symbol',
+            begin: /:[a-zA-Z_][a-zA-Z0-9_]*:/,
+            relevance: 3,
+        };
+
+        // Inline math: $`code`$
+        const INLINE_MATH = {
+            className: 'formula',
+            begin: /\$`/,
+            end: /`\$/,
+            relevance: 5,
+        };
+
+        // Display math: $$`code`$$
+        const DISPLAY_MATH = {
+            className: 'formula',
+            begin: /\$\$`/,
+            end: /`\$\$/,
+            relevance: 5,
+        };
+
+        // Raw format marker: {=html} or {=latex}
+        const RAW_FORMAT = {
+            className: 'meta',
+            begin: /\{=[a-zA-Z]+\}/,
+            relevance: 5,
+        };
+
+        // Escaped characters: \* \[ etc
+        const ESCAPE = {
+            className: 'symbol',
+            begin: /\\[!"#$%&'()*+,.\/:;<=>?@\[\\\]^_`{|}~-]/,
+            relevance: 0,
+        };
+
+        // Hard line break: \ at end of line
+        const HARD_BREAK = {
+            className: 'meta',
+            begin: /\\$/,
+            relevance: 2,
+        };
+
+        return {
+            name: 'Djot',
+            aliases: ['djot'],
+            case_insensitive: false,
+            contains: [
+                HEADING,
+                CODE_FENCE,
+                DIV_BLOCK,
+                FENCED_COMMENT,
+                HORIZONTAL_RULE,
+                TABLE_SEPARATOR,
+                TABLE_ROW,
+                LINE_BLOCK,
+                BLOCKQUOTE,
+                CAPTION,
+                TASK_LIST,
+                LIST_BULLET,
+                LIST_NUMBER,
+                DEFINITION_TERM,
+                REFERENCE_DEF,
+                FOOTNOTE_DEF,
+                FOOTNOTE_REF,
+                IMAGE,
+                SPAN,
+                LINK,
+                REFERENCE_LINK,
+                AUTOLINK,
+                EMAIL_AUTOLINK,
+                DISPLAY_MATH,
+                INLINE_MATH,
+                STRONG,
+                EMPHASIS,
+                HIGHLIGHT,
+                INSERT,
+                DELETE,
+                SUPERSCRIPT,
+                SUBSCRIPT,
+                INLINE_CODE,
+                INLINE_COMMENT,
+                SYMBOL,
+                RAW_FORMAT,
+                ATTRIBUTE,
+                ESCAPE,
+                HARD_BREAK,
+            ],
+        };
+    }
+
+    // Register with highlight.js
+    if (typeof hljs !== 'undefined') {
+        hljs.registerLanguage('djot', djot);
+    }
+
+    // Export for module systems
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = djot;
+    }
+})();


### PR DESCRIPTION
## Summary

Adds a highlight.js language definition for Djot markup syntax highlighting.

- New `docs/assets/hljs-djot.js` - highlight.js language definition
- New `docs/assets/README.md` - usage documentation

### Highlighted Elements

The language definition supports highlighting for:
- Headings, strong, emphasis
- Highlight, insert, delete markup
- Superscript, subscript
- Inline code, code fences
- Links, images, autolinks
- Reference links, footnotes
- Blockquotes, lists, task lists
- Definition lists, div blocks
- Tables, attributes
- Horizontal rules, escape sequences