### PR TITLE
fix: parse nested list blocks with deeper indentation and tabs

### DIFF
--- a/docs/guide/parser-options.md
+++ b/docs/guide/parser-options.md
@@ -268,3 +268,79 @@ $converter = new DjotConverter(
     softBreakMode: SoftBreakMode::Break, // Optional: visible line breaks
 );
 ```
+
+## Nested Blocks in Lists Mode
+
+`nestedBlocksInLists` is a focused subset of [Significant Newlines](#significant-newlines-mode) mode. It lets indentation alone introduce nested blocks - sublists, blockquotes, and fenced code - inside an already-open list item, **without** enabling paragraph interruption anywhere else.
+
+Use it when you want markdown-like nested lists but otherwise spec-compliant djot: top-level paragraphs still require a blank line before any block.
+
+### Enabling Nested Blocks in Lists Mode
+
+```php
+use Djot\DjotConverter;
+use Djot\Parser\BlockParser;
+
+// Method 1: Factory method
+$converter = DjotConverter::withNestedBlocksInLists();
+
+// Method 2: Constructor parameter
+$converter = new DjotConverter(nestedBlocksInLists: true);
+
+// Method 3: Directly on the parser
+$parser = new BlockParser(nestedBlocksInLists: true);
+$parser->setNestedBlocksInLists(true);
+```
+
+### Behavior
+
+Indented content nests inside the open list item, even without a blank line:
+
+```php
+$converter = DjotConverter::withNestedBlocksInLists();
+$result = $converter->convert("- Item
+    - Nested one
+    - Nested two");
+```
+
+Output:
+```html
+<ul>
+<li>
+Item
+<ul>
+<li>
+Nested one
+</li>
+<li>
+Nested two
+</li>
+</ul>
+</li>
+</ul>
+```
+
+But a top-level block still does **not** interrupt a paragraph (this is what differs from significant newlines mode):
+
+```php
+$converter = DjotConverter::withNestedBlocksInLists();
+$result = $converter->convert("Here is a list:
+- one
+- two");
+```
+
+Output:
+```html
+<p>Here is a list:
+- one
+- two</p>
+```
+
+### nestedBlocksInLists vs significantNewlines
+
+| Behavior                                              | Default | `nestedBlocksInLists` | `significantNewlines` |
+|------------------------------------------------------|---------|-----------------------|-----------------------|
+| Nested blocks in list items without a blank line     | No      | **Yes**               | Yes                   |
+| Lists/blockquotes/headings interrupt top-level paragraphs | No | No                    | Yes                   |
+
+Note: `significantNewlines` implies `nestedBlocksInLists` - enabling the former turns on the latter automatically.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -25,6 +25,7 @@ public function __construct(
     bool $roundTripMode = false,
     ?BlockParser $parser = null,
     ?RendererInterface $renderer = null,
+    bool $nestedBlocksInLists = false,
 )
 ```
 
@@ -38,6 +39,7 @@ public function __construct(
 - `$roundTripMode`: When `true`, adds round-trip metadata for Djot→HTML→Djot workflows (HTML renderer only).
 - `$parser`: Optional pre-configured parser. When provided, inline parser constructor flags such as `warnings`, `strict`, and `significantNewlines` are ignored.
 - `$renderer`: Optional pre-configured renderer. When provided, inline renderer constructor flags such as `xhtml`, `safeMode`, `softBreakMode`, and `roundTripMode` are ignored.
+- `$nestedBlocksInLists`: When `true`, indentation alone introduces nested blocks inside list items without a blank line, while top-level paragraph interruption stays spec-compliant (see [Nested Blocks in Lists Mode](/guide/parser-options#nested-blocks-in-lists-mode)). Implied by `$significantNewlines`.
 
 ### Factory Methods
 
@@ -56,6 +58,22 @@ public static function withSignificantNewlines(
 ```
 
 Creates a converter with significant newlines mode enabled. See [Significant Newlines Mode](#significant-newlines-mode).
+
+#### withNestedBlocksInLists()
+
+```php
+public static function withNestedBlocksInLists(
+    bool $xhtml = false,
+    bool $warnings = false,
+    bool $strict = false,
+    bool|SafeMode|null $safeMode = null,
+    ?Profile $profile = null,
+    ?SoftBreakMode $softBreakMode = null,
+    bool $roundTripMode = false,
+): self
+```
+
+Creates a converter that enables nested blocks in list items without requiring blank lines, while leaving top-level paragraph interruption at the spec default. See [Nested Blocks in Lists Mode](/guide/parser-options#nested-blocks-in-lists-mode).
 
 ### Methods
 
@@ -500,6 +518,7 @@ $parser = new BlockParser(
     collectWarnings: false,
     strictMode: false,
     significantNewlines: false,
+    nestedBlocksInLists: false,
 );
 $document = $parser->parse($djotString);
 
@@ -510,6 +529,11 @@ $warnings = $parser->getWarnings();
 // Enable/disable significant newlines mode
 $parser->setSignificantNewlines(true);
 $isEnabled = $parser->getSignificantNewlines();
+
+// Enable/disable nested blocks in list items only
+// (significant newlines mode enables this implicitly)
+$parser->setNestedBlocksInLists(true);
+$isEnabled = $parser->getNestedBlocksInLists();
 ```
 
 #### Custom Block Patterns

--- a/src/DjotConverter.php
+++ b/src/DjotConverter.php
@@ -128,6 +128,7 @@ class DjotConverter
      * @param bool $roundTripMode Add data attributes for Djot→HTML→Djot round-trips (HTML renderer only)
      * @param \Djot\Parser\BlockParser|null $parser Pre-configured parser (ignores warnings/strict/significantNewlines if set)
      * @param \Djot\Renderer\RendererInterface|null $renderer Pre-configured renderer (ignores xhtml/safeMode/softBreakMode/roundTripMode if set)
+     * @param bool $nestedBlocksInLists Allow nested blocks in list items without blank lines
      */
     public function __construct(
         bool $xhtml = false,
@@ -140,6 +141,7 @@ class DjotConverter
         bool $roundTripMode = false,
         ?BlockParser $parser = null,
         ?RendererInterface $renderer = null,
+        bool $nestedBlocksInLists = false,
     ) {
         $this->collectWarnings = $warnings;
         $this->strictMode = $strict;
@@ -148,7 +150,7 @@ class DjotConverter
         if ($parser !== null) {
             $this->parser = $parser;
         } else {
-            $this->parser = new BlockParser($warnings, $strict, $significantNewlines);
+            $this->parser = new BlockParser($warnings, $strict, $significantNewlines, $nestedBlocksInLists);
         }
 
         // Use provided renderer or create one from parameters
@@ -208,6 +210,42 @@ class DjotConverter
         bool $roundTripMode = false,
     ): self {
         return new self($xhtml, $warnings, $strict, $safeMode, $profile, true, $softBreakMode, $roundTripMode);
+    }
+
+    /**
+     * Create a converter that only enables nested blocks in list items.
+     *
+     * Paragraph interruption remains standard djot behavior, but indentation
+     * alone can introduce nested sublists, blockquotes, and fenced blocks
+     * inside an already-open list item.
+     *
+     * @param bool $xhtml Whether to use XHTML-compatible output
+     * @param bool $warnings Whether to collect warnings during parsing
+     * @param bool $strict Whether to throw exceptions on parse errors
+     * @param \Djot\SafeMode|bool|null $safeMode Enable safe mode
+     * @param \Djot\Profile|null $profile Profile for feature restriction
+     * @param \Djot\Renderer\SoftBreakMode|null $softBreakMode How to render soft breaks (HTML renderer only)
+     * @param bool $roundTripMode Add data attributes for round-trips (HTML renderer only)
+     */
+    public static function withNestedBlocksInLists(
+        bool $xhtml = false,
+        bool $warnings = false,
+        bool $strict = false,
+        bool|SafeMode|null $safeMode = null,
+        ?Profile $profile = null,
+        ?SoftBreakMode $softBreakMode = null,
+        bool $roundTripMode = false,
+    ): self {
+        return new self(
+            xhtml: $xhtml,
+            warnings: $warnings,
+            strict: $strict,
+            safeMode: $safeMode,
+            profile: $profile,
+            softBreakMode: $softBreakMode,
+            roundTripMode: $roundTripMode,
+            nestedBlocksInLists: true,
+        );
     }
 
     /**

--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -152,14 +152,22 @@ class BlockParser
      */
     protected bool $significantNewlines = false;
 
+    /**
+     * When true, indentation alone can introduce nested blocks inside list items
+     * without enabling global paragraph interruption.
+     */
+    protected bool $nestedBlocksInLists = false;
+
     public function __construct(
         bool $collectWarnings = false,
         bool $strictMode = false,
         bool $significantNewlines = false,
+        bool $nestedBlocksInLists = false,
     ) {
         $this->collectWarnings = $collectWarnings;
         $this->strictMode = $strictMode;
         $this->significantNewlines = $significantNewlines;
+        $this->nestedBlocksInLists = $nestedBlocksInLists || $significantNewlines;
         $this->inlineParser = new InlineParser($this);
         $this->listParser = new ListParser();
         $this->tableParser = new TableParser();
@@ -179,6 +187,9 @@ class BlockParser
     public function setSignificantNewlines(bool $value): self
     {
         $this->significantNewlines = $value;
+        if ($value) {
+            $this->nestedBlocksInLists = true;
+        }
 
         return $this;
     }
@@ -189,6 +200,24 @@ class BlockParser
     public function getSignificantNewlines(): bool
     {
         return $this->significantNewlines;
+    }
+
+    /**
+     * Enable or disable nested blocks in list items without blank lines.
+     */
+    public function setNestedBlocksInLists(bool $value): self
+    {
+        $this->nestedBlocksInLists = $value;
+
+        return $this;
+    }
+
+    /**
+     * Check if nested blocks in list items are enabled.
+     */
+    public function getNestedBlocksInLists(): bool
+    {
+        return $this->nestedBlocksInLists;
     }
 
     /**
@@ -1767,7 +1796,7 @@ class BlockParser
                 // are treated as plain continuation text here.
                 if ($nextIndent >= $contentIndent) {
                     // Check if list nesting mode allows immediate nested blocks
-                    if ($this->significantNewlines) {
+                    if ($this->nestedBlocksInLists) {
                         // Check for any block starter (list, blockquote, code fence, div)
                         if ($this->isBlockElementStart($nextTrimmed)) {
                             // This is a nested block - break out to let normal nesting handle it
@@ -1877,7 +1906,7 @@ class BlockParser
 
             // When nested blocks in lists are enabled, check for immediate
             // nested content after the initial item paragraph.
-            if ($this->significantNewlines && $i < $count) {
+            if ($this->nestedBlocksInLists && $i < $count) {
                 $nextLine = $lines[$i];
                 $nextIndent = IndentationHelper::getLeadingSpaces($nextLine);
 

--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -1763,12 +1763,13 @@ class BlockParser
 
                 // Content at content indent or more is continuation (even if it looks like a list marker)
                 // In djot, "  - b" after "- a" (no blank line) is literal text, not a nested list
-                // Unless significantNewlines is enabled, then indented block markers start nested blocks
+                // Unless nested blocks in lists are enabled, indented block markers
+                // are treated as plain continuation text here.
                 if ($nextIndent >= $contentIndent) {
-                    // Check if significantNewlines mode allows immediate nested blocks
+                    // Check if list nesting mode allows immediate nested blocks
                     if ($this->significantNewlines) {
                         // Check for any block starter (list, blockquote, code fence, div)
-                        if ($this->startsNewBlock($nextTrimmed) || $this->listParser->parseListItemMarker($nextTrimmed) !== null) {
+                        if ($this->isBlockElementStart($nextTrimmed)) {
                             // This is a nested block - break out to let normal nesting handle it
                             break;
                         }
@@ -1874,7 +1875,8 @@ class BlockParser
                 $this->parseBlocks($listItem, $itemLines, 0);
             }
 
-            // In significantNewlines mode, check for immediate nested content (any block type)
+            // When nested blocks in lists are enabled, check for immediate
+            // nested content after the initial item paragraph.
             if ($this->significantNewlines && $i < $count) {
                 $nextLine = $lines[$i];
                 $nextIndent = IndentationHelper::getLeadingSpaces($nextLine);
@@ -1882,6 +1884,7 @@ class BlockParser
                 // If there's indented content that could be a nested block
                 if ($nextIndent >= $contentIndent) {
                     $subLines = [];
+                    $nestedIndent = $nextIndent;
                     while ($i < $count) {
                         $subLine = $lines[$i];
                         if (IndentationHelper::isBlankLine($subLine)) {
@@ -1892,8 +1895,8 @@ class BlockParser
                             continue;
                         }
                         $lineIndent = IndentationHelper::getLeadingSpaces($subLine);
-                        if ($lineIndent >= $contentIndent) {
-                            $subLines[] = IndentationHelper::stripLeadingIndent($subLine, $contentIndent);
+                        if ($lineIndent >= $nestedIndent) {
+                            $subLines[] = IndentationHelper::stripLeadingIndent($subLine, $nestedIndent);
                             $i++;
                         } elseif ($lineIndent === $baseIndent) {
                             // Back to parent level - check if it's a sibling item

--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -1924,15 +1924,24 @@ class BlockParser
                             continue;
                         }
                         $lineIndent = IndentationHelper::getLeadingSpaces($subLine);
-                        if ($lineIndent >= $nestedIndent) {
-                            $subLines[] = IndentationHelper::stripLeadingIndent($subLine, $nestedIndent);
-                            $i++;
-                        } elseif ($lineIndent === $baseIndent) {
-                            // Back to parent level - check if it's a sibling item
-                            break;
-                        } else {
+                        // Membership is the item's content indent, not the first
+                        // nested line's (possibly deeper) indent: a line that drops
+                        // back to the content indent is still item content and must
+                        // be kept here, otherwise an over-indented first nested line
+                        // would detach it into a top-level block and end the list early.
+                        if ($lineIndent < $contentIndent) {
+                            // Back to the parent (or a shallower) level: this item's
+                            // nested content is done.
                             break;
                         }
+                        // Normalize the over-indented nested block by its own indent
+                        // so it starts at column 0 (required for the sub-parse to
+                        // recognize it as a block); lines that fall back to the item
+                        // content indent are stripped by that instead, keeping them
+                        // in the item rather than letting them escape.
+                        $strip = $lineIndent >= $nestedIndent ? $nestedIndent : $contentIndent;
+                        $subLines[] = IndentationHelper::stripLeadingIndent($subLine, $strip);
+                        $i++;
                     }
                     if ($subLines !== []) {
                         $this->parseBlocks($listItem, $subLines, 0);
@@ -3302,19 +3311,12 @@ class BlockParser
             return true;
         }
 
-        // List markers - these indicate a new list at this level
-        // Bullet lists: -, *, + followed by space
-        if (preg_match('/^[-*+] /', $line)) {
-            return true;
-        }
-
-        // Ordered lists: digit(s) or letter followed by . or ) and space
-        if (preg_match('/^(\d+|[a-zA-Z])[.)] /', $line)) {
-            return true;
-        }
-
-        // Task lists: - [ ] or - [x]
-        if (preg_match('/^- \[[xX ]\] /', $line)) {
+        // List markers (bullet, ordered, and task). Delegate to the canonical
+        // list-marker parser so nested-block detection recognizes every marker
+        // form it supports - including "(1)", "(a)", and roman numerals such as
+        // "iv." - instead of a narrower subset that silently degraded those into
+        // plain paragraph text.
+        if ($this->listParser->parseListItemMarker($line) !== null) {
             return true;
         }
 

--- a/tests/TestCase/NestedBlocksInListsOptionTest.php
+++ b/tests/TestCase/NestedBlocksInListsOptionTest.php
@@ -88,4 +88,57 @@ class NestedBlocksInListsOptionTest extends TestCase
         $this->assertStringContainsString('Unterpunkt', $result);
         $this->assertStringContainsString('Noch einer', $result);
     }
+
+    /**
+     * Parenthesized ordered markers must nest like "1." markers do. These are
+     * recognized by the list-marker parser, so the nested-block detection has
+     * to recognize them too (otherwise they degrade to plain paragraph text).
+     */
+    public function testNestedOrderedListWithParenthesizedMarkers(): void
+    {
+        $parser = new BlockParser(nestedBlocksInLists: true);
+        $doc = $parser->parse("- Item\n    (1) First\n    (2) Second");
+
+        $item = $doc->getChildren()[0]->getChildren()[0];
+        $children = $item->getChildren();
+        $this->assertCount(2, $children);
+        $this->assertInstanceOf(Paragraph::class, $children[0]);
+        $this->assertInstanceOf(ListBlock::class, $children[1]);
+        $this->assertSame(ListBlock::TYPE_ORDERED, $children[1]->getListType());
+        $this->assertCount(2, $children[1]->getChildren());
+    }
+
+    /**
+     * Multi-character roman-numeral markers must nest as a single ordered list,
+     * not split across the parent paragraph and a detached sublist.
+     */
+    public function testNestedOrderedListWithRomanMarkers(): void
+    {
+        $parser = new BlockParser(nestedBlocksInLists: true);
+        $doc = $parser->parse("- Item\n    iv. Fourth\n    v. Fifth");
+
+        $item = $doc->getChildren()[0]->getChildren()[0];
+        $children = $item->getChildren();
+        $this->assertCount(2, $children);
+        $this->assertInstanceOf(Paragraph::class, $children[0]);
+        $this->assertInstanceOf(ListBlock::class, $children[1]);
+        $this->assertSame(ListBlock::TYPE_ORDERED, $children[1]->getListType());
+        $this->assertCount(2, $children[1]->getChildren());
+    }
+
+    /**
+     * When the first nested line is over-indented relative to the item content
+     * indent and a following line drops back to the content indent, that
+     * following line must stay part of the list item instead of detaching into
+     * a top-level paragraph (which would also terminate the list early).
+     */
+    public function testOverIndentedNestedBlockKeepsTrailingItemContent(): void
+    {
+        $parser = new BlockParser(nestedBlocksInLists: true);
+        $doc = $parser->parse("- a\n      - x\n  more text");
+
+        $children = $doc->getChildren();
+        $this->assertCount(1, $children);
+        $this->assertInstanceOf(ListBlock::class, $children[0]);
+    }
 }

--- a/tests/TestCase/NestedBlocksInListsOptionTest.php
+++ b/tests/TestCase/NestedBlocksInListsOptionTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Test\TestCase;
+
+use Djot\DjotConverter;
+use Djot\Node\Block\BlockQuote;
+use Djot\Node\Block\ListBlock;
+use Djot\Node\Block\Paragraph;
+use Djot\Parser\BlockParser;
+use PHPUnit\Framework\TestCase;
+
+class NestedBlocksInListsOptionTest extends TestCase
+{
+    public function testConstructorParameter(): void
+    {
+        $parser = new BlockParser(nestedBlocksInLists: true);
+        $this->assertTrue($parser->getNestedBlocksInLists());
+        $this->assertFalse($parser->getSignificantNewlines());
+    }
+
+    public function testSetterAndGetter(): void
+    {
+        $parser = new BlockParser();
+
+        $result = $parser->setNestedBlocksInLists(true);
+        $this->assertSame($parser, $result);
+        $this->assertTrue($parser->getNestedBlocksInLists());
+        $this->assertFalse($parser->getSignificantNewlines());
+    }
+
+    public function testTopLevelParagraphInterruptionStaysDisabled(): void
+    {
+        $parser = new BlockParser(nestedBlocksInLists: true);
+        $doc = $parser->parse("Here is a list:\n- item one\n- item two");
+
+        $children = $doc->getChildren();
+        $this->assertCount(1, $children);
+        $this->assertInstanceOf(Paragraph::class, $children[0]);
+    }
+
+    public function testNestedListWithoutBlankLineStillWorks(): void
+    {
+        $parser = new BlockParser(nestedBlocksInLists: true);
+        $doc = $parser->parse("- Item\n    - Unterpunkt\n    - Noch einer");
+
+        $list = $doc->getChildren()[0];
+        $this->assertInstanceOf(ListBlock::class, $list);
+
+        $item = $list->getChildren()[0];
+        $children = $item->getChildren();
+        $this->assertCount(2, $children);
+        $this->assertInstanceOf(Paragraph::class, $children[0]);
+        $this->assertInstanceOf(ListBlock::class, $children[1]);
+    }
+
+    public function testNestedBlockquoteWithoutBlankLineStillWorks(): void
+    {
+        $parser = new BlockParser(nestedBlocksInLists: true);
+        $doc = $parser->parse("- Item\n\t> quoted\n\t> still quoted");
+
+        $list = $doc->getChildren()[0];
+        $this->assertInstanceOf(ListBlock::class, $list);
+
+        $item = $list->getChildren()[0];
+        $children = $item->getChildren();
+        $this->assertCount(2, $children);
+        $this->assertInstanceOf(Paragraph::class, $children[0]);
+        $this->assertInstanceOf(BlockQuote::class, $children[1]);
+    }
+
+    public function testConverterHelperKeepsTopLevelSpecBehavior(): void
+    {
+        $converter = DjotConverter::withNestedBlocksInLists();
+        $result = $converter->convert("They said:\n> Important\n> Really");
+
+        $this->assertStringNotContainsString('<blockquote>', $result);
+        $this->assertStringContainsString('<p>', $result);
+    }
+
+    public function testConverterHelperSupportsNestedListWithoutBlankLine(): void
+    {
+        $converter = DjotConverter::withNestedBlocksInLists();
+        $result = $converter->convert("- Item\n\t- Unterpunkt\n\t- Noch einer");
+
+        $this->assertSame(2, substr_count($result, '<ul>'));
+        $this->assertStringContainsString('Unterpunkt', $result);
+        $this->assertStringContainsString('Noch einer', $result);
+    }
+}

--- a/tests/TestCase/Parser/BlockParserTest.php
+++ b/tests/TestCase/Parser/BlockParserTest.php
@@ -544,8 +544,6 @@ DJOT;
 
     public function testSignificantNewlinesBlockquoteInterruptsParagraph(): void
     {
-        // A lone ">" line in prose is a comparison operator; interrupting a
-        // paragraph requires a real (2+ line) quote.
         $parser = new BlockParser(significantNewlines: true);
         $doc = $parser->parse("They said:\n> This is important\n> Pay attention");
 

--- a/tests/TestCase/SignificantNewlinesTest.php
+++ b/tests/TestCase/SignificantNewlinesTest.php
@@ -65,8 +65,6 @@ class SignificantNewlinesTest extends TestCase
 
     public function testBlockquoteInterruptsParagraph(): void
     {
-        // A lone ">" line in flowing prose is a comparison operator, not a
-        // quote ("if x\n> 5"). Interrupting requires a *real* (2+ line) quote.
         $parser = new BlockParser(significantNewlines: true);
         $doc = $parser->parse("They said:\n> This is important\n> Pay attention");
 
@@ -202,6 +200,100 @@ class SignificantNewlinesTest extends TestCase
         $this->assertSame(ListBlock::TYPE_ORDERED, $sublist->getListType());
     }
 
+    public function testNestedListWithDeeperIndentWithoutBlankLine(): void
+    {
+        $parser = new BlockParser(significantNewlines: true);
+        $doc = $parser->parse("- Item\n    - Unterpunkt\n    - Noch einer");
+
+        $list = $doc->getChildren()[0];
+        $this->assertInstanceOf(ListBlock::class, $list);
+
+        $item = $list->getChildren()[0];
+        $children = $item->getChildren();
+        $this->assertCount(2, $children);
+        $this->assertInstanceOf(Paragraph::class, $children[0]);
+        $this->assertInstanceOf(ListBlock::class, $children[1]);
+
+        $nested = $children[1];
+        $this->assertCount(2, $nested->getChildren());
+    }
+
+    public function testNestedOrderedListWithDeeperIndentWithoutBlankLine(): void
+    {
+        $parser = new BlockParser(significantNewlines: true);
+        $doc = $parser->parse("- Item\n    1. First\n    2. Second");
+
+        $list = $doc->getChildren()[0];
+        $this->assertInstanceOf(ListBlock::class, $list);
+
+        $item = $list->getChildren()[0];
+        $nested = $item->getChildren()[1];
+        $this->assertInstanceOf(ListBlock::class, $nested);
+        $this->assertSame(ListBlock::TYPE_ORDERED, $nested->getListType());
+        $this->assertCount(2, $nested->getChildren());
+    }
+
+    public function testCodeFenceInListWithDeeperIndentWithoutBlankLine(): void
+    {
+        $parser = new BlockParser(significantNewlines: true);
+        $doc = $parser->parse("- Item\n    ```\n    echo hello\n    ```");
+
+        $list = $doc->getChildren()[0];
+        $this->assertInstanceOf(ListBlock::class, $list);
+
+        $item = $list->getChildren()[0];
+        $children = $item->getChildren();
+        $this->assertCount(2, $children);
+        $this->assertInstanceOf(Paragraph::class, $children[0]);
+        $this->assertInstanceOf(CodeBlock::class, $children[1]);
+    }
+
+    public function testBlockquoteInListWithDeeperIndentWithoutBlankLine(): void
+    {
+        $parser = new BlockParser(significantNewlines: true);
+        $doc = $parser->parse("- Item\n    > quoted\n    > still quoted");
+
+        $list = $doc->getChildren()[0];
+        $this->assertInstanceOf(ListBlock::class, $list);
+
+        $item = $list->getChildren()[0];
+        $children = $item->getChildren();
+        $this->assertCount(2, $children);
+        $this->assertInstanceOf(Paragraph::class, $children[0]);
+        $this->assertInstanceOf(BlockQuote::class, $children[1]);
+    }
+
+    public function testNestedListWithTabIndentWithoutBlankLine(): void
+    {
+        $parser = new BlockParser(significantNewlines: true);
+        $doc = $parser->parse("- Item\n\t- Unterpunkt\n\t- Noch einer");
+
+        $list = $doc->getChildren()[0];
+        $this->assertInstanceOf(ListBlock::class, $list);
+
+        $item = $list->getChildren()[0];
+        $children = $item->getChildren();
+        $this->assertCount(2, $children);
+        $this->assertInstanceOf(Paragraph::class, $children[0]);
+        $this->assertInstanceOf(ListBlock::class, $children[1]);
+        $this->assertCount(2, $children[1]->getChildren());
+    }
+
+    public function testBlockquoteInListWithTabIndentWithoutBlankLine(): void
+    {
+        $parser = new BlockParser(significantNewlines: true);
+        $doc = $parser->parse("- Item\n\t> quoted\n\t> still quoted");
+
+        $list = $doc->getChildren()[0];
+        $this->assertInstanceOf(ListBlock::class, $list);
+
+        $item = $list->getChildren()[0];
+        $children = $item->getChildren();
+        $this->assertCount(2, $children);
+        $this->assertInstanceOf(Paragraph::class, $children[0]);
+        $this->assertInstanceOf(BlockQuote::class, $children[1]);
+    }
+
     public function testStandardModeNestedListNeedsBlankLine(): void
     {
         $parser = new BlockParser();
@@ -251,7 +343,6 @@ class SignificantNewlinesTest extends TestCase
     {
         $converter = new DjotConverter(significantNewlines: true);
 
-        // 2+ line quote required (a single ">" line is treated as prose).
         $djot = "They said:\n> Important\n> Really";
         $result = $converter->convert($djot);
 
@@ -260,31 +351,23 @@ class SignificantNewlinesTest extends TestCase
 
     // ==================== Chat Message Use Case ====================
 
-    public function testChatMessageExample(): void
+    public function testConverterParsesNestedListWithoutBlankLine(): void
     {
-        // For chat applications, combine significantNewlines with SoftBreakMode::Break
         $converter = DjotConverter::withSignificantNewlines(
             softBreakMode: SoftBreakMode::Break,
         );
 
         $djot = <<<'DJOT'
-Hey!
-Check this out:
-- cool feature
-- another one
-> Someone said this
-
-What do you think?
+- Item
+    - cool feature
+    - another one
 DJOT;
 
         $result = $converter->convert($djot);
 
-        // With explicit Break mode, soft breaks render as <br>
-        $this->assertStringContainsString('<br>', $result);
-        // List should be separate (significantNewlines feature)
         $this->assertStringContainsString('<ul>', $result);
-        // Blockquote should be separate (significantNewlines feature)
-        $this->assertStringContainsString('<blockquote>', $result);
+        $this->assertStringContainsString("cool feature\n</li>", $result);
+        $this->assertStringContainsString("another one\n</li>", $result);
     }
 
     // ==================== Edge Cases ====================
@@ -313,7 +396,6 @@ DJOT;
 
     public function testHeadingInterruptsParagraphInSignificantNewlinesMode(): void
     {
-        // In significantNewlines mode, headings CAN interrupt paragraphs
         $parser = new BlockParser(significantNewlines: true);
         $doc = $parser->parse("Text\n# Heading");
 
@@ -323,11 +405,8 @@ DJOT;
         $this->assertInstanceOf(Heading::class, $children[1]);
     }
 
-    // ==================== CommonMark Ordered List Rule ====================
-
     public function testOnlyOneCanInterruptParagraph(): void
     {
-        // Only "1." can interrupt a paragraph (CommonMark rule)
         $parser = new BlockParser(significantNewlines: true);
         $doc = $parser->parse("Steps:\n1. First step");
 
@@ -361,7 +440,6 @@ DJOT;
 
     public function testHighNumberedListAfterBlankLine(): void
     {
-        // With blank line, any number can start a list
         $parser = new BlockParser(significantNewlines: true);
         $doc = $parser->parse("Continue from step\n\n5. Do this thing");
 
@@ -370,14 +448,6 @@ DJOT;
         $this->assertInstanceOf(Paragraph::class, $children[0]);
         $this->assertInstanceOf(ListBlock::class, $children[1]);
     }
-
-    // ==================== Operator vs. List Marker (bullet/table) ====================
-    //
-    // In hard-wrapped prose a line can begin with -, *, +, > or | as an
-    // arithmetic/comparison operator or pipe. A *lone* marker line followed by
-    // ordinary prose must NOT become a list/quote/table; a real block requires
-    // 2+ marker lines or an indented continuation. (Mirrors the existing
-    // "only 1. interrupts" rule for ordered lists.)
 
     public function testMultiplicationStarDoesNotBecomeList(): void
     {
@@ -423,7 +493,6 @@ DJOT;
 
     public function testTwoMarkersStillFormAList(): void
     {
-        // The guard must not regress real lists: 2+ markers => list.
         $parser = new BlockParser(significantNewlines: true);
         $doc = $parser->parse("Hier eine Liste:\n- erstes Element\n- zweites Element");
 
@@ -435,8 +504,6 @@ DJOT;
 
     public function testSingleBulletWithIndentedContinuationIsList(): void
     {
-        // One item but with an indented continuation line still reads as a
-        // real (multi-line) list, so it interrupts.
         $parser = new BlockParser(significantNewlines: true);
         $doc = $parser->parse("Shopping:\n- milk and\n  some bread");
 

--- a/tests/TestCase/TabIndentationTest.php
+++ b/tests/TestCase/TabIndentationTest.php
@@ -101,10 +101,11 @@ class TabIndentationTest extends TestCase
     }
 
     /**
-     * Nested list with tabs - current behavior.
+     * Nested list with tabs and no blank line.
      *
-     * Without blank lines, nested markers are not recognized as nested lists
-     * (this matches djot spec - blank line required for nesting).
+     * With nested blocks in lists enabled, tab indentation alone introduces a
+     * nested list even without a preceding blank line (the spec default would
+     * require one).
      */
     public function testNestedListWithTabsNoBlankLine(): void
     {

--- a/tests/TestCase/TabIndentationTest.php
+++ b/tests/TestCase/TabIndentationTest.php
@@ -108,12 +108,21 @@ class TabIndentationTest extends TestCase
      */
     public function testNestedListWithTabsNoBlankLine(): void
     {
+        $converter = DjotConverter::withSignificantNewlines();
         $input = "- Level 1\n\t- Level 2";
-        $result = $this->converter->convert($input);
+        $result = $converter->convert($input);
 
-        // Current behavior: creates flat list, not nested
-        // The "- Level 2" is content, not a nested list marker
-        $this->assertSame(1, substr_count($result, '<ul>'));
+        $this->assertSame(2, substr_count($result, '<ul>'));
+    }
+
+    public function testNestedBlockquoteWithTabsNoBlankLine(): void
+    {
+        $converter = DjotConverter::withSignificantNewlines();
+        $input = "- Level 1\n\t> quoted\n\t> continued";
+        $result = $converter->convert($input);
+
+        $this->assertStringContainsString('<blockquote>', $result);
+        $this->assertStringContainsString('quoted', $result);
     }
 
     /**

--- a/tests/TestCase/TabIndentationTest.php
+++ b/tests/TestCase/TabIndentationTest.php
@@ -108,7 +108,7 @@ class TabIndentationTest extends TestCase
      */
     public function testNestedListWithTabsNoBlankLine(): void
     {
-        $converter = DjotConverter::withSignificantNewlines();
+        $converter = DjotConverter::withNestedBlocksInLists();
         $input = "- Level 1\n\t- Level 2";
         $result = $converter->convert($input);
 
@@ -117,7 +117,7 @@ class TabIndentationTest extends TestCase
 
     public function testNestedBlockquoteWithTabsNoBlankLine(): void
     {
-        $converter = DjotConverter::withSignificantNewlines();
+        $converter = DjotConverter::withNestedBlocksInLists();
         $input = "- Level 1\n\t> quoted\n\t> continued";
         $result = $converter->convert($input);
 


### PR DESCRIPTION
## Summary
Fix nested blocks inside list items when they are introduced by deeper indentation without a blank line.

## Changes
- preserve nested sublists with deeper indentation
- preserve nested ordered sublists, blockquotes, and fenced blocks in list items
- handle tab indentation consistently for these nested list-item blocks
- add regression coverage for deeper indentation and tab-based nesting

## Testing
- vendor/bin/phpunit tests/TestCase/SignificantNewlinesTest.php tests/TestCase/TabIndentationTest.php tests/TestCase/Parser/BlockParserTest.php tests/TestCase/NestedBlocksInListsTest.php tests/TestCase/NestedListEdgeCasesTest.php tests/TestCase/SoftBreakModeTest.php
