### PR TITLE
feat: add nestedBlocksInLists parser option

### DIFF
--- a/src/DjotConverter.php
+++ b/src/DjotConverter.php
@@ -128,6 +128,7 @@ class DjotConverter
      * @param bool $roundTripMode Add data attributes for Djot→HTML→Djot round-trips (HTML renderer only)
      * @param \Djot\Parser\BlockParser|null $parser Pre-configured parser (ignores warnings/strict/significantNewlines if set)
      * @param \Djot\Renderer\RendererInterface|null $renderer Pre-configured renderer (ignores xhtml/safeMode/softBreakMode/roundTripMode if set)
+     * @param bool $nestedBlocksInLists Allow nested blocks in list items without blank lines
      */
     public function __construct(
         bool $xhtml = false,
@@ -140,6 +141,7 @@ class DjotConverter
         bool $roundTripMode = false,
         ?BlockParser $parser = null,
         ?RendererInterface $renderer = null,
+        bool $nestedBlocksInLists = false,
     ) {
         $this->collectWarnings = $warnings;
         $this->strictMode = $strict;
@@ -148,7 +150,7 @@ class DjotConverter
         if ($parser !== null) {
             $this->parser = $parser;
         } else {
-            $this->parser = new BlockParser($warnings, $strict, $significantNewlines);
+            $this->parser = new BlockParser($warnings, $strict, $significantNewlines, $nestedBlocksInLists);
         }
 
         // Use provided renderer or create one from parameters
@@ -208,6 +210,42 @@ class DjotConverter
         bool $roundTripMode = false,
     ): self {
         return new self($xhtml, $warnings, $strict, $safeMode, $profile, true, $softBreakMode, $roundTripMode);
+    }
+
+    /**
+     * Create a converter that only enables nested blocks in list items.
+     *
+     * Paragraph interruption remains standard djot behavior, but indentation
+     * alone can introduce nested sublists, blockquotes, and fenced blocks
+     * inside an already-open list item.
+     *
+     * @param bool $xhtml Whether to use XHTML-compatible output
+     * @param bool $warnings Whether to collect warnings during parsing
+     * @param bool $strict Whether to throw exceptions on parse errors
+     * @param \Djot\SafeMode|bool|null $safeMode Enable safe mode
+     * @param \Djot\Profile|null $profile Profile for feature restriction
+     * @param \Djot\Renderer\SoftBreakMode|null $softBreakMode How to render soft breaks (HTML renderer only)
+     * @param bool $roundTripMode Add data attributes for round-trips (HTML renderer only)
+     */
+    public static function withNestedBlocksInLists(
+        bool $xhtml = false,
+        bool $warnings = false,
+        bool $strict = false,
+        bool|SafeMode|null $safeMode = null,
+        ?Profile $profile = null,
+        ?SoftBreakMode $softBreakMode = null,
+        bool $roundTripMode = false,
+    ): self {
+        return new self(
+            xhtml: $xhtml,
+            warnings: $warnings,
+            strict: $strict,
+            safeMode: $safeMode,
+            profile: $profile,
+            softBreakMode: $softBreakMode,
+            roundTripMode: $roundTripMode,
+            nestedBlocksInLists: true,
+        );
     }
 
     /**

--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -152,14 +152,22 @@ class BlockParser
      */
     protected bool $significantNewlines = false;
 
