### PR TITLE
Add stress tests for multi-line table cell continuations

### DIFF
--- a/tests/TestCase/MultilineTableCellsTest.php
+++ b/tests/TestCase/MultilineTableCellsTest.php
@@ -307,6 +307,488 @@ DJOT;
         $this->assertStringContainsString('This is a very long description that spans multiple lines', $html);
     }
 
+    // =========================================================================
+    // Stress Tests (see issue #60)
+    // =========================================================================
+
+    /**
+     * Stress test: Extended continuations with 10+ lines.
+     */
+    public function testExtendedContinuationTenPlusLines(): void
+    {
+        $djot = <<<'DJOT'
+| A | B |
+|---|---|
+| Start | Line 1 | \
+|       | Line 2 | \
+|       | Line 3 | \
+|       | Line 4 | \
+|       | Line 5 | \
+|       | Line 6 | \
+|       | Line 7 | \
+|       | Line 8 | \
+|       | Line 9 | \
+|       | Line 10 | \
+|       | Line 11 | \
+|       | Line 12 |
+DJOT;
+
+        $doc = $this->converter->parse($djot);
+
+        /** @var Table $table */
+        $table = $doc->getChildren()[0];
+        $this->assertInstanceOf(Table::class, $table);
+
+        $rows = $table->getChildren();
+        // Should be 2 rows: 1 header + 1 merged data row
+        $this->assertCount(2, $rows);
+
+        /** @var \Djot\Node\Block\TableRow $dataRow */
+        $dataRow = $rows[1];
+        $cells = $dataRow->getChildren();
+
+        /** @var TableCell $cell1 */
+        $cell1 = $cells[0];
+        $this->assertSame('Start', $this->getCellText($cell1));
+
+        /** @var TableCell $cell2 */
+        $cell2 = $cells[1];
+        $expected = 'Line 1 Line 2 Line 3 Line 4 Line 5 Line 6 Line 7 Line 8 Line 9 Line 10 Line 11 Line 12';
+        $this->assertSame($expected, $this->getCellText($cell2));
+    }
+
+    /**
+     * Stress test: Combining cell attributes, row attributes, and continuation lines.
+     */
+    public function testAttributeMixingComplex(): void
+    {
+        $djot = <<<'DJOT'
+| A | B | C |
+|---|---|---|
+|{.cell-a #id-a} First |{.cell-b} Second |{.cell-c} Third |{.row-class #row-id} \
+|                      | continued B     | continued C    |
+DJOT;
+
+        $doc = $this->converter->parse($djot);
+
+        /** @var Table $table */
+        $table = $doc->getChildren()[0];
+        $rows = $table->getChildren();
+
+        /** @var \Djot\Node\Block\TableRow $dataRow */
+        $dataRow = $rows[1];
+
+        // Row attributes from first line
+        $this->assertSame('row-class', $dataRow->getAttribute('class'));
+        $this->assertSame('row-id', $dataRow->getAttribute('id'));
+
+        $cells = $dataRow->getChildren();
+
+        /** @var TableCell $cellA */
+        $cellA = $cells[0];
+        $this->assertSame('cell-a', $cellA->getAttribute('class'));
+        $this->assertSame('id-a', $cellA->getAttribute('id'));
+        $this->assertSame('First', $this->getCellText($cellA));
+
+        /** @var TableCell $cellB */
+        $cellB = $cells[1];
+        $this->assertSame('cell-b', $cellB->getAttribute('class'));
+        $this->assertSame('Second continued B', $this->getCellText($cellB));
+
+        /** @var TableCell $cellC */
+        $cellC = $cells[2];
+        $this->assertSame('cell-c', $cellC->getAttribute('class'));
+        $this->assertSame('Third continued C', $this->getCellText($cellC));
+    }
+
+    /**
+     * Stress test: Multiple attributes on same row with continuation.
+     */
+    public function testMultipleAttributesWithContinuation(): void
+    {
+        $djot = <<<'DJOT'
+| X | Y |
+|---|---|
+|{.a #b data-x="1"} Content |{.c data-y="2"} More |{.row-style} \
+|                           | extra               |{.ignored}
+DJOT;
+
+        $doc = $this->converter->parse($djot);
+
+        /** @var Table $table */
+        $table = $doc->getChildren()[0];
+        $rows = $table->getChildren();
+
+        /** @var \Djot\Node\Block\TableRow $dataRow */
+        $dataRow = $rows[1];
+        // Row attrs come from first line only
+        $this->assertSame('row-style', $dataRow->getAttribute('class'));
+
+        $cells = $dataRow->getChildren();
+
+        /** @var TableCell $cell1 */
+        $cell1 = $cells[0];
+        $this->assertSame('a', $cell1->getAttribute('class'));
+        $this->assertSame('b', $cell1->getAttribute('id'));
+        $this->assertSame('1', $cell1->getAttribute('data-x'));
+
+        /** @var TableCell $cell2 */
+        $cell2 = $cells[1];
+        $this->assertSame('More extra', $this->getCellText($cell2));
+    }
+
+    /**
+     * Stress test: Code spans containing backslash characters.
+     */
+    public function testCodeSpansWithBackslashes(): void
+    {
+        $djot = <<<'DJOT'
+| Code | Description |
+|------|-------------|
+| `C:\Users\` | Windows path | \
+|             | continues    |
+DJOT;
+
+        $doc = $this->converter->parse($djot);
+
+        /** @var Table $table */
+        $table = $doc->getChildren()[0];
+        $rows = $table->getChildren();
+
+        // Should have 2 rows (header + 1 merged data row)
+        $this->assertCount(2, $rows);
+
+        $html = $this->converter->convert($djot);
+        $this->assertStringContainsString('<code>C:\Users\</code>', $html);
+        $this->assertStringContainsString('Windows path continues', $html);
+    }
+
+    /**
+     * Stress test: Code span with trailing backslash at end of cell.
+     */
+    public function testCodeSpanTrailingBackslash(): void
+    {
+        $djot = <<<'DJOT'
+| A | B |
+|---|---|
+| Path | `path\` | \
+|      | next    |
+DJOT;
+
+        $html = $this->converter->convert($djot);
+        $this->assertStringContainsString('<code>path\</code>', $html);
+    }
+
+    /**
+     * Stress test: Multiple code spans with various escape sequences.
+     */
+    public function testMultipleCodeSpansEscapeSequences(): void
+    {
+        $djot = <<<'DJOT'
+| Pattern | Meaning |
+|---------|---------|
+| `\\n` `\\t` `\\r` | Escape sequences | \
+|                   | for whitespace   |
+DJOT;
+
+        $html = $this->converter->convert($djot);
+        $this->assertStringContainsString('\\n', $html);
+        $this->assertStringContainsString('\\t', $html);
+        $this->assertStringContainsString('Escape sequences for whitespace', $html);
+    }
+
+    /**
+     * Stress test: Empty/blank continuation cells.
+     */
+    public function testEmptyContinuationCells(): void
+    {
+        $djot = <<<'DJOT'
+| A | B | C |
+|---|---|---|
+| First |   | Third | \
+|       |   |       |
+DJOT;
+
+        $doc = $this->converter->parse($djot);
+
+        /** @var Table $table */
+        $table = $doc->getChildren()[0];
+        $rows = $table->getChildren();
+
+        /** @var \Djot\Node\Block\TableRow $dataRow */
+        $dataRow = $rows[1];
+        $cells = $dataRow->getChildren();
+
+        $this->assertSame('First', $this->getCellText($cells[0]));
+        $this->assertSame('', $this->getCellText($cells[1]));
+        $this->assertSame('Third', $this->getCellText($cells[2]));
+    }
+
+    /**
+     * Stress test: All cells empty in continuation line.
+     */
+    public function testAllEmptyContinuationLine(): void
+    {
+        $djot = <<<'DJOT'
+| A | B |
+|---|---|
+| Content | Here | \
+|         |      |
+DJOT;
+
+        $doc = $this->converter->parse($djot);
+
+        /** @var Table $table */
+        $table = $doc->getChildren()[0];
+        $rows = $table->getChildren();
+
+        /** @var \Djot\Node\Block\TableRow $dataRow */
+        $dataRow = $rows[1];
+        $cells = $dataRow->getChildren();
+
+        // Content should remain unchanged when continuation is empty
+        $this->assertSame('Content', $this->getCellText($cells[0]));
+        $this->assertSame('Here', $this->getCellText($cells[1]));
+    }
+
+    /**
+     * Stress test: Continuation in first data row (boundary condition).
+     */
+    public function testContinuationInFirstDataRow(): void
+    {
+        $djot = <<<'DJOT'
+| Header A | Header B |
+|----------|----------|
+| First    | Row      | \
+|          | continued |
+| Second   | Row      |
+DJOT;
+
+        $doc = $this->converter->parse($djot);
+
+        /** @var Table $table */
+        $table = $doc->getChildren()[0];
+        $rows = $table->getChildren();
+
+        // Should be 3 rows: 1 header + 2 data rows (first merged)
+        $this->assertCount(3, $rows);
+
+        /** @var \Djot\Node\Block\TableRow $firstData */
+        $firstData = $rows[1];
+        $cells = $firstData->getChildren();
+        $this->assertSame('Row continued', $this->getCellText($cells[1]));
+
+        /** @var \Djot\Node\Block\TableRow $secondData */
+        $secondData = $rows[2];
+        $cells2 = $secondData->getChildren();
+        $this->assertSame('Row', $this->getCellText($cells2[1]));
+    }
+
+    /**
+     * Stress test: Continuation in last row of table (boundary condition).
+     */
+    public function testContinuationInLastRow(): void
+    {
+        $djot = <<<'DJOT'
+| A | B |
+|---|---|
+| Row 1 | Data |
+| Row 2 | Start | \
+|       | End   |
+DJOT;
+
+        $doc = $this->converter->parse($djot);
+
+        /** @var Table $table */
+        $table = $doc->getChildren()[0];
+        $rows = $table->getChildren();
+
+        // Should be 3 rows: 1 header + 2 data rows
+        $this->assertCount(3, $rows);
+
+        /** @var \Djot\Node\Block\TableRow $lastRow */
+        $lastRow = $rows[2];
+        $cells = $lastRow->getChildren();
+        $this->assertSame('Start End', $this->getCellText($cells[1]));
+    }
+
+    /**
+     * Stress test: Header row with continuation (boundary condition).
+     */
+    public function testHeaderRowContinuation(): void
+    {
+        $djot = <<<'DJOT'
+| Short | Very Long Header | \
+|       | Name Here        |
+|-------|------------------|
+| A     | B                |
+DJOT;
+
+        $doc = $this->converter->parse($djot);
+
+        /** @var Table $table */
+        $table = $doc->getChildren()[0];
+        $rows = $table->getChildren();
+
+        /** @var \Djot\Node\Block\TableRow $headerRow */
+        $headerRow = $rows[0];
+        $this->assertTrue($headerRow->isHeader());
+
+        $cells = $headerRow->getChildren();
+        $this->assertSame('Short', $this->getCellText($cells[0]));
+        $this->assertSame('Very Long Header Name Here', $this->getCellText($cells[1]));
+    }
+
+    /**
+     * Stress test: Single row table with continuation (boundary condition).
+     */
+    public function testSingleRowTableContinuation(): void
+    {
+        $djot = <<<'DJOT'
+| Only | Row | \
+|      | Here |
+|------|------|
+DJOT;
+
+        $doc = $this->converter->parse($djot);
+
+        /** @var Table $table */
+        $table = $doc->getChildren()[0];
+        $rows = $table->getChildren();
+
+        // Just header row after separator
+        $this->assertCount(1, $rows);
+
+        /** @var \Djot\Node\Block\TableRow $headerRow */
+        $headerRow = $rows[0];
+        $cells = $headerRow->getChildren();
+        $this->assertSame('Row Here', $this->getCellText($cells[1]));
+    }
+
+    /**
+     * Stress test: Large table with many continuations for performance.
+     */
+    public function testLargeTablePerformance(): void
+    {
+        // Generate a table with 50 rows, each having continuation
+        $lines = ['| A | B | C |', '|---|---|---|'];
+
+        for ($i = 1; $i <= 50; $i++) {
+            $lines[] = "| Row {$i} | Content {$i} | Data {$i} | \\";
+            $lines[] = "|        | cont {$i}    | more {$i} |";
+        }
+
+        $djot = implode("\n", $lines);
+
+        $startTime = microtime(true);
+        $doc = $this->converter->parse($djot);
+        $parseTime = microtime(true) - $startTime;
+
+        // Should parse reasonably fast (under 1 second)
+        $this->assertLessThan(1.0, $parseTime, 'Parsing large table took too long');
+
+        /** @var Table $table */
+        $table = $doc->getChildren()[0];
+        $rows = $table->getChildren();
+
+        // 1 header + 50 data rows (continuations merged)
+        $this->assertCount(51, $rows);
+
+        // Spot check a few rows
+        /** @var \Djot\Node\Block\TableRow $row25 */
+        $row25 = $rows[25];
+        $cells = $row25->getChildren();
+        $this->assertSame('Content 25 cont 25', $this->getCellText($cells[1]));
+    }
+
+    /**
+     * Stress test: Very wide table with many columns and continuation.
+     */
+    public function testWideTableWithContinuation(): void
+    {
+        $djot = <<<'DJOT'
+| A | B | C | D | E | F | G | H |
+|---|---|---|---|---|---|---|---|
+| 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | \
+| a | b | c | d | e | f | g | h |
+DJOT;
+
+        $doc = $this->converter->parse($djot);
+
+        /** @var Table $table */
+        $table = $doc->getChildren()[0];
+        $rows = $table->getChildren();
+
+        /** @var \Djot\Node\Block\TableRow $dataRow */
+        $dataRow = $rows[1];
+        $cells = $dataRow->getChildren();
+
+        $this->assertCount(8, $cells);
+        $this->assertSame('1 a', $this->getCellText($cells[0]));
+        $this->assertSame('4 d', $this->getCellText($cells[3]));
+        $this->assertSame('8 h', $this->getCellText($cells[7]));
+    }
+
+    /**
+     * Stress test: Mixed regular rows and continuation rows.
+     */
+    public function testMixedRegularAndContinuationRows(): void
+    {
+        $djot = <<<'DJOT'
+| A | B |
+|---|---|
+| Normal | row |
+| Multi | line | \
+|       | one  |
+| Another | normal |
+| Also | multi | \
+|      | line  | \
+|      | two   |
+| Final | row |
+DJOT;
+
+        $doc = $this->converter->parse($djot);
+
+        /** @var Table $table */
+        $table = $doc->getChildren()[0];
+        $rows = $table->getChildren();
+
+        // 1 header + 5 data rows
+        $this->assertCount(6, $rows);
+
+        // Check each row
+        $expectedB = ['row', 'line one', 'normal', 'multi line two', 'row'];
+        for ($i = 1; $i <= 5; $i++) {
+            /** @var \Djot\Node\Block\TableRow $row */
+            $row = $rows[$i];
+            $cells = $row->getChildren();
+            /** @var TableCell $cellB */
+            $cellB = $cells[1];
+            $this->assertSame($expectedB[$i - 1], $this->getCellText($cellB), "Row {$i} mismatch");
+        }
+    }
+
+    /**
+     * Stress test: Continuation terminated by non-table content.
+     */
+    public function testContinuationTerminatedByParagraph(): void
+    {
+        $djot = <<<'DJOT'
+| A | B |
+|---|---|
+| Start | here | \
+
+This is a paragraph that should end the table.
+DJOT;
+
+        $doc = $this->converter->parse($djot);
+        $children = $doc->getChildren();
+
+        // Should have a table and a paragraph
+        $this->assertCount(2, $children);
+        $this->assertInstanceOf(Table::class, $children[0]);
+    }
+
     /**
      * Extract text content from a table cell.
      */


### PR DESCRIPTION
## Summary

- Add comprehensive stress tests for multi-line table cell feature as requested in #60

Test scenarios covered:

1. *Extended continuations*: 10+ line continuations verify deep merging works
2. *Attribute mixing*: Cell attributes + row attributes + continuation lines
3. *Code spans*: Backslash characters in code spans (Windows paths, escape sequences)
4. *Empty cells*: Blank continuation cells and all-empty continuation rows
5. *Boundary conditions*: First row, last row, header row, single-row table
6. *Performance*: Large table with 50 continuation rows (verifies < 1s parse time)
7. *Wide tables*: 8 columns with continuation
8. *Mixed rows*: Alternating regular and continuation rows
9. *Termination*: Continuation ended by paragraph (blank line)

Closes #60