### PR TITLE
Add Profile::excerpt() for plain text preview generation

### DIFF
--- a/src/Profile.php
+++ b/src/Profile.php
@@ -240,6 +240,78 @@ class Profile
     }
 
     /**
+     * Create an excerpt profile for generating plain text previews
+     *
+     * Designed for generating short text snippets from content, such as:
+     * - Search result snippets
+     * - Social media previews (Open Graph descriptions)
+     * - Email subject lines from content
+     * - RSS feed summaries
+     * - Forum/comment thread previews
+     *
+     * Strips elements that don't belong in excerpts:
+     * - Blockquotes: Quoted content isn't the author's original text
+     * - Code blocks: Technical details not suitable for previews
+     * - Images: Can't be represented in plain text
+     * - Tables: Complex structure doesn't translate to excerpts
+     * - Footnotes: Reference material not needed in previews
+     * - Raw HTML: Security and doesn't render as text
+     *
+     * Keeps basic text and inline formatting, which will render as
+     * plain text when combined with strip_tags().
+     *
+     * Example usage:
+     * ```php
+     * $converter = new DjotConverter(profile: Profile::excerpt());
+     * $html = $converter->convert($djot);
+     * $text = trim(strip_tags($html));
+     * $excerpt = mb_substr($text, 0, 160) . '...';
+     * ```
+     */
+    public static function excerpt(): self
+    {
+        $profile = new self();
+        $profile->name = 'excerpt';
+        $profile->description = 'Plain text excerpts. Strips quotes, code, images, tables.';
+        $profile
+            ->denyBlock([
+                NodeType::BLOCKQUOTE,
+                NodeType::CODE_BLOCK,
+                NodeType::TABLE,
+                NodeType::FOOTNOTE,
+                NodeType::RAW_BLOCK,
+                NodeType::DIV,
+                NodeType::SECTION,
+                NodeType::THEMATIC_BREAK,
+                NodeType::LINE_BLOCK,
+            ])
+            ->denyInline([
+                NodeType::IMAGE,
+                NodeType::RAW_INLINE,
+                NodeType::FOOTNOTE_REF,
+                NodeType::MATH,
+                NodeType::SYMBOL,
+            ])
+            ->onDisallowed(self::ACTION_STRIP);
+
+        $profile->featureReasons = [
+            NodeType::BLOCKQUOTE => 'Quoted content is excluded from excerpts as it represents others\' text.',
+            NodeType::CODE_BLOCK => 'Code blocks are excluded from excerpts for readability.',
+            NodeType::TABLE => 'Tables are too complex for plain text excerpts.',
+            NodeType::IMAGE => 'Images cannot be represented in plain text excerpts.',
+            NodeType::FOOTNOTE => 'Footnotes are reference material not needed in excerpts.',
+            NodeType::FOOTNOTE_REF => 'Footnote references are not needed in excerpts.',
+            NodeType::RAW_BLOCK => 'Raw HTML is excluded for security and text extraction.',
+            NodeType::RAW_INLINE => 'Raw HTML is excluded for security and text extraction.',
+            NodeType::MATH => 'Math notation is excluded from plain text excerpts.',
+            NodeType::SYMBOL => 'Symbols are excluded from excerpts.',
+            'default' => 'This element type is not suitable for plain text excerpts.',
+        ];
+
+        return $profile;
+    }
+
+    /**
      * Get the profile name
      */
     public function getName(): string

--- a/tests/TestCase/ProfileTest.php
+++ b/tests/TestCase/ProfileTest.php
@@ -284,6 +284,183 @@ DJOT;
         $this->assertFalse($converter->hasProfileViolations());
     }
 