+    /**
+     * When true, indentation alone can introduce nested blocks inside list items
+     * without enabling global paragraph interruption.
+     */
+    protected bool $nestedBlocksInLists = false;
+
     public function __construct(
         bool $collectWarnings = false,
         bool $strictMode = false,
         bool $significantNewlines = false,
+        bool $nestedBlocksInLists = false,
     ) {
         $this->collectWarnings = $collectWarnings;
         $this->strictMode = $strictMode;
         $this->significantNewlines = $significantNewlines;
+        $this->nestedBlocksInLists = $nestedBlocksInLists || $significantNewlines;
         $this->inlineParser = new InlineParser($this);
         $this->listParser = new ListParser();
         $this->tableParser = new TableParser();
@@ -179,6 +187,9 @@ class BlockParser
     public function setSignificantNewlines(bool $value): self
     {
         $this->significantNewlines = $value;
+        if ($value) {
+            $this->nestedBlocksInLists = true;
+        }
 
         return $this;
     }
@@ -189,6 +200,24 @@ class BlockParser
     public function getSignificantNewlines(): bool
     {
         return $this->significantNewlines;
+    }
+
+    /**
+     * Enable or disable nested blocks in list items without blank lines.
+     */
+    public function setNestedBlocksInLists(bool $value): self
+    {
+        $this->nestedBlocksInLists = $value;
+
+        return $this;
+    }
+
+    /**
+     * Check if nested blocks in list items are enabled.
+     */
+    public function getNestedBlocksInLists(): bool
+    {
+        return $this->nestedBlocksInLists;
     }
 
     /**
@@ -1767,7 +1796,7 @@ class BlockParser
                 // are treated as plain continuation text here.
                 if ($nextIndent >= $contentIndent) {
                     // Check if list nesting mode allows immediate nested blocks
-                    if ($this->significantNewlines) {
+                    if ($this->nestedBlocksInLists) {
                         // Check for any block starter (list, blockquote, code fence, div)
                         if ($this->isBlockElementStart($nextTrimmed)) {
                             // This is a nested block - break out to let normal nesting handle it
@@ -1877,7 +1906,7 @@ class BlockParser
 
             // When nested blocks in lists are enabled, check for immediate
             // nested content after the initial item paragraph.
-            if ($this->significantNewlines && $i < $count) {
+            if ($this->nestedBlocksInLists && $i < $count) {
                 $nextLine = $lines[$i];
                 $nextIndent = IndentationHelper::getLeadingSpaces($nextLine);
 

--- a/tests/TestCase/NestedBlocksInListsOptionTest.php
+++ b/tests/TestCase/NestedBlocksInListsOptionTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Test\TestCase;
+
+use Djot\DjotConverter;
+use Djot\Node\Block\BlockQuote;
+use Djot\Node\Block\ListBlock;
+use Djot\Node\Block\Paragraph;
+use Djot\Parser\BlockParser;
+use PHPUnit\Framework\TestCase;
+
+class NestedBlocksInListsOptionTest extends TestCase
+{
+    public function testConstructorParameter(): void
+    {
+        $parser = new BlockParser(nestedBlocksInLists: true);
+        $this->assertTrue($parser->getNestedBlocksInLists());
+        $this->assertFalse($parser->getSignificantNewlines());
+    }
+
+    public function testSetterAndGetter(): void
+    {
+        $parser = new BlockParser();
+
+        $result = $parser->setNestedBlocksInLists(true);
+        $this->assertSame($parser, $result);
+        $this->assertTrue($parser->getNestedBlocksInLists());
+        $this->assertFalse($parser->getSignificantNewlines());
+    }
+
+    public function testTopLevelParagraphInterruptionStaysDisabled(): void
+    {
+        $parser = new BlockParser(nestedBlocksInLists: true);
+        $doc = $parser->parse("Here is a list:\n- item one\n- item two");
+
+        $children = $doc->getChildren();
+        $this->assertCount(1, $children);
+        $this->assertInstanceOf(Paragraph::class, $children[0]);
+    }
+
+    public function testNestedListWithoutBlankLineStillWorks(): void
+    {
+        $parser = new BlockParser(nestedBlocksInLists: true);
+        $doc = $parser->parse("- Item\n    - Unterpunkt\n    - Noch einer");
+
+        $list = $doc->getChildren()[0];
+        $this->assertInstanceOf(ListBlock::class, $list);
+
+        $item = $list->getChildren()[0];
+        $children = $item->getChildren();
+        $this->assertCount(2, $children);
+        $this->assertInstanceOf(Paragraph::class, $children[0]);
+        $this->assertInstanceOf(ListBlock::class, $children[1]);
+    }
+
+    public function testNestedBlockquoteWithoutBlankLineStillWorks(): void
+    {
+        $parser = new BlockParser(nestedBlocksInLists: true);
+        $doc = $parser->parse("- Item\n\t> quoted\n\t> still quoted");
+
+        $list = $doc->getChildren()[0];
+        $this->assertInstanceOf(ListBlock::class, $list);
+
+        $item = $list->getChildren()[0];
+        $children = $item->getChildren();
+        $this->assertCount(2, $children);
+        $this->assertInstanceOf(Paragraph::class, $children[0]);
+        $this->assertInstanceOf(BlockQuote::class, $children[1]);
+    }
+
+    public function testConverterHelperKeepsTopLevelSpecBehavior(): void
+    {
+        $converter = DjotConverter::withNestedBlocksInLists();
+        $result = $converter->convert("They said:\n> Important\n> Really");
+
+        $this->assertStringNotContainsString('<blockquote>', $result);
+        $this->assertStringContainsString('<p>', $result);
+    }
+
+    public function testConverterHelperSupportsNestedListWithoutBlankLine(): void
+    {
+        $converter = DjotConverter::withNestedBlocksInLists();
+        $result = $converter->convert("- Item\n\t- Unterpunkt\n\t- Noch einer");
+
+        $this->assertSame(2, substr_count($result, '<ul>'));
+        $this->assertStringContainsString('Unterpunkt', $result);
+        $this->assertStringContainsString('Noch einer', $result);
+    }
+}

--- a/tests/TestCase/TabIndentationTest.php
+++ b/tests/TestCase/TabIndentationTest.php
@@ -108,7 +108,7 @@ class TabIndentationTest extends TestCase
      */
     public function testNestedListWithTabsNoBlankLine(): void
     {
-        $converter = DjotConverter::withSignificantNewlines();
+        $converter = DjotConverter::withNestedBlocksInLists();
         $input = "- Level 1\n\t- Level 2";
         $result = $converter->convert($input);
 
@@ -117,7 +117,7 @@ class TabIndentationTest extends TestCase
 
     public function testNestedBlockquoteWithTabsNoBlankLine(): void
     {
-        $converter = DjotConverter::withSignificantNewlines();
+        $converter = DjotConverter::withNestedBlocksInLists();
         $input = "- Level 1\n\t> quoted\n\t> continued";
         $result = $converter->convert($input);
 


### PR DESCRIPTION
## Summary
Add a narrow parser option for enabling nested blocks inside list items without also enabling top-level paragraph interruption.

## Changes
- add `nestedBlocksInLists` to `BlockParser`
- keep `significantNewlines` backward compatible while enabling nested list-item blocks through the new option
- add `DjotConverter::withNestedBlocksInLists()`
- add focused tests covering the new option's behavior boundary

## Testing
- vendor/bin/phpunit tests/TestCase/SignificantNewlinesTest.php tests/TestCase/NestedBlocksInListsOptionTest.php tests/TestCase/TabIndentationTest.php tests/TestCase/Parser/BlockParserTest.php tests/TestCase/NestedBlocksInListsTest.php tests/TestCase/NestedListEdgeCasesTest.php tests/TestCase/SoftBreakModeTest.php
