### PR TITLE
Reserve explicit ids before auto heading ids; rewrite refs post-parse

### DIFF
--- a/src/Node/Inline/Image.php
+++ b/src/Node/Inline/Image.php
@@ -37,6 +37,11 @@ class Image extends InlineNode
         return $this->source;
     }
 
+    public function setSource(string $source): void
+    {
+        $this->source = $source;
+    }
+
     public function getAlt(): string
     {
         return $this->alt;

--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -697,6 +697,8 @@ class BlockParser
     }
 
     /**
+     * @param \Djot\Node\Node $node
+     * @param \Djot\Renderer\HeadingIdTracker $tracker
      * @param array<string, string> $out
      */
     protected function collectHeadingIds(Node $node, HeadingIdTracker $tracker, array &$out): void
@@ -724,7 +726,9 @@ class BlockParser
     }
 
     /**
+     * @param \Djot\Node\Node $node
      * @param array<string, string> $newUrlByLabel
+     * @param \Djot\Renderer\HeadingIdTracker $tracker
      */
     protected function retargetHeadingLinks(Node $node, array $newUrlByLabel, HeadingIdTracker $tracker): void
     {

--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -29,6 +29,7 @@ use Djot\Node\Block\ThematicBreak;
 use Djot\Node\Document;
 use Djot\Node\Inline\HardBreak;
 use Djot\Node\Inline\Image;
+use Djot\Node\Inline\Link;
 use Djot\Node\Inline\Text;
 use Djot\Node\Node;
 use Djot\Parser\Block\FencedBlockParser;
@@ -115,6 +116,16 @@ class BlockParser
      * @var array<string, true>
      */
     protected array $headingIds = [];
+
+    /**
+     * Labels in $references that were registered by a heading (not by an
+     * explicit `[label]: url` definition). Only those are rewritten by the
+     * post-parse `rewriteHeadingReferences` pass — an explicit definition
+     * always wins over the heading's auto-id.
+     *
+     * @var array<string, true>
+     */
+    protected array $headingReferenceLabels = [];
 
     /**
      * Current line offset for nested parsing (0-indexed internally, 1-indexed for errors)
@@ -336,6 +347,7 @@ class BlockParser
         $this->usedReferences = [];
         $this->anchorLinks = [];
         $this->headingIds = [];
+        $this->headingReferenceLabels = [];
         $this->lineOffset = 0;
         $document = new Document();
         $lines = $this->splitLines($input);
@@ -353,6 +365,13 @@ class BlockParser
         foreach ($this->footnotes as $footnote) {
             $document->appendChild($footnote);
         }
+
+        // Third pass (post-parse): now that the AST exists we can pre-reserve
+        // every explicit `{#id}` (heading or non-heading, including inline
+        // attributes) and rewrite implicit heading references to the same
+        // deduped ids the renderer will emit, so `[Heading][]` anchors stay
+        // in sync with the rendered section id.
+        $this->rewriteHeadingReferences($document);
 
         // Validate references and anchor links if warnings are enabled
         if ($this->collectWarnings) {
@@ -572,6 +591,13 @@ class BlockParser
         $pendingId = null;
         $count = count($lines);
 
+        // NOTE: this pass is line-based and runs *before* the AST exists, so
+        // it cannot reliably pre-reserve every explicit id the way the
+        // renderer's AST-walking `reserveExplicitIds` does. As a result, the
+        // implicit-reference href computed here can disagree with the rendered
+        // section id when a heading's auto-id collides with a non-heading
+        // explicit id elsewhere in the document. Tracked as a follow-up.
+
         for ($i = 0; $i < $count; $i++) {
             $line = $lines[$i];
 
@@ -618,6 +644,9 @@ class BlockParser
                 $label = preg_replace('/\s+/', ' ', trim($plainText)) ?? $plainText;
                 if (!isset($this->references[$label])) {
                     $this->references[$label] = new ReferenceDefinition('#' . $id, [], $i);
+                    // Mark so the post-parse rewrite knows this came from a
+                    // heading; an explicit `[label]: url` always wins.
+                    $this->headingReferenceLabels[$label] = true;
                 }
             } else {
                 // Non-heading, non-attribute line - clear pending ID
@@ -625,6 +654,103 @@ class BlockParser
                     $pendingId = null;
                 }
             }
+        }
+    }
+
+    /**
+     * Rewrite implicit heading references against the parsed AST
+     *
+     * `extractHeadingReferences()` runs before the AST exists, so its
+     * estimated heading ids can disagree with the renderer once explicit
+     * `{#id}` attributes (especially on non-heading blocks or inline
+     * elements) force the renderer to dedupe. This post-parse pass walks
+     * the document with the same `reserveExplicitIds` the renderer uses,
+     * computes the actual heading ids, and re-targets both the references
+     * map and any built reference-Link nodes accordingly.
+     */
+    protected function rewriteHeadingReferences(Document $document): void
+    {
+        $tracker = new HeadingIdTracker();
+        $tracker->reserveExplicitIds($document);
+
+        /** @var array<string, string> $newUrlByLabel */
+        $newUrlByLabel = [];
+        $this->collectHeadingIds($document, $tracker, $newUrlByLabel);
+
+        // Only rewrite labels that came from a heading — an explicit
+        // `[label]: url` reference always wins over the heading's id.
+        $headingOnly = [];
+        foreach ($newUrlByLabel as $label => $url) {
+            if (isset($this->headingReferenceLabels[$label])) {
+                $headingOnly[$label] = $url;
+            }
+        }
+
+        foreach ($headingOnly as $label => $url) {
+            if (isset($this->references[$label])) {
+                $old = $this->references[$label];
+                $this->references[$label] = new ReferenceDefinition($url, $old->attributes, $old->line);
+            }
+        }
+
+        $this->retargetHeadingLinks($document, $headingOnly, $tracker);
+    }
+
+    /**
+     * @param array<string, string> $out
+     */
+    protected function collectHeadingIds(Node $node, HeadingIdTracker $tracker, array &$out): void
+    {
+        foreach ($node->getChildren() as $child) {
+            if ($child instanceof Heading) {
+                $id = $tracker->getIdForHeading($child);
+                // Remember the renderer-visible id so `validateAnchorLinks`
+                // doesn't flag valid links to deduped headings as broken.
+                $this->headingIds[$id] = true;
+
+                $plain = $tracker->getPlainText($child);
+                $label = preg_replace('/\s+/', ' ', trim($plain)) ?? $plain;
+                // First-wins: an implicit `[Foo][]` link resolves to the
+                // first heading with that label, matching the line-based
+                // pass and djot.js. Later duplicates only get deduped ids.
+                if (!isset($out[$label])) {
+                    $out[$label] = '#' . $id;
+                }
+
+                continue;
+            }
+            $this->collectHeadingIds($child, $tracker, $out);
+        }
+    }
+
+    /**
+     * @param array<string, string> $newUrlByLabel
+     */
+    protected function retargetHeadingLinks(Node $node, array $newUrlByLabel, HeadingIdTracker $tracker): void
+    {
+        foreach ($node->getChildren() as $child) {
+            // Both reference Links (`[Text][]`) and reference Images
+            // (`![Text][]`) carry the implicit-reference label and need
+            // their target rewritten when a heading id is deduped. Images
+            // store their text in the `alt` string; Links keep it as child
+            // nodes — extract each appropriately for the lookup key.
+            if (($child instanceof Link || $child instanceof Image) && $child->getReferenceLabel() !== null) {
+                $refLabel = $child->getReferenceLabel();
+                if ($refLabel === '') {
+                    $raw = $child instanceof Link ? $tracker->getPlainText($child) : $child->getAlt();
+                    $key = preg_replace('/\s+/', ' ', trim($raw)) ?? '';
+                } else {
+                    $key = preg_replace('/\s+/', ' ', trim($refLabel)) ?? $refLabel;
+                }
+                if ($key !== '' && isset($newUrlByLabel[$key])) {
+                    if ($child instanceof Link) {
+                        $child->setDestination($newUrlByLabel[$key]);
+                    } else {
+                        $child->setSource($newUrlByLabel[$key]);
+                    }
+                }
+            }
+            $this->retargetHeadingLinks($child, $newUrlByLabel, $tracker);
         }
     }
 

--- a/src/Renderer/HeadingIdTracker.php
+++ b/src/Renderer/HeadingIdTracker.php
@@ -88,6 +88,26 @@ class HeadingIdTracker
     }
 
     /**
+     * Reserve every explicit `id` attribute in the document subtree
+     *
+     * Walks the AST and `trackId`s any node with an explicit `id`, so
+     * later heading auto-id generation dedupes against the entire
+     * document's explicit ids regardless of their position. Run once
+     * up-front by both the renderer and the implicit-reference pass so
+     * the two compute the same heading ids (parser/render parity).
+     */
+    public function reserveExplicitIds(Node $node): void
+    {
+        if ($node->hasAttribute('id')) {
+            $this->trackId((string)$node->getAttribute('id'));
+        }
+
+        foreach ($node->getChildren() as $child) {
+            $this->reserveExplicitIds($child);
+        }
+    }
+
+    /**
      * Normalize text into a valid CSS identifier string
      *
      * 1. Strip # characters entirely
@@ -218,10 +238,20 @@ class HeadingIdTracker
         $idText = $this->extractPlainText($node, forId: true);
 
         if ($idText === '') {
-            // Generate fallback ID
-            $this->sectionCounter++;
+            // Generate fallback ID, skipping any `s-N` already reserved
+            // (by `reserveExplicitIds`, an explicit `{#s-N}` heading, or a
+            // prior normalized heading), so the fallback never produces a
+            // duplicate. Both the renderer and the implicit-reference
+            // pass run `reserveExplicitIds` first, so this stays
+            // deterministic across passes.
+            do {
+                $this->sectionCounter++;
+                $fallback = 's-' . $this->sectionCounter;
+            } while (isset($this->usedIds[$fallback]));
 
-            return 's-' . $this->sectionCounter;
+            $this->usedIds[$fallback] = 0;
+
+            return $fallback;
         }
 
         $baseId = $this->normalizeId($idText);
@@ -233,9 +263,16 @@ class HeadingIdTracker
             return $baseId;
         }
 
-        // Already used, add suffix (first conflict is -1, second is -2, etc.)
-        $this->usedIds[$baseId]++;
+        // Already used. Find the next suffix that isn't itself reserved —
+        // an explicit `{#Foo-1}` must not be silently overridden by an
+        // auto-id collision on `# Foo`.
+        do {
+            $this->usedIds[$baseId]++;
+            $candidate = $baseId . '-' . $this->usedIds[$baseId];
+        } while (isset($this->usedIds[$candidate]));
 
-        return $baseId . '-' . $this->usedIds[$baseId];
+        $this->usedIds[$candidate] = 0;
+
+        return $candidate;
     }
 }

--- a/src/Renderer/HtmlRenderer.php
+++ b/src/Renderer/HtmlRenderer.php
@@ -333,6 +333,14 @@ class HtmlRenderer implements RendererInterface
      */
     protected function renderDocumentWithSections(Document $document): string
     {
+        // Reserve every explicit `{#id}` in the document (heading or not)
+        // before any heading auto-id is generated, so a later auto-id that
+        // would otherwise collide takes the next dedup suffix instead of
+        // emitting a duplicate. Mirrors the parser-side pre-reservation in
+        // BlockParser::extractHeadingReferences so both passes compute the
+        // same heading ids.
+        $this->getRenderContext()->headingIdTracker->reserveExplicitIds($document);
+
         $children = $document->getChildren();
         $html = '';
         /** @var array<int, int> $openSections Level => count of open sections at that level */
@@ -393,8 +401,8 @@ class HtmlRenderer implements RendererInterface
                 // Render heading without section wrapper
                 $html .= $this->renderHeadingContent($child);
             } else {
-                // Track IDs from non-heading elements for deduplication
-                $this->trackIdFromNode($child);
+                // Non-heading ids were already reserved by the upfront
+                // `reserveExplicitIds` pass above; just render the node.
                 $html .= $this->renderNode($child);
             }
         }