+    // ==================== Excerpt Profile Tests ====================
+
+    public function testExcerptProfileStripsBlockquotes(): void
+    {
+        $converter = new DjotConverter(profile: Profile::excerpt());
+        $html = $converter->convert("> This is a quote\n\nThis is my text.");
+
+        $this->assertStringNotContainsString('<blockquote>', $html);
+        $this->assertStringNotContainsString('This is a quote', $html);
+        $this->assertStringContainsString('This is my text.', $html);
+    }
+
+    public function testExcerptProfileStripsCodeBlocks(): void
+    {
+        $converter = new DjotConverter(profile: Profile::excerpt());
+        $html = $converter->convert("```\ncode here\n```\n\nRegular text.");
+
+        $this->assertStringNotContainsString('<pre>', $html);
+        $this->assertStringNotContainsString('code here', $html);
+        $this->assertStringContainsString('Regular text.', $html);
+    }
+
+    public function testExcerptProfileStripsImages(): void
+    {
+        $converter = new DjotConverter(profile: Profile::excerpt());
+        $html = $converter->convert('![alt text](image.jpg)');
+
+        $this->assertStringNotContainsString('<img', $html);
+        $this->assertStringNotContainsString('alt text', $html);
+    }
+
+    public function testExcerptProfileStripsTables(): void
+    {
+        $converter = new DjotConverter(profile: Profile::excerpt());
+        $html = $converter->convert("| A | B |\n|---|---|\n| 1 | 2 |");
+
+        $this->assertStringNotContainsString('<table>', $html);
+    }
+
+    public function testExcerptProfileKeepsBasicText(): void
+    {
+        $converter = new DjotConverter(profile: Profile::excerpt());
+        $html = $converter->convert('This is *bold* and _italic_ text.');
+
+        $this->assertStringContainsString('bold', $html);
+        $this->assertStringContainsString('italic', $html);
+        $this->assertStringContainsString('This is', $html);
+    }
+
+    public function testExcerptProfileKeepsHeadings(): void
+    {
+        $converter = new DjotConverter(profile: Profile::excerpt());
+        $html = $converter->convert("# Heading\n\nParagraph text");
+
+        // Headings are allowed in excerpts (stripped to plain text later)
+        $this->assertStringContainsString('Heading', $html);
+        $this->assertStringContainsString('Paragraph text', $html);
+    }
+
+    public function testExcerptProfileKeepsLinks(): void
+    {
+        $converter = new DjotConverter(profile: Profile::excerpt());
+        $html = $converter->convert('Check out [this link](https://example.com).');
+
+        // Links are kept (text remains after strip_tags)
+        $this->assertStringContainsString('this link', $html);
+        $this->assertStringContainsString('Check out', $html);
+    }
+
+    public function testExcerptProfileKeepsLists(): void
+    {
+        $converter = new DjotConverter(profile: Profile::excerpt());
+        $html = $converter->convert("- Item 1\n- Item 2");
+
+        // Lists are allowed
+        $this->assertStringContainsString('Item 1', $html);
+        $this->assertStringContainsString('Item 2', $html);
+    }
+
+    public function testExcerptProfileUseCaseSearchSnippet(): void
+    {
+        $converter = new DjotConverter(profile: Profile::excerpt());
+
+        // Forum post with quote and user's response
+        $content = <<<'DJOT'
+> Previous poster wrote:
+> This is what they said before.
+
+I think the answer is quite simple. You need to check the configuration file and ensure the settings are correct.
+
+![screenshot](debug.png)
+
+```
+config.php
+```
+DJOT;
+
+        $html = $converter->convert($content);
+        $text = trim(strip_tags($html));
+
+        // Quote content should be stripped
+        $this->assertStringNotContainsString('Previous poster wrote', $text);
+        $this->assertStringNotContainsString('This is what they said before', $text);
+
+        // User's actual text should be present
+        $this->assertStringContainsString('I think the answer is quite simple', $text);
+
+        // Code and images should be stripped
+        $this->assertStringNotContainsString('config.php', $text);
+        $this->assertStringNotContainsString('screenshot', $text);
+    }
+
+    public function testExcerptProfileUseCaseOpenGraph(): void
+    {
+        $converter = new DjotConverter(profile: Profile::excerpt());
+
+        // Blog post excerpt for Open Graph meta description
+        $content = <<<'DJOT'
+# 10 Tips for Better PHP Code
+
+> "Clean code is not written by following a set of rules." — Robert C. Martin
+
+In this article, I'll share practical tips that will help you write cleaner, more maintainable PHP code.
+
+| Tip | Difficulty |
+|-----|------------|
+| 1   | Easy       |
+
+![feature image](header.jpg)
+DJOT;
+
+        $html = $converter->convert($content);
+        $text = preg_replace('/\s+/', ' ', trim(strip_tags($html)));
+
+        // Should have meaningful content for OG description
+        $this->assertStringContainsString('10 Tips for Better PHP Code', $text);
+        $this->assertStringContainsString("practical tips", $text);
+
+        // Should not contain quoted content
+        $this->assertStringNotContainsString('Robert C. Martin', $text);
+
+        // Should not contain table content
+        $this->assertStringNotContainsString('Difficulty', $text);
+
+        // Can be truncated for OG description
+        $excerpt = mb_substr($text, 0, 160);
+        $this->assertLessThanOrEqual(160, strlen($excerpt));
+    }
+
+    public function testExcerptProfileName(): void
+    {
+        $this->assertEquals('excerpt', Profile::excerpt()->getName());
+    }
+
+    public function testExcerptProfileDescription(): void
+    {
+        $this->assertNotEmpty(Profile::excerpt()->getDescription());
+        $this->assertStringContainsString('excerpt', strtolower(Profile::excerpt()->getDescription()));
+    }
+
+    public function testExcerptProfileReasonDisallowed(): void
+    {
+        $profile = Profile::excerpt();
+
+        // Check reasons for disallowed types
+        $reason = $profile->getReasonDisallowed(NodeType::BLOCKQUOTE);
+        $this->assertNotNull($reason);
+        $this->assertStringContainsString('excerpt', strtolower($reason));
+
+        $reason = $profile->getReasonDisallowed(NodeType::CODE_BLOCK);
+        $this->assertNotNull($reason);
+
+        // Should return null for allowed types
+        $this->assertNull($profile->getReasonDisallowed(NodeType::PARAGRAPH));
+        $this->assertNull($profile->getReasonDisallowed(NodeType::STRONG));
+    }
+
     // ==================== Custom Profile Tests ====================
 
     public function testCustomProfileWithAllowlist(): void
