### PR TITLE
Fix lone marker line wrongly starting a block in significantNewlines mode

### DIFF
--- a/docs/guide/parser-options.md
+++ b/docs/guide/parser-options.md
@@ -170,6 +170,28 @@ Output:
 
 Note: Soft break rendering is controlled separately via `SoftBreakMode` - see the [Soft Break Modes](#soft-break-modes) section above.
 
+#### Lone marker lines are not blocks
+
+Hard-wrapped prose frequently starts a line with `-`, `*`, `+`, `>` or `|` as an
+arithmetic/comparison operator or pipe rather than a list/quote/table marker:
+
+```text
+Die Frage ist, wann ist x = 5
+* 3 + 17 wahr.
+```
+
+To avoid turning these into spurious lists, a **single** marker line followed by
+ordinary prose does *not* interrupt a paragraph. A bullet/blockquote/table
+marker only interrupts when it forms a *real* block:
+
+- two or more consecutive marker lines (`- a` / `- b`, or `> a` / `> b`), **or**
+- a marker line with an indented continuation (`- item` / `  more`), **or**
+- it is preceded by a blank line (then any single marker starts a block).
+
+This mirrors the existing rule that only `1.` (not `5.` or `1985.`) interrupts
+a paragraph as an ordered list. Headings (`#`) and code/comment/div fences are
+unambiguous and still interrupt on a single line.
+
 ### Preventing Block Interruption with Escaping
 
 In significant newlines mode, if you want to include literal block markers without triggering block parsing, escape the first character with a backslash:
@@ -177,15 +199,17 @@ In significant newlines mode, if you want to include literal block markers witho
 ```php
 $converter = DjotConverter::withSignificantNewlines();
 
-// Without escaping - creates a list
+// Without escaping - two markers form a list
 $result = $converter->convert("Price:
-- 10 dollars");
-// Output: <p>Price:</p><ul><li>10 dollars</li></ul>
+- 10 dollars
+- 5 cents");
+// Output: <p>Price:</p><ul><li>10 dollars</li><li>5 cents</li></ul>
 
-// With escaping - literal text
+// With escaping - literal text (first marker neutralized)
 $result = $converter->convert("Price:
-\\- 10 dollars");
-// Output: <p>Price:<br>- 10 dollars</p>
+\\- 10 dollars
+- 5 cents");
+// Output: <p>Price:<br>- 10 dollars<br>- 5 cents</p>
 ```
 
 Common escapes:

--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -2724,7 +2724,7 @@ class BlockParser
                 break;
             }
 
-            if (!$hasUnclosedBrace && $this->startsNewBlock($nextLine)) {
+            if (!$hasUnclosedBrace && $this->startsNewBlock($nextLine, $lines, $i)) {
                 break;
             }
 
@@ -2876,7 +2876,15 @@ class BlockParser
         }
     }
 