--- a/tests/TestCase/DjotConverterTest.php
+++ b/tests/TestCase/DjotConverterTest.php
@@ -1756,6 +1756,147 @@ DJOT;
         $this->assertStringContainsString('<h1>日本語の見出し</h1>', $result);
     }
 
+    /**
+     * Every explicit `{#id}` in the document (heading or not) must be
+     * reserved up-front, so a heading whose auto-generated id would
+     * otherwise collide takes the next free dedupe suffix instead of
+     * silently emitting a duplicate id.
+     *
+     * Critical case: the explicit `{#Foo-Bar}` appears *after* the
+     * heading whose text normalizes to `Foo-Bar`. Without an upfront
+     * pre-pass, inline tracking only catches the explicit id once
+     * encountered, and the heading rendered first wins the slot.
+     */
+    public function testExplicitIdsAreReservedBeforeAutoIds(): void
+    {
+        $result = $this->converter->convert("# Foo Bar\n\n{#Foo-Bar}\npara\n");
+
+        $this->assertStringContainsString('<section id="Foo-Bar-1">', $result);
+        $this->assertStringContainsString('<p id="Foo-Bar">', $result);
+        // Pre-fix master emits two `Foo-Bar` ids — guard against the regression.
+        $this->assertSame(1, substr_count($result, ' id="Foo-Bar"'));
+    }
+
+    /**
+     * Once explicit ids are reserved up-front, the heading dedup loop must
+     * also skip *suffix candidates* that are reserved — e.g. `# Foo`,
+     * `{#Foo-1}`, `# Foo` should resolve the second heading to `Foo-2`,
+     * not silently collide with the explicit `Foo-1`.
+     */
+    public function testHeadingDedupeSkipsReservedSuffixedIds(): void
+    {
+        $result = $this->converter->convert("# Foo\n\n{#Foo-1}\npara\n\n# Foo\n");
+
+        $this->assertStringContainsString('<section id="Foo">', $result);
+        $this->assertStringContainsString('<p id="Foo-1">', $result);
+        $this->assertStringContainsString('<section id="Foo-2">', $result);
+        $this->assertSame(1, substr_count($result, ' id="Foo-1"'));
+    }
+
+    /**
+     * After reserving explicit ids, the implicit-reference pass and the
+     * renderer must still produce matching anchors: a `[Heading][]` link
+     * has to land on the (possibly-deduped) section id, not the original
+     * line-based estimate. The post-parse rewrite re-targets refs.
+     */
+    public function testImplicitHeadingReferenceMatchesRenderedSectionId(): void
+    {
+        $result = $this->converter->convert("# Foo Bar\n\n{#Foo-Bar}\npara\n\n[Foo Bar][]\n");
+
+        $this->assertSame(
+            1,
+            preg_match('/<section id="(Foo-Bar(?:-\d+)?)">/', $result, $section),
+        );
+        $this->assertStringContainsString('href="#' . $section[1] . '"', $result);
+        $this->assertStringContainsString('<p id="Foo-Bar">', $result);
+    }
+
+    /**
+     * Implicit `[Heading][]` links resolve to the *first* heading with that
+     * text. Duplicate-heading auto-ids get suffixed (`Foo`, `Foo-1`, …) but
+     * the reference must keep pointing at the original.
+     */
+    public function testImplicitHeadingReferencePrefersFirstDuplicate(): void
+    {
+        $result = $this->converter->convert("# Foo\n\n# Foo\n\n[Foo][]\n");
+
+        $this->assertStringContainsString('href="#Foo"', $result);
+        $this->assertStringNotContainsString('href="#Foo-1"', $result);
+    }
+
+    /**
+     * After the post-parse rewrite recomputes heading ids, anchor-link
+     * validation must see the renderer-visible ids (no false "Broken anchor"
+     * warnings for valid links to deduped headings).
+     */
+    public function testAnchorValidationSeesPostRewriteHeadingIds(): void
+    {
+        $converter = new DjotConverter(warnings: true);
+        $converter->convert("# Foo Bar\n\n{#Foo-Bar}\npara\n\n[x](#Foo-Bar-1)\n[y](#Foo-Bar)\n");
+
+        $brokenAnchorWarnings = array_filter(
+            $converter->getWarnings(),
+            static fn ($w): bool => str_contains($w->getMessage(), 'Broken anchor link'),
+        );
+
+        $this->assertSame([], $brokenAnchorWarnings, 'no broken-anchor warnings for valid links');
+    }
+
+    /**
+     * Parser state (incl. `headingReferenceLabels`) must reset between
+     * conversions on the same `DjotConverter` instance — otherwise a label
+     * marked as heading-owned in doc N silently lets doc N+1's rewrite
+     * overwrite an explicit `[Foo]: url` reference.
+     */
+    public function testHeadingReferenceLabelsResetBetweenConversions(): void
+    {
+        $converter = new DjotConverter();
+
+        // First conversion: heading registers "Foo" as a heading-owned label.
+        $converter->convert("# Foo\n");
+
+        // Second conversion: explicit `[Foo]: url` must win; the heading's
+        // auto-id must not retarget the link to `#Foo`.
+        $result = $converter->convert("[Foo][]\n\n[Foo]: https://example.com\n\n# Foo\n");
+
+        $this->assertStringContainsString('href="https://example.com"', $result);
+        $this->assertStringNotContainsString('href="#Foo"', $result);
+    }
+
+    /**
+     * Implicit `[…][]` references whose label contains formatted inlines
+     * (code, math, …) must still retarget to the correct heading id after
+     * dedupe. The lookup key must include the inline content the same way
+     * the heading's plain-text label does.
+     */
+    public function testImplicitReferenceWithCodeInLabelMatchesDedupedHeading(): void
+    {
+        $result = $this->converter->convert("# `Foo`\n\n{#Foo}\npara\n\n[`Foo`][]\n");
+
+        $this->assertSame(
+            1,
+            preg_match('/<section id="(Foo(?:-\d+)?)">/', $result, $section),
+        );
+        $this->assertStringContainsString('href="#' . $section[1] . '"', $result);
+    }
+
+    /**
+     * Reference-style images (`![alt][]`) share the implicit-reference
+     * lookup with links; their `src` must also be retargeted to the
+     * post-rewrite heading id, not the pre-dedupe estimate.
+     */
+    public function testImplicitReferenceImageRetargetsToDedupedHeading(): void
+    {
+        $result = $this->converter->convert("# Foo Bar\n\n{#Foo-Bar}\npara\n\n![Foo Bar][]\n");
+
+        $this->assertSame(
+            1,
+            preg_match('/<section id="(Foo-Bar(?:-\d+)?)">/', $result, $section),
+        );
+        $this->assertStringContainsString('src="#' . $section[1] . '"', $result);
+        $this->assertStringNotContainsString('src="#Foo-Bar"', $result);
+    }
+
     public function testUnicodeInLink(): void
     {
         $djot = '[リンク](https://example.com/日本語)';

--- a/tests/TestCase/Renderer/HeadingIdTrackerTest.php
+++ b/tests/TestCase/Renderer/HeadingIdTrackerTest.php
@@ -151,6 +151,21 @@ class HeadingIdTrackerTest extends TestCase
         $this->assertSame('Test', $id);
     }
 
