### PR TITLE
Fix unindented paragraph absorbed into list item after nested block

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -8,7 +8,10 @@
 
     <exclude-pattern>*/vendor/*</exclude-pattern>
 
-    <rule ref="PhpCollective"/>
+    <rule ref="PhpCollective">
+        <!-- Conflicts with Universal.WhiteSpace.AnonClassKeywordSpacing which PhpCollective enables -->
+        <exclude name="PSR12.Classes.AnonClassDeclaration.SpaceAfterKeyword"/>
+    </rule>
 
     <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration"/>
     <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInClosureUse"/>

--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -1500,6 +1500,14 @@ class BlockParser
                             if ($itemInfo !== null && $itemInfo['type'] === $listInfo['type'] && $itemInfo['marker'] === $listInfo['marker'] && $sameStyle) {
                                 break;
                             }
+                            // After a blank line, content dropping back to base indent
+                            // starts a new block outside the list - let parent handle it.
+                            if ($sawBlankLine) {
+                                $lastItemHadBlankAfter = true;
+                                $brokeForParentContent = true;
+
+                                break;
+                            }
                             // Content at base indent that's not a matching list marker
                             // Check if it's a block element - if so, end list content collection
                             // Use isBlockElementStart() which detects blocks regardless of mode

--- a/tests/TestCase/Extension/HeadingReferenceExtensionTest.php
+++ b/tests/TestCase/Extension/HeadingReferenceExtensionTest.php
@@ -251,7 +251,7 @@ DJOT);
 
     public function testUserAuthoredLinkWithMatchingPlaceholderIsNotRewritten(): void
     {
-        $extension = new class ('heading-ref') extends HeadingReferenceExtension {
+        $extension = new class('heading-ref') extends HeadingReferenceExtension {
             protected function generatePlaceholderPrefix(): string
             {
                 return 'collision-placeholder-';

--- a/tests/TestCase/NestedBlocksInListsTest.php
+++ b/tests/TestCase/NestedBlocksInListsTest.php
@@ -633,4 +633,39 @@ DJOT;
         // Should NOT be inline code
         $this->assertStringNotContainsString('<p><code>', $result);
     }
+
+    /**
+     * After a nested block inside a list item and a blank line, an
+     * unindented paragraph must terminate the list rather than being
+     * absorbed as a sub-item of the previous list item.
+     *
+     * @see https://github.com/php-collective/djot-php/issues/176
+     */
+    public function testIssue176UnindentedParagraphAfterNestedCodeBlockEndsList(): void
+    {
+        $djot = <<<'DJOT'
+1. Item 1
+2. Item 2
+
+   ```
+   Example
+   ```
+
+New list:
+
+* New item 1
+* New item 2
+DJOT;
+
+        $result = $this->converter->convert($djot);
+
+        $this->assertStringContainsString('</ol>', $result);
+        // The "New list:" paragraph must appear after the ordered list closes.
+        $olClose = strpos($result, '</ol>');
+        $paragraph = strpos($result, '<p>New list:</p>');
+        $this->assertNotFalse($paragraph);
+        $this->assertGreaterThan($olClose, $paragraph);
+        // And the following bullet list must be a sibling, not nested in <li>.
+        $this->assertMatchesRegularExpression('#</ol>\s*<p>New list:</p>\s*<ul>#', $result);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #176.

When a list item contains a nested block (e.g. an indented code block) followed by a blank line and an unindented paragraph, djot-php incorrectly collected the paragraph as lazy continuation of the list item, nesting it under the last `<li>` instead of closing the list.

### Example

```djot
1. Item 1
2. Item 2

   ```
   Example
   ```

New list:

* New item 1
* New item 2
```

Before: `New list:` and the bullet list rendered inside the last `<li>`.
After: matches djot.js — `</ol>` closes, then `<p>New list:</p>`, then `<ul>`.

## Fix

In `BlockParser::tryParseList()`, the sub-content collection loop treated any line at base indent that wasn't a block starter or matching list marker as lazy continuation. After a blank line (`sawBlankLine`), dropping back to base indent now breaks out with `brokeForParentContent = true` so the outer parser handles it as a new block.

Regression test added in `NestedBlocksInListsTest::testIssue176UnindentedParagraphAfterNestedCodeBlockEndsList`. Full suite (2127 tests) and PHPStan pass.