### PR TITLE
Fix nested BBCode quote handling in BbcodeToDjot converter

### DIFF
--- a/src/Converter/BbcodeToDjot.php
+++ b/src/Converter/BbcodeToDjot.php
@@ -160,8 +160,8 @@ class BbcodeToDjot
         $i = 0;
 
         while ($i < $length) {
-            // Check for opening quote tag
-            if (preg_match('/\[quote(?:=([^\]]*))?\]/i', $text, $matches, 0, $i) && strpos($text, $matches[0], $i) === $i) {
+            // Check for opening quote tag - matches [quote], [quote=...], or [quote ...]
+            if (preg_match('/\[quote(?:[= ]([^\]]*))?\]/i', $text, $matches, 0, $i) && strpos($text, $matches[0], $i) === $i) {
                 $author = $matches[1] ?? null;
                 $tagLength = strlen($matches[0]);
                 $i += $tagLength;
@@ -172,7 +172,7 @@ class BbcodeToDjot
 
                 while ($i < $length) {
                     // Check for nested opening quote
-                    if (preg_match('/\[quote(?:=[^\]]*)?\]/i', $text, $m, 0, $i) && strpos($text, $m[0], $i) === $i) {
+                    if (preg_match('/\[quote(?:[= ][^\]]*)?\]/i', $text, $m, 0, $i) && strpos($text, $m[0], $i) === $i) {
                         $depth++;
                         $i += strlen($m[0]);
 
@@ -237,47 +237,68 @@ class BbcodeToDjot
     }
 
     /**
-     * Parse BBCode quote attribution and format as "name (datetime)" or just "name".
+     * Parse BBCode quote attribution and format as "name (datetime) #id".
      *
      * Handles formats like:
      * - username
      * - username date="2024-01-01"
-     * - username time="12:00"
-     * - username date="2024-01-01" time="12:00"
+     * - "9" name="user" date="2024-01-01 12:30"
+     * - id="9" name="user" date="2024-01-01"
      */
     protected function formatAttribution(string $attribution): string
     {
         $attribution = trim($attribution);
+        $remaining = $attribution;
 
-        // Extract date/time attributes
-        $datetime = '';
-        $name = $attribution;
+        $id = null;
+        $name = null;
+        $datetime = null;
 
-        // Match date="..." or time="..." patterns
-        if (preg_match_all('/\b(date|time)=["\']?([^"\'>\s]+)["\']?/i', $attribution, $matches, PREG_SET_ORDER)) {
-            $parts = [];
-            foreach ($matches as $match) {
-                $parts[strtolower($match[1])] = $match[2];
-                // Remove this attribute from the name
-                $name = str_replace($match[0], '', $name);
-            }
-
-            if (isset($parts['date']) && isset($parts['time'])) {
-                $datetime = $parts['date'] . ' ' . $parts['time'];
-            } elseif (isset($parts['date'])) {
-                $datetime = $parts['date'];
-            } elseif (isset($parts['time'])) {
-                $datetime = $parts['time'];
-            }
+        // Extract id="..." or bare "..." at start (post/message ID)
+        if (preg_match('/^["\'](\d+)["\']/', $remaining, $m)) {
+            $id = $m[1];
+            $remaining = trim(substr($remaining, strlen($m[0])));
+        } elseif (preg_match('/\bid=["\']?(\d+)["\']?/i', $remaining, $m)) {
+            $id = $m[1];
+            $remaining = str_replace($m[0], '', $remaining);
         }
 
-        $name = trim($name);
-
-        if ($datetime !== '') {
-            return $name . ' (' . $datetime . ')';
+        // Extract name="..."
+        if (preg_match('/\bname=["\']([^"\']+)["\']/i', $remaining, $m)) {
+            $name = $m[1];
+            $remaining = str_replace($m[0], '', $remaining);
         }
 
-        return $name;
+        // Extract date="..." (may include time)
+        if (preg_match('/\bdate=["\']([^"\']+)["\']/i', $remaining, $m)) {
+            $datetime = $m[1];
+            $remaining = str_replace($m[0], '', $remaining);
+        }
+
+        // Extract time="..." separately if present
+        if (preg_match('/\btime=["\']([^"\']+)["\']/i', $remaining, $m)) {
+            $datetime = $datetime !== null ? $datetime . ' ' . $m[1] : $m[1];
+            $remaining = str_replace($m[0], '', $remaining);
+        }
+
+        // If no name attribute found, use remaining text as name
+        $remaining = trim($remaining);
+        if ($name === null && $remaining !== '') {
+            $name = $remaining;
+        }
+
+        // Build output: name (datetime) #id
+        $output = $name ?? '';
+
+        if ($datetime !== null) {
+            $output .= ' (' . $datetime . ')';
+        }
+
+        if ($id !== null) {
+            $output .= ' #' . $id;
+        }
+
+        return trim($output);
     }
 
     protected function convertLists(string $text): string

--- a/tests/TestCase/Converter/BbcodeToDjotTest.php
+++ b/tests/TestCase/Converter/BbcodeToDjotTest.php
@@ -219,11 +219,23 @@ class BbcodeToDjotTest extends TestCase
         $this->assertStringContainsString('^ username (2024-01-01)', $result);
         $this->assertStringContainsString('Content', $result);
 
-        // With date and time
+        // With date and time as separate attributes
         $bbcode = '[quote=username date="2024-01-01" time="12:30"]Content[/quote]';
         $result = $this->converter->convert($bbcode);
 
         $this->assertStringContainsString('^ username (2024-01-01 12:30)', $result);
+
+        // Full forum format with ID, name, and datetime
+        $bbcode = '[quote="9" name="superadmin" date="2025-12-06 18:35:26"]Content[/quote]';
+        $result = $this->converter->convert($bbcode);
+
+        $this->assertStringContainsString('^ superadmin (2025-12-06 18:35:26) #9', $result);
+
+        // With id= attribute instead of bare value
+        $bbcode = '[quote id="42" name="admin" date="2024-01-01"]Content[/quote]';
+        $result = $this->converter->convert($bbcode);
+
+        $this->assertStringContainsString('^ admin (2024-01-01) #42', $result);
     }
 
     // ==================== Lists ====================


### PR DESCRIPTION
## Summary

Fixes nested `[quote]` tag handling in `BbcodeToDjot` converter and improves quote attribution formatting.

## Changes

### 1. Fix Nested Quotes
The previous regex-based approach failed on nested quotes because `.*?` (non-greedy) matches to the first `[/quote]` regardless of nesting depth. Replaced with depth-tracking parser.

### 2. Proper Djot Caption Syntax
Changed from inline `*Author wrote:*` to proper Djot caption syntax (`^ Author`) which renders as `<figcaption>`.

### 3. Parse Quote Attributes
Extract ID, name, date/time from various BBCode quote formats:

| Input | Output |
|-------|--------|
| `[quote=John]` | `^ John` |
| `[quote=John date="2024-01-01"]` | `^ John (2024-01-01)` |
| `[quote=John date="2024-01-01" time="12:30"]` | `^ John (2024-01-01 12:30)` |
| `[quote="9" name="admin" date="2024-01-01 12:30"]` | `^ admin (2024-01-01 12:30) #9` |
| `[quote id="42" name="user" date="2024-01-01"]` | `^ user (2024-01-01) #42` |

### 4. PHPStan Fixes
Fixed redundant `$depth > 0` comparisons.

## Test Plan

- [x] Added test cases for nested quote scenarios
- [x] Added tests for date/time attribute parsing
- [x] Added tests for full forum format with ID
- [x] All 35 BbcodeToDjot tests pass
- [x] Full test suite passes (1320 tests)
- [x] PHPStan passes with no errors