-    protected function startsNewBlock(string $line): bool
+    /**
+     * Determine whether a continuation line should interrupt the current block (paragraph etc.).
+     *
+     * @param string $line The continuation line being inspected
+     * @param array<string>|null $lines All source lines, when lookahead is available (prose
+     *     interruption only). When null, a lone marker keeps the legacy "interrupts" behavior.
+     * @param int $index Index of $line within $lines (so the next line is $lines[$index + 1])
+     */
+    protected function startsNewBlock(string $line, ?array $lines = null, int $index = -1): bool
     {
         // Quick check: empty lines don't start blocks
         if ($line === '' || !isset($line[0])) {
@@ -2897,7 +2905,7 @@ class BlockParser
 
         // In significantNewlines mode, block elements can interrupt paragraphs
         if ($this->significantNewlines) {
-            return $this->startsNewBlockSignificant($line);
+            return $this->startsNewBlockSignificant($line, $lines, $index);
         }
 
         // Standard djot behavior:
@@ -2914,8 +2922,13 @@ class BlockParser
      * - Ordered lists (1. 2. etc)
      * - Code fences (```)
      * - Fenced divs (:::)
+     *
+     * @param string $line The continuation line being inspected
+     * @param array<string>|null $lines All source lines, when prose lookahead is
+     *     available; null keeps the legacy "lone marker interrupts" behavior.
+     * @param int $index Index of $line within $lines
      */
-    protected function startsNewBlockSignificant(string $line): bool
+    protected function startsNewBlockSignificant(string $line, ?array $lines = null, int $index = -1): bool
     {
         // Use first-char switch to avoid unnecessary regex checks
         $first = $line[0];
@@ -2929,16 +2942,34 @@ class BlockParser
             case '+':
                 // Unordered lists or thematic breaks
                 if (isset($line[1]) && $line[1] === ' ') {
+                    // A lone marker line in flowing prose is almost always an
+                    // operator ("x = 5\n* 3 + 17", "10\n- 3 ist 7"), not a list.
+                    // When prose lookahead is available, only interrupt for a
+                    // real block: 2+ markers or an indented continuation.
+                    if ($lines !== null) {
+                        return $this->significantMarkerHasBlockContinuation('bullet', $lines, $index);
+                    }
+
                     return true; // Unordered list
                 }
 
                 // Thematic breaks: *\s*\*\s*\* or -\s*-\s*-
                 return preg_match('/^(\*\s*\*\s*\*|-\s*-\s*-)/', $line) === 1;
             case '|':
-                // Tables
+                // Tables — a single "| ..." line is not a valid table; in prose
+                // require a real table (next line also a row, e.g. delimiter).
+                if ($lines !== null) {
+                    return $this->significantMarkerHasBlockContinuation('table', $lines, $index);
+                }
+
                 return true;
             case '>':
-                // Block quotes
+                // Block quotes — a lone ">" in prose ("if x\n> 5 then") is a
+                // comparison, not a quote; require a real (multi-line) quote.
+                if ($lines !== null) {
+                    return $this->significantMarkerHasBlockContinuation('quote', $lines, $index);
+                }
+
                 return true;
             case '`':
                 // Code fences: `{3,}
@@ -2958,6 +2989,46 @@ class BlockParser
 
                 return false;
         }
+    }
+
+    /**
+     * In significantNewlines mode, decide whether a lone marker line in flowing
+     * prose really begins a block, or is just an operator/punctuation that
+     * happens to start a hard-wrapped line ("x = 5\n* 3 + 17", "if x\n> 5").
+     *
+     * A real block requires the immediately following line to either continue
+     * the block (another same-kind marker, i.e. 2+ markers) or be an indented
+     * continuation. A single isolated marker line stays paragraph text.
+     *
+     * @param string $kind One of 'bullet', 'quote', 'table'
+     * @param array<string> $lines All source lines
+     * @param int $index Index of the marker line within $lines
+     */
+    private function significantMarkerHasBlockContinuation(string $kind, array $lines, int $index): bool
+    {
+        $next = $lines[$index + 1] ?? null;
+
+        // Lone marker as the last line (e.g. "Total: 5\n- 3") is not a block.
+        if ($next === null || IndentationHelper::isBlankLine($next)) {
+            return false;
+        }
+
+        // Indented continuation of a multi-line first item ("- item\n  more").
+        // Only meaningful for lists; quotes/tables need their own marker.
+        if ($kind === 'bullet' && preg_match('/^\s/', $next) === 1) {
+            return true;
+        }
+
+        $t = ltrim($next);
+
+        return match ($kind) {
+            'bullet' => isset($t[0], $t[1])
+                && ($t[0] === '-' || $t[0] === '*' || $t[0] === '+')
+                && $t[1] === ' ',
+            'quote' => isset($t[0]) && $t[0] === '>',
+            'table' => isset($t[0]) && $t[0] === '|',
+            default => true,
+        };
     }
 
     /**

--- a/tests/TestCase/Parser/BlockParserTest.php
+++ b/tests/TestCase/Parser/BlockParserTest.php
@@ -544,8 +544,10 @@ DJOT;
 
     public function testSignificantNewlinesBlockquoteInterruptsParagraph(): void
     {
+        // A lone ">" line in prose is a comparison operator; interrupting a
+        // paragraph requires a real (2+ line) quote.
         $parser = new BlockParser(significantNewlines: true);
-        $doc = $parser->parse("They said:\n> This is important");
+        $doc = $parser->parse("They said:\n> This is important\n> Pay attention");
 
         $children = $doc->getChildren();
         $this->assertCount(2, $children);

--- a/tests/TestCase/SignificantNewlinesTest.php
+++ b/tests/TestCase/SignificantNewlinesTest.php
@@ -65,13 +65,26 @@ class SignificantNewlinesTest extends TestCase
 
     public function testBlockquoteInterruptsParagraph(): void
     {
+        // A lone ">" line in flowing prose is a comparison operator, not a
+        // quote ("if x\n> 5"). Interrupting requires a *real* (2+ line) quote.
         $parser = new BlockParser(significantNewlines: true);
-        $doc = $parser->parse("They said:\n> This is important");
+        $doc = $parser->parse("They said:\n> This is important\n> Pay attention");
 
         $children = $doc->getChildren();
         $this->assertCount(2, $children);
         $this->assertInstanceOf(Paragraph::class, $children[0]);
         $this->assertInstanceOf(BlockQuote::class, $children[1]);
+    }
+
+    public function testLoneBlockquoteMarkerDoesNotInterruptParagraph(): void
+    {
+        // "if x\n> 5 then ..." — the ">" is greater-than, not a blockquote.
+        $parser = new BlockParser(significantNewlines: true);
+        $doc = $parser->parse("Wenn x\n> 5 dann ist die Bedingung wahr.");
+
+        $children = $doc->getChildren();
+        $this->assertCount(1, $children);
+        $this->assertInstanceOf(Paragraph::class, $children[0]);
     }
 
     public function testOrderedListInterruptsParagraph(): void
@@ -238,7 +251,8 @@ class SignificantNewlinesTest extends TestCase
     {
         $converter = new DjotConverter(significantNewlines: true);
 
-        $djot = "They said:\n> Important";
+        // 2+ line quote required (a single ">" line is treated as prose).
+        $djot = "They said:\n> Important\n> Really";
         $result = $converter->convert($djot);
 
         $this->assertStringContainsString('<blockquote>', $result);
@@ -350,6 +364,81 @@ DJOT;
         // With blank line, any number can start a list
         $parser = new BlockParser(significantNewlines: true);
         $doc = $parser->parse("Continue from step\n\n5. Do this thing");
+
+        $children = $doc->getChildren();
+        $this->assertCount(2, $children);
+        $this->assertInstanceOf(Paragraph::class, $children[0]);
+        $this->assertInstanceOf(ListBlock::class, $children[1]);
+    }
+
+    // ==================== Operator vs. List Marker (bullet/table) ====================
+    //
+    // In hard-wrapped prose a line can begin with -, *, +, > or | as an
+    // arithmetic/comparison operator or pipe. A *lone* marker line followed by
+    // ordinary prose must NOT become a list/quote/table; a real block requires
+    // 2+ marker lines or an indented continuation. (Mirrors the existing
+    // "only 1. interrupts" rule for ordered lists.)
+
+    public function testMultiplicationStarDoesNotBecomeList(): void
+    {
+        $parser = new BlockParser(significantNewlines: true);
+        $doc = $parser->parse("Die Frage ist, wann ist x = 5\n* 3 + 17 wahr. Leider eine Liste\nim Text.");
+
+        $children = $doc->getChildren();
+        $this->assertCount(1, $children);
+        $this->assertInstanceOf(Paragraph::class, $children[0]);
+    }
+
+    public function testMinusOperatorDoesNotBecomeList(): void
+    {
+        $parser = new BlockParser(significantNewlines: true);
+        $doc = $parser->parse("Das Ergebnis von 10\n- 3 ist 7. Kein Listenpunkt.");
+
+        $children = $doc->getChildren();
+        $this->assertCount(1, $children);
+        $this->assertInstanceOf(Paragraph::class, $children[0]);
+    }
+
+    public function testPlusOperatorDoesNotBecomeList(): void
+    {
+        $parser = new BlockParser(significantNewlines: true);
+        $doc = $parser->parse("Die Summe ist 5\n+ 3 ergibt 8. Keine Liste.");
+
+        $children = $doc->getChildren();
+        $this->assertCount(1, $children);
+        $this->assertInstanceOf(Paragraph::class, $children[0]);
+    }
+
+    public function testLonePipeLineDoesNotSplitParagraph(): void
+    {
+        // Regression: a single "| ..." line is not a valid table, yet it used
+        // to sever the paragraph into two stray <p> blocks.
+        $parser = new BlockParser(significantNewlines: true);
+        $doc = $parser->parse("Das berechnet a\n| b als bitweises Oder.");
+
+        $children = $doc->getChildren();
+        $this->assertCount(1, $children);
+        $this->assertInstanceOf(Paragraph::class, $children[0]);
+    }
+
+    public function testTwoMarkersStillFormAList(): void
+    {
+        // The guard must not regress real lists: 2+ markers => list.
+        $parser = new BlockParser(significantNewlines: true);
+        $doc = $parser->parse("Hier eine Liste:\n- erstes Element\n- zweites Element");
+
+        $children = $doc->getChildren();
+        $this->assertCount(2, $children);
+        $this->assertInstanceOf(Paragraph::class, $children[0]);
+        $this->assertInstanceOf(ListBlock::class, $children[1]);
+    }
+
+    public function testSingleBulletWithIndentedContinuationIsList(): void
+    {
+        // One item but with an indented continuation line still reads as a
+        // real (multi-line) list, so it interrupts.
+        $parser = new BlockParser(significantNewlines: true);
+        $doc = $parser->parse("Shopping:\n- milk and\n  some bread");
 
         $children = $doc->getChildren();
         $this->assertCount(2, $children);

--- a/tests/TestCase/SoftBreakModeTest.php
+++ b/tests/TestCase/SoftBreakModeTest.php
@@ -131,9 +131,12 @@ DJOT;
             softBreakMode: SoftBreakMode::Space,
         );
 
+        // A real (2+ line) quote interrupts without a blank line; a single ">"
+        // line in prose is treated as a comparison operator, not a quote.
         $djot = <<<'DJOT'
 Some text
 > A quote
+> spanning two lines
 More text
 DJOT;
 


### PR DESCRIPTION
## Problem

In `significantNewlines` mode, a hard-wrapped prose line beginning with `-`, `*`, `+`, `>` or `|` was unconditionally treated as a list/blockquote/table marker. Arithmetic and comparison expressions in flowing prose became spurious blocks:

```text
Die Frage ist, wann ist x = 5
* 3 + 17 wahr. Leider eine Liste
im Text.
```

→ `<p>… x = 5</p>` followed by a `<ul>`. Same for `10\n- 3`, `5\n+ 3`, `if x\n> 5`, and a lone `| …` line even split the paragraph into two stray `<p>` blocks.

## Root cause

The bullet/blockquote/table branches of `startsNewBlockSignificant()` returned `true` on a first-char + space check with no "is this really a block?" guard — unlike the ordered-list branch, which already restricts paragraph interruption to `1.` (so `5.` / `1985.` stay prose).

## Fix

A bounded one-line lookahead, threaded **only** into the paragraph collector (`tryParseParagraph`). The other 12 `startsNewBlock()` call sites default to `lines = null` and keep their previous behavior, so standalone (post-blank-line) blocks and nested-in-list parsing are untouched.

A lone bullet/blockquote/table marker interrupts a paragraph only when it forms a *real* block:

- two or more consecutive marker lines, **or**
- a marker line with an indented continuation, **or**
- it is preceded by a blank line.

Headings (`#`) and code/comment/div fences are unambiguous and still interrupt on a single line. The default (spec-compliant) djot mode is completely unaffected — it never interrupts paragraphs at all.

## Behavior change (bc-breaking, significantNewlines only)

Single-item lists and single-line blockquotes no longer interrupt a paragraph without a blank line. This is the deliberate, accepted trade — `Price:\n- 10 dollars` and `… 10\n- 3` are syntactically identical, so there is no free-lunch rule. It mirrors the existing "only `1.` interrupts" precedent. Documented in `docs/guide/parser-options.md` (new "Lone marker lines are not blocks" section + corrected escaping example).

## Verification

- Full suite green: 2147 tests, phpstan clean, phpcs clean.
- 4 existing tests updated to the new semantics with explanatory comments; 6 regression tests added covering the operator/marker cases and the real-list/indented-continuation cases that must still work.