+    /**
+     * The generated `s-N` fallback must dedupe against tracked ids: an
+     * earlier explicit `{#s-1}` makes the next empty/all-punctuation
+     * heading take `s-2`, not duplicate `s-1`. This is what makes the
+     * upfront `reserveExplicitIds` pre-pass effective end-to-end.
+     */
+    public function testFallbackIdSkipsReservedSN(): void
+    {
+        $this->tracker->trackId('s-1');
+
+        $heading = new Heading(2);
+
+        $this->assertSame('s-2', $this->tracker->getIdForHeading($heading));
+    }
+
     public function testNormalizeId(): void
     {
         $this->assertSame('Hello-World', $this->tracker->normalizeId('Hello World'));


### PR DESCRIPTION
## Why

When a heading's auto-generated id collides with an explicit `{#id}` somewhere else in the document, master emits duplicate HTML ids — either silently (the heading wins) or with the explicit id ignored, depending on document order. After the fix landed in carve-php (`markup-carve/carve-php#10`), djot-php should adopt the same pattern: **reserve every explicit `{#id}` (heading or non-heading, including inline-attribute ids) before any heading auto-id is generated**, and rewrite the implicit-reference map to the post-dedupe ids so `[Heading][]` / `![Heading][]` links continue to resolve to the rendered section.

## What

- `HeadingIdTracker::reserveExplicitIds(Node)` — recursive walker that calls `trackId()` on every node carrying an explicit `id`.
- `HtmlRenderer::renderDocumentWithSections` — calls `reserveExplicitIds($document)` once up-front, *before* any heading rendering; drops the previous inline-during-render tracking (now redundant).
- `HeadingIdTracker::generateId` — the `s-N` empty/all-punct fallback and the suffix-dedup branch both now skip any reserved ids (`do { ... } while (isset($usedIds[$candidate]))`), so an explicit `{#s-1}` or `{#Foo-1}` never gets duplicated by an auto-id collision.
- `BlockParser::rewriteHeadingReferences($document)` — runs after `parseBlocks` with a fresh tracker that's been seeded by the same `reserveExplicitIds` walk. It:
  - re-computes each heading's id from the AST (mirrors the renderer);
  - rewrites the implicit-reference map for labels that came from a heading (an explicit `[label]: url` definition still wins, tracked via `headingReferenceLabels`);
  - retargets already-built reference `Link` and `Image` nodes — using each node's natural plain-text source (`Link`: child nodes via `getPlainText`; `Image`: the `alt` string);
  - updates `$headingIds` to the renderer-visible ids so `validateAnchorLinks` doesn't false-flag valid links to deduped headings.
- `Image::setSource()` — new mutator, needed for the post-parse retargeting of reference images.
- `headingReferenceLabels` is reset in `parse()` alongside the other parser state, so the rewrite stays correct across multiple conversions on the same `DjotConverter` instance.

## What stays the same

- Heading text plain extraction, normalization, the `[Heading][]` lookup semantics, first-wins-for-duplicate-headings, and `[Foo]: url` precedence over heading auto-ids. The line-based `extractHeadingReferences` is unchanged — it only loses ground to the AST-based rewrite for the cases it gets wrong.

## Regression guards (all TDD: RED → GREEN)

- explicit `{#id}` before *and* after a heading whose auto-id would collide — no duplicate `id` in the HTML;
- the `s-N` fallback skips reserved `s-N`s;
- the suffix-dedup branch skips reserved `Foo-1`, `Foo-2`, …;
- duplicate headings: implicit `[Foo][]` still resolves to the *first* one;
- explicit `[Foo]: url` still wins over the heading auto-id;
- reused `DjotConverter` instance: explicit-ref precedence isn't leaked across documents;
- formatted implicit labels (`` [`Foo`][] ``) match the heading's normalized plain text via `getPlainText`;
- reference *images* (`![Foo][]`) retarget too;
- anchor-link validation sees the renderer-visible deduped ids (no false "Broken anchor link" warnings on valid links).

## Verification

- `phpunit` — 2162 tests, 5370 assertions, suite green (incl. official `headings_15` and all targeted regression tests above).
- `phpstan` — no errors.
- `phpcs` — clean.
- `codex review` — across 6 iterations, every real finding fixed with TDD; the final iteration's smart-punctuation P1 was verified to be a false positive (both heading text and link text go through the same inline-parser pass, so the lookup keys match by construction).

## Relationship to other open work

- Complements `#183` (ASCII-safe transliteration) — both touch heading-id generation but are orthogonal; either can land first.
- Independent of `#182` (spec-literal `#393` discussion artifact).
