### PR TITLE
Only allow 1. to interrupt paragraphs in significantNewlines mode

### DIFF
--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -2533,9 +2533,10 @@ class BlockParser
                 // Fenced divs: :{3,}
                 return isset($line[1], $line[2]) && $line[1] === ':' && $line[2] === ':';
             default:
-                // Ordered lists: digit or letter followed by . or )
-                if (ctype_digit($first) || ctype_alpha($first)) {
-                    return preg_match('/^(\d+|[a-zA-Z])[.)]\s/', $line) === 1;
+                // Only 1. or 1) can interrupt paragraphs (CommonMark rule)
+                // Prevents "1985. That year..." from becoming a list
+                if ($first === '1') {
+                    return preg_match('/^1[.)]\s/', $line) === 1;
                 }
 
                 return false;

--- a/tests/TestCase/SignificantNewlinesTest.php
+++ b/tests/TestCase/SignificantNewlinesTest.php
@@ -291,4 +291,52 @@ DJOT;
         $this->assertInstanceOf(Paragraph::class, $children[0]);
         $this->assertInstanceOf(Heading::class, $children[1]);
     }
+
+    // ==================== CommonMark Ordered List Rule ====================
+
+    public function testOnlyOneCanInterruptParagraph(): void
+    {
+        // Only "1." can interrupt a paragraph (CommonMark rule)
+        $parser = new BlockParser(significantNewlines: true);
+        $doc = $parser->parse("Steps:\n1. First step");
+
+        $children = $doc->getChildren();
+        $this->assertCount(2, $children);
+        $this->assertInstanceOf(Paragraph::class, $children[0]);
+        $this->assertInstanceOf(ListBlock::class, $children[1]);
+    }
+
+    public function testYearDoesNotBecomeList(): void
+    {
+        // "1985." should NOT interrupt - prevents years becoming lists
+        $parser = new BlockParser(significantNewlines: true);
+        $doc = $parser->parse("My favorite year was\n1985. It was great.");
+
+        $children = $doc->getChildren();
+        $this->assertCount(1, $children);
+        $this->assertInstanceOf(Paragraph::class, $children[0]);
+    }
+
+    public function testHighNumberedListDoesNotInterrupt(): void
+    {
+        // "5." should NOT interrupt paragraphs
+        $parser = new BlockParser(significantNewlines: true);
+        $doc = $parser->parse("Continue from step\n5. Do this thing");
+
+        $children = $doc->getChildren();
+        $this->assertCount(1, $children);
+        $this->assertInstanceOf(Paragraph::class, $children[0]);
+    }
+
+    public function testHighNumberedListAfterBlankLine(): void
+    {
+        // With blank line, any number can start a list
+        $parser = new BlockParser(significantNewlines: true);
+        $doc = $parser->parse("Continue from step\n\n5. Do this thing");
+
+        $children = $doc->getChildren();
+        $this->assertCount(2, $children);
+        $this->assertInstanceOf(Paragraph::class, $children[0]);
+        $this->assertInstanceOf(ListBlock::class, $children[1]);
+    }
 }


### PR DESCRIPTION
## Summary

Applies the CommonMark rule for ordered list paragraph interruption in `significantNewlines` mode:

- Only `1.` or `1)` can interrupt a paragraph
- Higher numbers like `1985.` no longer accidentally become list items

### Before
```
My favorite year was
1985. It was great.
```
Would become: paragraph + list item starting at 1985

### After
Stays as a single paragraph (correct behavior)

### Starting a list at higher numbers

Still works with a blank line:
```
Continue from step

5. Do this thing
```