### PR TITLE
Fix HeadingPermalinksExtension to extract text recursively

### DIFF
--- a/src/Extension/HeadingPermalinksExtension.php
+++ b/src/Extension/HeadingPermalinksExtension.php
@@ -7,9 +7,12 @@ namespace Djot\Extension;
 use Djot\DjotConverter;
 use Djot\Event\RenderEvent;
 use Djot\Node\Block\Heading;
+use Djot\Node\Inline\HardBreak;
 use Djot\Node\Inline\Link;
+use Djot\Node\Inline\SoftBreak;
 use Djot\Node\Inline\Span;
 use Djot\Node\Inline\Text;
+use Djot\Node\Node;
 
 /**
  * Adds permalink anchors to headings
@@ -132,20 +135,18 @@ class HeadingPermalinksExtension implements ExtensionInterface
     }
 
     /**
-     * Extract plain text from a node and its children
+     * Extract plain text from a node and its children (recursive)
      */
-    protected function getPlainText(Heading $node): string
+    protected function getPlainText(Node $node): string
     {
         $text = '';
         foreach ($node->getChildren() as $child) {
             if ($child instanceof Text) {
                 $text .= $child->getContent();
-            } elseif (method_exists($child, 'getChildren')) {
-                foreach ($child->getChildren() as $grandChild) {
-                    if ($grandChild instanceof Text) {
-                        $text .= $grandChild->getContent();
-                    }
-                }
+            } elseif ($child instanceof SoftBreak || $child instanceof HardBreak) {
+                $text .= ' ';
+            } elseif ($child instanceof Node) {
+                $text .= $this->getPlainText($child);
             }
         }
 

--- a/tests/TestCase/Extension/HeadingPermalinksExtensionTest.php
+++ b/tests/TestCase/Extension/HeadingPermalinksExtensionTest.php
@@ -121,4 +121,28 @@ class HeadingPermalinksExtensionTest extends TestCase
 
         $this->assertStringContainsString('href="#custom-id"', $html);
     }
+
+    public function testHeadingWithDeeplyNestedFormatting(): void
+    {
+        $converter = new DjotConverter();
+        $converter->addExtension(new HeadingPermalinksExtension());
+
+        // Deeply nested: emphasis containing strong containing text
+        $html = $converter->convert('# _emphasized *strong* text_');
+
+        // The ID should contain all the text, not just the first level
+        $this->assertStringContainsString('href="#emphasized-strong-text"', $html);
+    }
+
+    public function testHeadingWithLineBreak(): void
+    {
+        $converter = new DjotConverter();
+        $converter->addExtension(new HeadingPermalinksExtension());
+
+        // Hard break in heading (backslash at end of line)
+        $html = $converter->convert("# Hello\\\nWorld");
+
+        // The break should become a space in the ID
+        $this->assertStringContainsString('href="#Hello-World"', $html);
+    }
 }


### PR DESCRIPTION
## Summary

- Fixed `getPlainText()` to recursively extract text from nested inline elements (matching `HtmlRenderer` behavior)
- Added handling for `SoftBreak` and `HardBreak` nodes (convert to spaces)
- Added tests for deeply nested formatting and line breaks in headings

## Problem

The previous implementation only extracted text one level deep:

```php
// OLD - only goes 1 level deep
foreach ($child->getChildren() as $grandChild) {
    if ($grandChild instanceof Text) {
        $text .= $grandChild->getContent();
    }
}
```

This caused incorrect ID generation for headings like `# _emphasized *strong* text_` - the "strong" text would be missing from the generated ID.

## Solution

Now uses proper recursion matching `HtmlRenderer::getPlainText()`:

```php
// NEW - recursive
} elseif ($child instanceof Node) {
    $text .= $this->getPlainText($child);
}
```

## Test plan

- [x] Existing tests pass (9 tests)
- [x] Added test for deeply nested formatting
- [x] Added test for headings with line breaks
- [x] Full test suite passes (1330 tests)
- [x] PHPStan level 9 passes