### PR TITLE
Add code span continuation support

### DIFF
--- a/src/Parser/Block/TableParser.php
+++ b/src/Parser/Block/TableParser.php
@@ -316,6 +316,129 @@ class TableParser
     }
 
     /**
+     * Parse table cells from a row WITHOUT respecting code spans.
+     *
+     * This is used for look-ahead when checking if continuation rows
+     * can close unclosed code spans. It simply splits on | characters.
+     *
+     * @param string $line The table row line
+     *
+     * @return array<string> Array of cell contents
+     */
+    public function parseTableCellsRaw(string $line): array
+    {
+        // Strip row attributes first
+        $line = $this->stripRowAttributes($line);
+
+        // Must start with | to be a potential table row
+        if (!str_starts_with($line, '|')) {
+            return [];
+        }
+
+        // Remove leading |
+        $line = substr($line, 1);
+
+        // Remove trailing | if present
+        if (str_ends_with($line, '|')) {
+            $line = substr($line, 0, -1);
+        }
+
+        // Simple split on |, handling escaped pipes
+        $cells = [];
+        $currentCell = '';
+        $length = strlen($line);
+
+        for ($i = 0; $i < $length; $i++) {
+            $char = $line[$i];
+
+            // Check for escaped pipe
+            if ($char === '\\' && $i + 1 < $length && $line[$i + 1] === '|') {
+                $currentCell .= '|';
+                $i++; // Skip the |
+
+                continue;
+            }
+
+            // Cell delimiter
+            if ($char === '|') {
+                $cells[] = $currentCell;
+                $currentCell = '';
+
+                continue;
+            }
+
+            $currentCell .= $char;
+        }
+
+        // Add the last cell
+        $cells[] = $currentCell;
+
+        return $cells;
+    }
+
+    /**
+     * Check if a line looks like a table row but has unclosed code spans.
+     *
+     * This is used to detect rows where a code span starts but continues
+     * into a continuation row.
+     *
+     * @param string $line The line to check
+     *
+     * @return bool True if line looks like a table row but has unclosed code span
+     */
+    public function isPotentialTableRowWithUnclosedCodeSpan(string $line): bool
+    {
+        $trimmed = trim($line);
+        if ($trimmed === '' || $trimmed[0] !== '|') {
+            return false;
+        }
+
+        // Strip row attributes if present
+        $lineWithoutRowAttrs = $this->stripRowAttributes($line);
+
+        // Must start with |
+        if (!str_starts_with($lineWithoutRowAttrs, '|')) {
+            return false;
+        }
+
+        // Check if it has an unclosed code span
+        return $this->hasUnclosedCodeSpan($lineWithoutRowAttrs);
+    }
+
+    /**
+     * Check if combining base content with continuation content results in balanced code spans.
+     *
+     * @param string $baseContent The base cell content
+     * @param string $continuationContent The continuation cell content
+     *
+     * @return bool True if the combined content has balanced code spans
+     */
+    public function combinedContentHasBalancedCodeSpans(string $baseContent, string $continuationContent): bool
+    {
+        $combined = $baseContent . ' ' . $continuationContent;
+
+        return !$this->hasUnclosedCodeSpan($combined);
+    }
+
+    /**
+     * Validate that merged cell contents result in a valid table row.
+     *
+     * @param array<string> $mergedCells The merged cell contents
+     *
+     * @return bool True if all cells have balanced code spans
+     */
+    public function mergedCellsAreValid(array $mergedCells): bool
+    {
+        foreach ($mergedCells as $cell) {
+            if ($this->hasUnclosedCodeSpan($cell)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Check if a cell contains a rowspan marker (^).
      * A cell with only ^ (and optional whitespace) indicates it's spanned from the cell above.
      *
@@ -362,8 +485,37 @@ class TableParser
             return false;
         }
 
-        // Must end with | (outside code spans)
-        return $this->lineEndsWithPipeOutsideCodeSpan($trimmed);
+        // Check for standard case: ends with | outside code spans
+        if ($this->lineEndsWithPipeOutsideCodeSpan($trimmed)) {
+            return true;
+        }
+
+        // Also accept continuation rows that might close a code span from the previous row
+        // These have an "orphan" closing backtick that makes the | look like it's inside a code span
+        return $this->isPotentialContinuationRowWithCodeSpan($trimmed);
+    }
+
+    /**
+     * Check if a line is a potential continuation row that contains code span syntax.
+     *
+     * This handles the case where a continuation row closes a code span started
+     * in the previous row.
+     *
+     * @param string $line The trimmed line (starting with +)
+     *
+     * @return bool True if this looks like a continuation row with code span
+     */
+    protected function isPotentialContinuationRowWithCodeSpan(string $line): bool
+    {
+        // Must start with + and contain |
+        if (!str_starts_with($line, '+') || !str_contains($line, '|')) {
+            return false;
+        }
+
+        // Check if it ends with | (even if inside "code span")
+        $trimmed = rtrim($line);
+
+        return str_ends_with($trimmed, '|');
     }
 
     /**

--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -2102,15 +2102,24 @@ class BlockParser
     protected function tryParseTable(Node $parent, array $lines, int $start): ?int
     {
         $line = $lines[$start];
+        $count = count($lines);
 
         // Use TableParser to check if this is a valid table row
         if (!$this->tableParser->isTableRow($line)) {
-            return null;
+            // Check if it's a potential table row with unclosed code span
+            // that might be closed by continuation rows
+            if (!$this->tableParser->isPotentialTableRowWithUnclosedCodeSpan($line)) {
+                return null;
+            }
+
+            // Look ahead for continuation rows that might close the code span
+            if (!$this->canCloseCodeSpanWithContinuations($lines, $start, $count)) {
+                return null;
+            }
         }
 
         $table = new Table();
         $i = $start;
-        $count = count($lines);
         $alignments = [];
         $headerFound = false;
 
@@ -2532,6 +2541,47 @@ class BlockParser
         foreach ($cellsToRemove as $cellToRemove) {
             $row->removeChild($cellToRemove);
         }
+    }
+
+    /**
+     * Check if a row with unclosed code spans can be closed by continuation rows.
+     *
+     * This looks ahead for continuation rows and checks if merging their content
+     * would result in balanced code spans.
+     *
+     * @param array<string> $lines All lines
+     * @param int $start Starting line index
+     * @param int $count Total line count
+     *
+     * @return bool True if continuation rows can close the code spans
+     */
+    protected function canCloseCodeSpanWithContinuations(array $lines, int $start, int $count): bool
+    {
+        $baseLine = $lines[$start];
+
+        // Parse cells from base row (using raw parsing that ignores code span issues)
+        $baseCells = $this->tableParser->parseTableCellsRaw($baseLine);
+        if ($baseCells === []) {
+            return false;
+        }
+
+        $mergedCells = $baseCells;
+        $i = $start + 1;
+
+        // Look for continuation rows
+        while ($i < $count && $this->tableParser->isContinuationRow($lines[$i])) {
+            $continuationCells = $this->tableParser->parseContinuationCells($lines[$i]);
+            $mergedCells = $this->tableParser->mergeCellContents($mergedCells, $continuationCells);
+            $i++;
+        }
+
+        // Check if we found any continuations and if merged content is valid
+        if ($i === $start + 1) {
+            // No continuation rows found
+            return false;
+        }
+
+        return $this->tableParser->mergedCellsAreValid($mergedCells);
     }
 
     /**

--- a/tests/TestCase/MultilineTableCellsTest.php
+++ b/tests/TestCase/MultilineTableCellsTest.php
@@ -613,6 +613,83 @@ DJOT;
     }
 
     /**
+     * Test code span spanning continuation lines.
+     *
+     * This addresses jgm's concern that code spans should work across continuation lines.
+     *
+     * @see https://github.com/jgm/djot/issues/368
+     */
+    public function testCodeSpanAcrossContinuation(): void
+    {
+        $djot = <<<'DJOT'
+| Header | Code                   |
+|--------|------------------------|
+| Row 1  | `function foo() {      |
++        | return true; }`        |
+DJOT;
+
+        $doc = $this->converter->parse($djot);
+        $html = $this->converter->render($doc);
+
+        // Code span should be properly closed and rendered
+        $this->assertStringContainsString('<code>function foo() { return true; }</code>', $html);
+        $this->assertStringContainsString('<td>Row 1</td>', $html);
+    }
+
+    public function testCodeSpanWithDoubleBackticksAcrossContinuation(): void
+    {
+        $djot = <<<'DJOT'
+| Name | Code                    |
+|------|-------------------------|
+| Test | ``const x = `template`  |
++      | with backticks``        |
+DJOT;
+
+        $doc = $this->converter->parse($djot);
+        $html = $this->converter->render($doc);
+
+        // Double backtick code span should work across lines
+        $this->assertStringContainsString('<code>', $html);
+        $this->assertStringContainsString('template', $html);
+    }
+
+    public function testMultipleCodeSpansInContinuation(): void
+    {
+        $djot = <<<'DJOT'
+| A    | B               | C     |
+|------|-----------------|-------|
+| text | `code1          | other |
++      | continued`      |       |
+DJOT;
+
+        $doc = $this->converter->parse($djot);
+        $html = $this->converter->render($doc);
+
+        // First cell should have text, second should have code span
+        $this->assertStringContainsString('<td>text</td>', $html);
+        $this->assertStringContainsString('<code>code1 continued</code>', $html);
+    }
+
+    public function testCodeSpanContinuationWithOtherContent(): void
+    {
+        // jgm's exact example from the issue
+        $djot = <<<'DJOT'
+| aaa | `this is a really long |
++     | code span`             |
+| new | row here               |
+DJOT;
+
+        $doc = $this->converter->parse($djot);
+        $html = $this->converter->render($doc);
+
+        // Code span should be merged correctly
+        $this->assertStringContainsString('<code>this is a really long code span</code>', $html);
+        $this->assertStringContainsString('aaa', $html);
+        $this->assertStringContainsString('new', $html);
+        $this->assertStringContainsString('row here', $html);
+    }
+
+    /**
      * Helper to extract text content from a cell.
      */
     protected function getCellTextContent(TableCell $cell): string


### PR DESCRIPTION
## Summary

Addresses jgm's concern from https://github.com/jgm/djot/issues/368 that code spans should work across continuation lines in tables.

### The Problem

Previously, a table row with an unclosed code span would not be recognized as a table row:

```djot
| aaa | `this is a really long |
+     | code span`             |
```

This was rejected because `lineEndsWithPipeOutsideCodeSpan()` returned false (the final `|` was considered "inside" the unclosed code span).

### The Solution

1. Detect potential table rows with unclosed code spans
2. Look ahead for continuation rows that might close the code spans
3. Parse cells and merge content
4. Validate that merged content has balanced code spans

### Changes

- `isPotentialTableRowWithUnclosedCodeSpan()` - detect rows with unclosed spans
- `canCloseCodeSpanWithContinuations()` - look-ahead validation
- `parseTableCellsRaw()` - parse cells ignoring code span tracking
- `isPotentialContinuationRowWithCodeSpan()` - accept continuation rows that close spans
- `mergedCellsAreValid()` - validate balanced code spans after merging

### Tests Added

- `testCodeSpanAcrossContinuation` - basic code span continuation
- `testCodeSpanWithDoubleBackticksAcrossContinuation` - double backtick code spans
- `testMultipleCodeSpansInContinuation` - multiple cells with code spans
- `testCodeSpanContinuationWithOtherContent` - jgm's exact example

### Performance Impact

Negligible (<5% variance, within measurement noise):

```
Simple table:                    0.0712 ms/iter
Code span across continuation:   0.0678 ms/iter (-4.9%)
```

The look-ahead check only runs when a potential row with unclosed code span is detected.