### PR TITLE
Convert kbd/samp/var/abbr/dfn tags in MarkdownToDjot

### DIFF
--- a/src/Converter/MarkdownToDjot.php
+++ b/src/Converter/MarkdownToDjot.php
@@ -260,6 +260,38 @@ class MarkdownToDjot
         // <code>text</code> → `text`
         $line = preg_replace('/<code>([^<]+)<\/code>/i', '`$1`', $line) ?? $line;
 
+        // Semantic spans rendered via attribute syntax (matches HtmlToDjot).
+        // <kbd>text</kbd> → [text]{kbd}
+        $line = preg_replace('/<kbd>([^<]+)<\/kbd>/i', '[$1]{kbd}', $line) ?? $line;
+
+        // <samp>text</samp> → [text]{samp}
+        $line = preg_replace('/<samp>([^<]+)<\/samp>/i', '[$1]{samp}', $line) ?? $line;
+
+        // <var>text</var> → [text]{var}
+        $line = preg_replace('/<var>([^<]+)<\/var>/i', '[$1]{var}', $line) ?? $line;
+
+        // <abbr title="...">text</abbr> → [text]{abbr="..."}
+        // The quote char is captured and back-referenced so a title may contain
+        // the other quote (e.g. title="Bob's API").
+        $line = preg_replace_callback(
+            '/<abbr\s+title=(["\'])(.*?)\1\s*>([^<]+)<\/abbr>/i',
+            static fn (array $matches): string => '[' . $matches[3] . ']{abbr="' . str_replace(['\\', '"'], ['\\\\', '\\"'], $matches[2]) . '"}',
+            $line,
+        ) ?? $line;
+
+        // <abbr>text</abbr> → [text]{abbr}
+        $line = preg_replace('/<abbr>([^<]+)<\/abbr>/i', '[$1]{abbr}', $line) ?? $line;
+
+        // <dfn title="...">text</dfn> → [text]{dfn="..."}
+        $line = preg_replace_callback(
+            '/<dfn\s+title=(["\'])(.*?)\1\s*>([^<]+)<\/dfn>/i',
+            static fn (array $matches): string => '[' . $matches[3] . ']{dfn="' . str_replace(['\\', '"'], ['\\\\', '\\"'], $matches[2]) . '"}',
+            $line,
+        ) ?? $line;
+
+        // <dfn>text</dfn> → [text]{dfn}
+        $line = preg_replace('/<dfn>([^<]+)<\/dfn>/i', '[$1]{dfn}', $line) ?? $line;
+
         // Convert $$math$$ to $$`math` (Djot display math) - must come before inline
         $line = preg_replace('/\$\$([^$]+)\$\$/', '$$`$1`', $line) ?? $line;
 

--- a/tests/TestCase/MarkdownToDjotTest.php
+++ b/tests/TestCase/MarkdownToDjotTest.php
@@ -700,4 +700,78 @@ DJOT;
 
         $this->assertSame($expected, $this->converter->convert($markdown));
     }
+
+    public function testKbdTag(): void
+    {
+        $markdown = 'Press <kbd>Ctrl</kbd> to copy';
+        $expected = 'Press [Ctrl]{kbd} to copy';
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testSampTag(): void
+    {
+        $markdown = 'Output: <samp>done</samp>';
+        $expected = 'Output: [done]{samp}';
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testVarTag(): void
+    {
+        $markdown = 'The <var>x</var> value';
+        $expected = 'The [x]{var} value';
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testAbbrTagWithTitle(): void
+    {
+        $markdown = '<abbr title="HyperText Markup Language">HTML</abbr> spec';
+        $expected = '[HTML]{abbr="HyperText Markup Language"} spec';
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testAbbrTagWithoutTitle(): void
+    {
+        // A title-less abbr is preserved as a flag span (matches HtmlToDjot),
+        // so it round-trips back to <abbr>.
+        $markdown = 'A plain <abbr>CSS</abbr> abbreviation';
+        $expected = 'A plain [CSS]{abbr} abbreviation';
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testDfnTagWithTitle(): void
+    {
+        $markdown = 'A <dfn title="A definition">term</dfn> here';
+        $expected = 'A [term]{dfn="A definition"} here';
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testDfnTagWithoutTitle(): void
+    {
+        $markdown = 'A <dfn>term</dfn> here';
+        $expected = 'A [term]{dfn} here';
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testAbbrTitleEscapesBackslash(): void
+    {
+        $markdown = '<abbr title="a\\b">X</abbr>';
+        $expected = '[X]{abbr="a\\\\b"}';
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testAbbrTitleWithApostropheInDoubleQuotes(): void
+    {
+        $markdown = '<abbr title="Bob\'s API">API</abbr>';
+        $expected = '[API]{abbr="Bob\'s API"}';
+
+        $this->assertSame($expected, $this->converter->convert($markdown));
+    }
 }


### PR DESCRIPTION
## Summary

`MarkdownToDjot` already converts a dozen inline HTML tags to Djot equivalents "for round-trip support" (`<mark>`, `<ins>`, `<del>`, `<s>`, `<sup>`, `<sub>`, `<em>`, `<strong>`, `<b>`, `<i>`, `<code>`), but the semantic-span elements were missing, so they were left as raw HTML. Add them so the converter is complete and consistent with `HtmlToDjot` (which already handles all five):

- `<kbd>`, `<samp>`, `<var>` → `[text]{kbd}` / `{samp}` / `{var}`
- `<abbr title="...">` / `<dfn title="...">` → `[text]{abbr="..."}` / `{dfn="..."}`
- title-less `<abbr>` / `<dfn>` → `[text]{abbr}` / `{dfn}` (matches `HtmlToDjot`)

The `title` regex captures the quote character and back-references it, so a value may contain the other quote (e.g. `title="Bob's API"`); backslashes/quotes in the value are escaped for the Djot attribute.

## Notes

- title-less `<abbr>` renders to plain text (a title-less abbr has no visual effect anyway), same as `HtmlToDjot`. This is strictly better than the previous behavior, where the raw `<abbr>` survived into Djot and rendered as escaped literal text.
- Adds tests covering each tag, the title/no-title forms, attribute escaping, and an apostrophe inside a double-quoted title.