### PR TITLE
Fix compatibility report parser for 4-backtick fences

### DIFF
--- a/tests/compatibility-report.php
+++ b/tests/compatibility-report.php
@@ -22,10 +22,17 @@ function parseTestFile(string $filename): array
     $tests = [];
 
     // Match code blocks containing test cases
-    preg_match_all('/```\n(.*?)\n```/s', $content, $matches);
+    // Support both 3-backtick and 4-backtick fences (longer fences first to handle nesting)
+    preg_match_all('/````\n(.*?)\n````|```\n(.*?)\n```/s', $content, $matches, PREG_SET_ORDER);
 
     $index = 0;
-    foreach ($matches[1] as $block) {
+    foreach ($matches as $match) {
+        // Get the captured content (either from 4-backtick or 3-backtick group)
+        $block = $match[1] !== '' ? $match[1] : ($match[2] ?? '');
+        if ($block === '') {
+            continue;
+        }
+
         // Split on the separator line (a single `.`)
         $parts = preg_split('/\n\.\n/', $block, 2);
         if (count($parts) === 2) {


### PR DESCRIPTION
## Summary

Fixes the compatibility report's test file parser to correctly parse official djot test files that use 4-backtick fences.

## The Problem

The compatibility report was showing 2 failing tests (99% compatibility), but investigation revealed the actual djot parser handles these cases correctly. The issue was in how `tests/compatibility-report.php` parses the official test files.

Many djot tests use 4-backtick fences (``````) to wrap test cases that contain 3-backtick code blocks (`` ``` ``). The parser's regex only matched 3-backtick fences, causing it to incorrectly parse nested content.

## The Fix

Updated the regex to match both fence lengths:
```php
// Before: only matched 3 backticks
preg_match_all('/```\n(.*?)\n```/s', ...)

// After: matches both, longer first for proper nesting
preg_match_all('/````\n(.*?)\n````|```\n(.*?)\n```/s', ...)
```

## Result

- **Before:** 236/238 tests (99% compatibility) - false failures
- **After:** 245/245 tests (100% compatibility)

The increase in test count (238 → 245) is because tests wrapped in 4-backtick fences are now correctly parsed, and some test files had additional tests that were previously missed.