### PR TITLE
Add fuzz testing infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 /_*
 /tests/benchmark_alternatives/results/
 /tests/benchmark/results/
+# Fuzz testing artifacts
+/fuzz/crash-*
+/fuzz/minimized-*

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "php": "^8.2"
     },
     "require-dev": {
+        "nikic/php-fuzzer": "^0.0.11",
         "php-collective/code-sniffer": "dev-master",
         "phpstan/phpstan": "^2.1.32",
         "phpunit/phpunit": "^11.0 || ^12.0"
@@ -35,6 +36,8 @@
         ],
         "cs-check": "phpcs --colors --parallel=16",
         "cs-fix": "phpcbf --colors --parallel=16",
+        "fuzz": "php-fuzzer fuzz fuzz/target.php fuzz/corpus/",
+        "fuzz-strict": "php-fuzzer fuzz fuzz/target-strict.php fuzz/corpus/",
         "stan": "phpstan analyze",
         "test": "phpunit"
     },

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,63 @@
+# Fuzz Testing
+
+This directory contains fuzz testing infrastructure for the djot-php parser using [nikic/php-fuzzer](https://github.com/nikic/PHP-Fuzzer).
+
+## Setup
+
+```bash
+composer install
+```
+
+## Running Fuzz Tests
+
+### Basic fuzzing (default mode):
+```bash
+composer fuzz
+# or directly:
+php vendor/bin/php-fuzzer fuzz fuzz/target.php fuzz/corpus/
+```
+
+### Fuzzing with warnings enabled:
+```bash
+composer fuzz-strict
+# or directly:
+php vendor/bin/php-fuzzer fuzz fuzz/target-strict.php fuzz/corpus/
+```
+
+## How It Works
+
+The fuzzer generates random inputs based on:
+1. Initial seed corpus in `corpus/`
+2. Dictionary of djot syntax fragments in `djot.dict`
+3. Mutations of discovered interesting inputs
+
+It looks for:
+- Uncaught `Error` exceptions (bugs)
+- Timeouts (infinite loops)
+- Warnings/notices converted to errors
+
+## Files
+
+- `target.php` - Main fuzz target for DjotConverter
+- `target-strict.php` - Fuzz target with warning collection enabled
+- `djot.dict` - Dictionary of djot syntax fragments
+- `corpus/` - Initial seed inputs
+
+## Crash Investigation
+
+When a crash is found:
+
+```bash
+# Minimize the crash to smallest reproducing input
+php vendor/bin/php-fuzzer minimize-crash fuzz/target.php crash-HASH.txt
+
+# Run single input for debugging
+php vendor/bin/php-fuzzer run-single fuzz/target.php minimized-HASH.txt
+```
+
+## Coverage Report
+
+Generate a coverage report:
+```bash
+php vendor/bin/php-fuzzer report-coverage fuzz/target.php fuzz/corpus/ coverage/
+```

--- a/fuzz/corpus/attributes.txt
+++ b/fuzz/corpus/attributes.txt
@@ -1,0 +1,6 @@
+{.class #id key=value}
+# Header with attributes
+
+Paragraph{.special}
+
+[Link]{target=_blank}(https://example.com)

--- a/fuzz/corpus/basic_text.txt
+++ b/fuzz/corpus/basic_text.txt
@@ -1,0 +1,3 @@
+Hello world. This is a paragraph.
+
+This is another paragraph with *emphasis* and _more emphasis_.

--- a/fuzz/corpus/code_blocks.txt
+++ b/fuzz/corpus/code_blocks.txt
@@ -1,0 +1,11 @@
+Inline `code` here.
+
+```php
+function test() {
+    return true;
+}
+```
+
+````
+Nested ``` backticks
+````

--- a/fuzz/corpus/definition_list.txt
+++ b/fuzz/corpus/definition_list.txt
@@ -1,0 +1,8 @@
+: Term 1
+
+  Definition for term 1.
+
+: Term 2
+
+  Definition for term 2.
+  With multiple lines.

--- a/fuzz/corpus/headers.txt
+++ b/fuzz/corpus/headers.txt
@@ -1,0 +1,7 @@
+# Header 1
+
+## Header 2
+
+### Header 3
+
+Paragraph after header.

--- a/fuzz/corpus/links_images.txt
+++ b/fuzz/corpus/links_images.txt
@@ -1,0 +1,11 @@
+[Link text](https://example.com)
+
+![Alt text](image.png)
+
+[ref]: https://example.com
+
+A [reference link][ref].
+
+[^note]: This is a footnote.
+
+See footnote[^note].

--- a/fuzz/corpus/lists.txt
+++ b/fuzz/corpus/lists.txt
@@ -1,0 +1,9 @@
+- Item 1
+- Item 2
+  - Nested item
+  - Another nested
+- Item 3
+
+1. First
+2. Second
+3. Third

--- a/fuzz/corpus/tables.txt
+++ b/fuzz/corpus/tables.txt
@@ -1,0 +1,4 @@
+| Col 1 | Col 2 | Col 3 |
+|-------|:-----:|------:|
+| Left  | Center| Right |
+| A     | B     | C     |

--- a/fuzz/djot.dict
+++ b/fuzz/djot.dict
@@ -1,0 +1,115 @@
+# Djot syntax dictionary for fuzzing
+# Emphasis and strong
+"_"
+"*"
+"__"
+"**"
+"_*"
+"*_"
+
+# Links and images
+"["
+"]"
+"("
+")"
+"[link](url)"
+"![alt](url)"
+"[^"
+"]:"
+
+# Code
+"`"
+"``"
+"```"
+"````"
+"~~~"
+"~~~~"
+
+# Headers
+"#"
+"##"
+"###"
+"####"
+"#####"
+"######"
+
+# Lists
+"-"
+"+"
+"1."
+"2."
+"- [ ]"
+"- [x]"
+":"
+"  "
+
+# Block elements
+">"
+"---"
+"***"
+":::"
+"{."
+"}"
+"{#"
+"{-"
+"{+"
+
+# Escapes and special
+"\\"
+"&"
+"&amp;"
+"&lt;"
+"&gt;"
+"&#"
+"&#x"
+
+# Attributes
+"{.class}"
+"{#id}"
+"{key=value}"
+
+# Tables
+"|"
+"|-"
+"|:"
+":|"
+":--:"
+
+# Math
+"$"
+"$$"
+
+# Footnotes
+"[^note]"
+"[^1]"
+
+# Smart punctuation
+"--"
+"..."
+"'"
+
+# Superscript/subscript
+"^"
+"~"
+
+# Highlighting
+"{="
+"=}"
+"+}"
+"-}"
+
+# Whitespace (using hex escapes)
+"\x0a\x0a"
+"\x0d\x0a"
+"\x09"
+"   "
+"    "
+
+# Nested structures
+"[[["
+"]]]"
+"((("
+")))"
+
+# Simple space
+" "

--- a/fuzz/target-strict.php
+++ b/fuzz/target-strict.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fuzz testing target for DjotConverter in strict mode
+ *
+ * Tests with warnings collection enabled.
+ * Run with: php vendor/bin/php-fuzzer fuzz fuzz/target-strict.php fuzz/corpus/
+ *
+ * @var PhpFuzzer\Config $config
+ */
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use Djot\DjotConverter;
+
+$config->setTarget(function (string $input): void {
+    // Create converter with warning collection
+    $converter = new DjotConverter(warnings: true);
+
+    // Parse and convert the input
+    $converter->convert($input);
+
+    // Also get warnings to exercise that code path
+    $converter->getWarnings();
+});
+
+// Limit input length
+$config->setMaxLen(8192);
+
+// Add dictionary
+$config->addDictionary(__DIR__ . '/djot.dict');

--- a/fuzz/target.php
+++ b/fuzz/target.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fuzz testing target for DjotConverter
+ *
+ * This file is used by nikic/php-fuzzer to find bugs in the parser.
+ * Run with: php vendor/bin/php-fuzzer fuzz fuzz/target.php fuzz/corpus/
+ *
+ * @var PhpFuzzer\Config $config
+ */
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use Djot\DjotConverter;
+
+$converter = new DjotConverter();
+
+$config->setTarget(function (string $input) use ($converter): void {
+    // Parse and convert the input
+    // Exceptions are expected for malformed input, but Error exceptions indicate bugs
+    $converter->convert($input);
+});
+
+// Limit input length - most parser bugs are found with smaller inputs
+$config->setMaxLen(8192);
+
+// Add dictionary of common djot syntax fragments
+$config->addDictionary(__DIR__ . '/djot.dict');

--- a/tests/EdgeCaseTest.php
+++ b/tests/EdgeCaseTest.php
@@ -1,0 +1,314 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Test;
+
+use Djot\DjotConverter;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Edge case tests to verify parser robustness
+ *
+ * These tests ensure the parser handles malformed, unusual,
+ * and boundary-condition inputs without crashing.
+ */
+class EdgeCaseTest extends TestCase
+{
+    private DjotConverter $converter;
+
+    protected function setUp(): void
+    {
+        $this->converter = new DjotConverter();
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function emptyAndWhitespaceProvider(): array
+    {
+        return [
+            'empty string' => [''],
+            'single space' => [' '],
+            'multiple spaces' => ['     '],
+            'single tab' => ["\t"],
+            'single newline' => ["\n"],
+            'multiple newlines' => ["\n\n\n\n\n"],
+            'crlf' => ["\r\n"],
+            'mixed whitespace' => [" \t\n \r\n \t "],
+            'only carriage returns' => ["\r\r\r"],
+        ];
+    }
+
+    #[DataProvider('emptyAndWhitespaceProvider')]
+    public function testEmptyAndWhitespaceInputs(string $input): void
+    {
+        // Should not throw
+        $result = $this->converter->convert($input);
+        $this->assertIsString($result);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function unclosedDelimitersProvider(): array
+    {
+        return [
+            'unclosed emphasis' => ['*unclosed'],
+            'unclosed strong' => ['**unclosed'],
+            'unclosed underscore' => ['_unclosed'],
+            'unclosed double underscore' => ['__unclosed'],
+            'unclosed link bracket' => ['[unclosed link'],
+            'unclosed link paren' => ['[link](unclosed'],
+            'unclosed code backtick' => ['`unclosed code'],
+            'unclosed code fence' => ["```\nunclosed fence"],
+            'unclosed attribute' => ['{.class'],
+            'unclosed math inline' => ['$unclosed math'],
+            'unclosed math display' => ["$$\nunclosed display math"],
+            'unclosed superscript' => ['^{unclosed'],
+            'unclosed subscript' => ['~{unclosed'],
+        ];
+    }
+
+    #[DataProvider('unclosedDelimitersProvider')]
+    public function testUnclosedDelimiters(string $input): void
+    {
+        // Should not throw - unclosed delimiters should be treated as literal text
+        $result = $this->converter->convert($input);
+        $this->assertIsString($result);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function deepNestingProvider(): array
+    {
+        return [
+            'deeply nested emphasis' => [str_repeat('*', 50) . 'text' . str_repeat('*', 50)],
+            'deeply nested brackets' => [str_repeat('[', 50) . 'text' . str_repeat(']', 50)],
+            'deeply nested quotes' => [str_repeat('> ', 100) . 'text'],
+            'deeply nested lists' => [implode("\n", array_map(fn ($i) => str_repeat('  ', $i) . '- item', range(0, 50)))],
+            'nested code fences' => ["```\n````\n`````\ncode\n`````\n````\n```"],
+        ];
+    }
+
+    #[DataProvider('deepNestingProvider')]
+    public function testDeepNesting(string $input): void
+    {
+        // Should handle deep nesting without stack overflow
+        $result = $this->converter->convert($input);
+        $this->assertIsString($result);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function longInputProvider(): array
+    {
+        return [
+            'very long line' => [str_repeat('a', 10000)],
+            'many short lines' => [str_repeat("line\n", 5000)],
+            'long word with emphasis' => ['*' . str_repeat('a', 5000) . '*'],
+            'many repeated headers' => [str_repeat("# Header\n\n", 1000)],
+            'large table' => [self::generateLargeTable(100, 10)],
+        ];
+    }
+
+    private static function generateLargeTable(int $rows, int $cols): string
+    {
+        $header = '| ' . implode(' | ', array_fill(0, $cols, 'Col')) . " |\n";
+        $separator = '|' . str_repeat('---|', $cols) . "\n";
+        $row = '| ' . implode(' | ', array_fill(0, $cols, 'Cell')) . " |\n";
+
+        return $header . $separator . str_repeat($row, $rows);
+    }
+
+    #[DataProvider('longInputProvider')]
+    public function testLongInputs(string $input): void
+    {
+        // Should handle long inputs without timeout or memory issues
+        $result = $this->converter->convert($input);
+        $this->assertIsString($result);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function specialCharactersProvider(): array
+    {
+        return [
+            'null byte' => ["text\x00text"],
+            'unicode replacement char' => ["text\xEF\xBF\xBDtext"],
+            'emoji' => ['Hello 👋 World 🌍'],
+            'rtl text' => ['مرحبا بالعالم'],
+            'mixed scripts' => ['Hello مرحبا 你好 🌍'],
+            'zero width chars' => ["text\u{200B}text\u{200C}text"],
+            'control characters' => ["text\x01\x02\x03text"],
+            'backspace' => ["text\x08text"],
+            'bell' => ["text\x07text"],
+            'high unicode' => ['𝕳𝖊𝖑𝖑𝖔'],
+        ];
+    }
+
+    #[DataProvider('specialCharactersProvider')]
+    public function testSpecialCharacters(string $input): void
+    {
+        // Should handle special characters gracefully
+        $result = $this->converter->convert($input);
+        $this->assertIsString($result);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function escapeSequencesProvider(): array
+    {
+        return [
+            'escaped backslash' => ['\\\\'],
+            'many escaped backslashes' => [str_repeat('\\\\', 100)],
+            'escaped everything' => ['\\*\\[\\]\\(\\)\\`\\#\\-\\+\\.\\!'],
+            'backslash at end' => ['text\\'],
+            'only backslashes' => ['\\\\\\\\\\\\'],
+            'escaped newline' => ["text\\\ntext"],
+        ];
+    }
+
+    #[DataProvider('escapeSequencesProvider')]
+    public function testEscapeSequences(string $input): void
+    {
+        // Should handle escape sequences without issues
+        $result = $this->converter->convert($input);
+        $this->assertIsString($result);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function htmlEntityProvider(): array
+    {
+        return [
+            'valid entity' => ['&amp;'],
+            'invalid entity' => ['&invalid;'],
+            'numeric entity' => ['&#65;'],
+            'hex entity' => ['&#x41;'],
+            'unclosed entity' => ['&amp'],
+            'entity in code' => ['`&amp;`'],
+            'many entities' => [str_repeat('&amp;', 1000)],
+            'malformed numeric' => ['&#99999999999;'],
+            'malformed hex' => ['&#xZZZ;'],
+        ];
+    }
+
+    #[DataProvider('htmlEntityProvider')]
+    public function testHtmlEntities(string $input): void
+    {
+        // Should handle HTML entities properly
+        $result = $this->converter->convert($input);
+        $this->assertIsString($result);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function mixedSyntaxProvider(): array
+    {
+        return [
+            'link in emphasis' => ['*[link](url)*'],
+            'emphasis in link' => ['[*text*](url)'],
+            'code in emphasis' => ['*`code`*'],
+            'emphasis in code' => ['`*not emphasis*`'],
+            'nested quotes with list' => ["> - item\n> - item"],
+            'header in quote' => ['> # Header'],
+            'table after list' => ["- item\n\n| a | b |\n|---|---|\n| 1 | 2 |"],
+            'all inline elements' => ['*_`^sub~{=mark=}+ins+-del-`_*'],
+        ];
+    }
+
+    #[DataProvider('mixedSyntaxProvider')]
+    public function testMixedSyntax(string $input): void
+    {
+        // Should handle mixed syntax combinations
+        $result = $this->converter->convert($input);
+        $this->assertIsString($result);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function boundaryConditionsProvider(): array
+    {
+        return [
+            'single character' => ['a'],
+            'single special char' => ['*'],
+            'two chars opening' => ['*a'],
+            'two chars closing' => ['a*'],
+            'min header' => ['# a'],
+            'header no space' => ['#text'],
+            'list no space' => ['-text'],
+            'min code fence' => ["```\n```"],
+            'min table' => ["| a |\n|---|\n| b |"],
+            'link empty text' => ['[](url)'],
+            'link empty url' => ['[text]()'],
+            'image empty alt' => ['![](url)'],
+            'attribute empty' => ['{}'],
+            'ref empty label' => ['[]:url'],
+        ];
+    }
+
+    #[DataProvider('boundaryConditionsProvider')]
+    public function testBoundaryConditions(string $input): void
+    {
+        // Should handle boundary conditions
+        $result = $this->converter->convert($input);
+        $this->assertIsString($result);
+    }
+
+    public function testStrictModeWithMalformedInput(): void
+    {
+        $converter = new DjotConverter(warnings: true);
+
+        // Various malformed inputs that might generate warnings
+        $inputs = [
+            '[undefined reference]',
+            '[link][missing]',
+            '![image][missing]',
+            "```unknownlang\ncode\n```",
+        ];
+
+        foreach ($inputs as $input) {
+            $result = $converter->convert($input);
+            $this->assertIsString($result);
+        }
+
+        // Should have collected some warnings
+        $warnings = $converter->getWarnings();
+        $this->assertIsArray($warnings);
+    }
+
+    public function testRepeatedConversions(): void
+    {
+        // Test that the converter works correctly across multiple conversions
+        $inputs = [
+            '# Header',
+            '*emphasis*',
+            '[link](url)',
+            '`code`',
+        ];
+
+        foreach ($inputs as $input) {
+            $result = $this->converter->convert($input);
+            $this->assertIsString($result);
+            $this->assertNotEmpty($result);
+        }
+    }
+
+    public function testConverterReuse(): void
+    {
+        // Convert multiple documents with the same converter instance
+        for ($i = 0; $i < 100; $i++) {
+            $result = $this->converter->convert("# Document $i\n\nContent $i");
+            $this->assertStringContainsString("Document $i", $result);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add nikic/php-fuzzer as dev dependency for automated fuzz testing
- Create fuzz testing targets for both normal and strict (warnings-enabled) modes
- Add djot syntax dictionary for guided fuzzing (contains common markup fragments)
- Add seed corpus with representative djot structures
- Add comprehensive EdgeCaseTest (82 tests) covering robustness scenarios:
  - Empty and whitespace inputs
  - Unclosed delimiters
  - Deep nesting
  - Long inputs
  - Special characters (unicode, control chars, emoji)
  - Escape sequences
  - HTML entities
  - Mixed syntax combinations
  - Boundary conditions

## Usage

```bash
# Run fuzz testing
composer fuzz

# Run with warnings enabled
composer fuzz-strict
```

## Test plan

- [x] All existing tests pass (1298 tests)
- [x] All new edge case tests pass (82 tests)
- [x] Code style checks pass
- [x] Fuzzer runs without crashes on initial test