@@ -373,6 +550,7 @@ DJOT;
         $this->assertEquals('article', Profile::article()->getName());
         $this->assertEquals('comment', Profile::comment()->getName());
         $this->assertEquals('minimal', Profile::minimal()->getName());
+        $this->assertEquals('excerpt', Profile::excerpt()->getName());
     }
 
     public function testProfileDescription(): void
@@ -381,6 +559,7 @@ DJOT;
         $this->assertNotEmpty(Profile::article()->getDescription());
         $this->assertNotEmpty(Profile::comment()->getDescription());
         $this->assertNotEmpty(Profile::minimal()->getDescription());
+        $this->assertNotEmpty(Profile::excerpt()->getDescription());
     }
 
     public function testReasonDisallowed(): void


### PR DESCRIPTION
## Summary

Adds a new `Profile::excerpt()` static method for generating plain text previews/snippets from Djot content.

## Use Cases

### 1. Search Result Snippets
When indexing content for search, you want to show a preview of the actual content without quoted text or code blocks:

```php
$converter = new DjotConverter(profile: Profile::excerpt());
$html = $converter->convert($document->content);
$snippet = mb_substr(trim(strip_tags($html)), 0, 200) . '...';
```

### 2. Social Media Previews (Open Graph)
For meta descriptions, you want the author's text, not quoted material:

```php
// Blog post with quote at the start
$content = <<<'DJOT'
> "The best code is no code at all." — Jeff Atwood

In this article, I'll explain why simplicity matters...
DJOT;

$converter = new DjotConverter(profile: Profile::excerpt());
$text = trim(strip_tags($converter->convert($content)));
// Result: "In this article, I'll explain why simplicity matters..."
// (Quote is stripped)
```

### 3. Forum/Comment Thread Previews
Show the user's actual response, not what they're quoting:

```php
// Forum reply with nested quotes
$reply = <<<'DJOT'
> @user123 wrote:
> I think the API needs improvement.

Actually, the API is well-designed. Here's why...
DJOT;

$converter = new DjotConverter(profile: Profile::excerpt());
$preview = trim(strip_tags($converter->convert($reply)));
// Result: "Actually, the API is well-designed. Here's why..."
```

### 4. RSS Feed Summaries
Generate clean summaries without code blocks or images:

```php
$converter = new DjotConverter(profile: Profile::excerpt());
$html = $converter->convert($article->body);
$summary = html_entity_decode(trim(strip_tags($html)));
```

### 5. Email Subject Lines from Content
Extract meaningful text for automated emails:

```php
$converter = new DjotConverter(profile: Profile::excerpt());
$text = trim(strip_tags($converter->convert($notification->message)));
$subject = mb_substr($text, 0, 50);
```

## What Gets Stripped

| Element Type | Reason |
|--------------|--------|
| Blockquotes | Quoted content represents others' text, not the author's |
| Code blocks | Technical details not suitable for previews |
| Images | Cannot be represented in plain text |
| Tables | Complex structure doesn't translate to excerpts |
| Footnotes | Reference material not needed in previews |
| Raw HTML | Security concern and doesn't render as text |
| Math/Symbols | Don't translate well to plain text |

## What Gets Kept

- Paragraphs, headings, lists (structure for text extraction)
- Inline formatting (bold, italic, etc.) - renders as HTML, stripped by `strip_tags()`
- Links - link text is preserved after `strip_tags()`

## Test Plan

- [x] Added 13 new test cases covering excerpt profile functionality
- [x] Added use case tests for search snippets and Open Graph
- [x] Updated existing profile name/description tests
- [x] All 94 profile tests pass