### PR TITLE
Add release notes configuration

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,13 +1,15 @@
 changelog:
+  exclude:
+    labels:
+      - skip-changelog
+    authors:
+      - dependabot
   categories:
     - title: "Fixes"
       labels:
         - bug
-        - fix
-        - bugfix
     - title: "Improvements"
       labels:
         - enhancement
         - feature
-        - improvement
         - "*"


### PR DESCRIPTION
## Summary

Adds `.github/release.yml` to customize auto-generated release notes with two categories:
- **Fixes** - for bug/fix/bugfix labels
- **Improvements** - for enhancement/feature/improvement labels and everything else