### PR TITLE
feat: add experimental citations extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $html = $converter->convert('Hello *world*!');
 - **Advanced**: Footnotes, math expressions, symbols, block attributes, raw HTML blocks, comments
 - **Smart typography**: Curly quotes, en/em dashes, ellipsis
 - **Multiple renderers**: HTML, plain text, Markdown, ANSI terminal output
-- **Extensions**: Built-in extensions for external links, TOC, heading permalinks, @mentions, autolinks, default attributes
+- **Extensions**: Built-in extensions for external links, TOC, heading permalinks, @mentions, autolinks, default attributes, and experimental citations
 - **Extensible**: Custom inline/block patterns, render events
 - **File support**: Parse and convert files directly
 - **CLI tools**: `bin/djot` (one-shot convert) and `bin/djot-watch` (live-reload preview server) — see [CLI reference](https://php-collective.github.io/djot-php/reference/cli)

--- a/docs/extensions/index.md
+++ b/docs/extensions/index.md
@@ -619,7 +619,7 @@ $converter->addExtension(new ExperimentalCitationsExtension());
 
 // Optional: resolve parsed groups to rendered inline strings
 $converter->addExtension(new ExperimentalCitationsExtension(
-    resolver: function (array $groups): array {
+    resolver: function (array $groups, \Djot\Node\Document $document): array {
         $resolved = [];
         foreach ($groups as $group) {
             $resolved[$group->id] = '(citation ' . count($group->references) . ')';
@@ -655,14 +655,14 @@ Multi-cite: [@kuhn1962; @watson1953, ch. 2].
 
 ### Resolver Contract
 
-The resolver callback receives the full list of parsed citation groups in document order:
+The resolver callback receives the full list of parsed citation groups in document order plus the parsed `Document` AST:
 
 ```php
 use Djot\Extension\CitationGroup;
 use Djot\Extension\ExperimentalCitationsExtension;
 
 $converter->addExtension(new ExperimentalCitationsExtension(
-    resolver: function (array $groups): array {
+    resolver: function (array $groups, \Djot\Node\Document $document): array {
         return array_reduce(
             $groups,
             function (array $carry, CitationGroup $group): array {
@@ -678,6 +678,8 @@ $converter->addExtension(new ExperimentalCitationsExtension(
     },
 ));
 ```
+
+Use the `Document` argument when bibliography placement, document-level metadata, or other AST-aware decisions matter. Ignore it when a pure `groups => rendered string` mapping is enough.
 
 The extension re-parses each resolved string as Djot inline content, so the resolver may emit plain text or simple Djot inline markup.
 

--- a/docs/extensions/index.md
+++ b/docs/extensions/index.md
@@ -602,6 +602,105 @@ Thanks @johndoe for the help!
 <p>Thanks <a href="/users/view/johndoe" data-username="johndoe" class="mention">@johndoe</a> for the help!</p>
 ```
 
+## ExperimentalCitationsExtension
+
+Parses experimental Pandoc/Citum-style citations into semantic inline spans.
+
+This extension is intentionally narrow:
+
+- It recognizes citation syntax such as `[@key]`, `[+@key]`, `[-@key]`, `[@a; @b]`, and `[@key, p. 10]`.
+- It does **not** ship a CSL processor or bibliography engine.
+- It is explicitly experimental because Djot does not have an official citation syntax yet.
+
+```php
+use Djot\Extension\ExperimentalCitationsExtension;
+
+$converter->addExtension(new ExperimentalCitationsExtension());
+
+// Optional: resolve parsed groups to rendered inline strings
+$converter->addExtension(new ExperimentalCitationsExtension(
+    resolver: function (array $groups): array {
+        $resolved = [];
+        foreach ($groups as $group) {
+            $resolved[$group->id] = '(citation ' . count($group->references) . ')';
+        }
+
+        return $resolved;
+    },
+));
+```
+
+**Input:**
+```djot
+Parenthetical: [@kuhn1962].
+
+Integral: [+@smith2010, p. 10] argues the point.
+
+Author suppressed: [-@watson1953, p. 737].
+
+Multi-cite: [@kuhn1962; @watson1953, ch. 2].
+```
+
+**Default HTML output:**
+```html
+<p>Parenthetical: <span class="citation experimental-citation citation-single" data-citation-id="citation-1" data-citation-source="[@kuhn1962]" data-citation-keys="kuhn1962" data-citation-items="{...}">[@kuhn1962]</span>.</p>
+```
+
+**Configuration options:**
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `resolver` | `callable|null` | `null` | Optional callback that receives all parsed `CitationGroup` objects for the document and returns a `groupId => rendered string` map |
+| `cssClass` | `string` | `'citation experimental-citation'` | CSS classes added to each citation span |
+
+### Resolver Contract
+
+The resolver callback receives the full list of parsed citation groups in document order:
+
+```php
+use Djot\Extension\CitationGroup;
+use Djot\Extension\ExperimentalCitationsExtension;
+
+$converter->addExtension(new ExperimentalCitationsExtension(
+    resolver: function (array $groups): array {
+        return array_reduce(
+            $groups,
+            function (array $carry, CitationGroup $group): array {
+                $carry[$group->id] = '[' . implode(', ', array_map(
+                    static fn ($reference) => $reference->key,
+                    $group->references,
+                )) . ']';
+
+                return $carry;
+            },
+            [],
+        );
+    },
+));
+```
+
+The extension re-parses each resolved string as Djot inline content, so the resolver may emit plain text or simple Djot inline markup.
+
+### Data Attributes
+
+Each parsed citation span stores the source and normalized references:
+
+- `data-citation-id`
+- `data-citation-source`
+- `data-citation-keys`
+- `data-citation-items` (JSON payload)
+
+This makes the extension useful even without a resolver, because downstream tools can inspect the citation metadata from the rendered HTML.
+
+### Scope and Status
+
+This extension follows Citum's current experimental Djot direction rather than an official Djot spec:
+
+- News / rationale: https://citum.org/news/citum-is-on-crates-io-and-jsr-io.html
+- Integration guide: https://docs.citum.org/guides/integrations/djot.html
+
+Because upstream Djot citation syntax is still unsettled, prefer this extension for opt-in experiments and integrations, not for long-term format guarantees.
+
 ## MermaidExtension
 
 Transforms code blocks with language `mermaid` into Mermaid.js-compatible markup for rendering diagrams. Mermaid supports flowcharts, sequence diagrams, class diagrams, state diagrams, ER diagrams, Gantt charts, pie charts, git graphs, and more.

--- a/src/Extension/CitationGroup.php
+++ b/src/Extension/CitationGroup.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Extension;
+
+/**
+ * Parsed experimental citation group, e.g. [@a; -@b, p. 10].
+ */
+final readonly class CitationGroup
+{
+    /**
+     * @param list<\Djot\Extension\CitationReference> $references
+     */
+    public function __construct(
+        public string $id,
+        public string $source,
+        public array $references,
+    ) {
+    }
+
+    /**
+     * @return array{id: string, source: string, references: list<array{key: string, mode: string, suffix?: string}>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'source' => $this->source,
+            'references' => array_map(
+                static fn (CitationReference $reference): array => $reference->toArray(),
+                $this->references,
+            ),
+        ];
+    }
+
+    /**
+     * @param array{id: string, source: string, references: list<array{key: string, mode?: string, suffix?: string|null}>} $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['id'],
+            $data['source'],
+            array_map(
+                static fn (array $reference): CitationReference => CitationReference::fromArray($reference),
+                $data['references'],
+            ),
+        );
+    }
+}

--- a/src/Extension/CitationGroup.php
+++ b/src/Extension/CitationGroup.php
@@ -9,12 +9,12 @@ namespace Djot\Extension;
  */
 final readonly class CitationGroup
 {
-    /**
-     * @param list<\Djot\Extension\CitationReference> $references
-     */
     public function __construct(
         public string $id,
         public string $source,
+        /**
+         * @var list<\Djot\Extension\CitationReference>
+         */
         public array $references,
     ) {
     }

--- a/src/Extension/CitationReference.php
+++ b/src/Extension/CitationReference.php
@@ -9,8 +9,25 @@ namespace Djot\Extension;
  */
 final readonly class CitationReference
 {
+    /**
+     * Standard parenthetical citation.
+     *
+     * @var string
+     */
     public const MODE_PARENTHESES = 'parenthetical';
+
+    /**
+     * Narrative / author-in-text citation.
+     *
+     * @var string
+     */
     public const MODE_INTEGRAL = 'integral';
+
+    /**
+     * Citation with suppressed author.
+     *
+     * @var string
+     */
     public const MODE_SUPPRESS_AUTHOR = 'suppress-author';
 
     public function __construct(

--- a/src/Extension/CitationReference.php
+++ b/src/Extension/CitationReference.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Extension;
+
+/**
+ * Parsed experimental citation item.
+ */
+final readonly class CitationReference
+{
+    public const MODE_PARENTHESES = 'parenthetical';
+    public const MODE_INTEGRAL = 'integral';
+    public const MODE_SUPPRESS_AUTHOR = 'suppress-author';
+
+    public function __construct(
+        public string $key,
+        public string $mode = self::MODE_PARENTHESES,
+        public ?string $suffix = null,
+    ) {
+    }
+
+    /**
+     * @return array{key: string, mode: string, suffix?: string}
+     */
+    public function toArray(): array
+    {
+        $data = [
+            'key' => $this->key,
+            'mode' => $this->mode,
+        ];
+
+        if ($this->suffix !== null) {
+            $data['suffix'] = $this->suffix;
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param array{key: string, mode?: string, suffix?: string|null} $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['key'],
+            $data['mode'] ?? self::MODE_PARENTHESES,
+            $data['suffix'] ?? null,
+        );
+    }
+}

--- a/src/Extension/ExperimentalCitationsExtension.php
+++ b/src/Extension/ExperimentalCitationsExtension.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Extension;
+
+use Closure;
+use Djot\DjotConverter;
+use Djot\Node\Document;
+use Djot\Node\Inline\Span;
+use Djot\Node\Inline\Text;
+use Djot\Node\Node;
+use Djot\Parser\InlineParser;
+use JsonException;
+
+/**
+ * Experimental Pandoc/Citum-style citations for Djot.
+ *
+ * Supported forms:
+ * - [@key]
+ * - [+@key]
+ * - [-@key]
+ * - [@a; @b]
+ * - [@key, p. 10]
+ *
+ * This extension only parses and semantically marks citation groups. Proper
+ * bibliography processing remains the responsibility of an external engine.
+ */
+class ExperimentalCitationsExtension implements ExtensionInterface, BeforeRenderExtensionInterface
+{
+    protected ?InlineParser $inlineParser = null;
+
+    protected int $nextCitationId = 1;
+
+    /**
+     * @var \Closure(list<\Djot\Extension\CitationGroup>, \Djot\Node\Document): array<string, string>|null
+     */
+    protected ?Closure $resolver;
+
+    /**
+     * @param callable(list<\Djot\Extension\CitationGroup>, \Djot\Node\Document): array<string, string>|null $resolver
+     * @param string $cssClass CSS classes added to parsed citation spans
+     */
+    public function __construct(
+        callable|Closure|null $resolver = null,
+        protected string $cssClass = 'citation experimental-citation',
+    ) {
+        $this->resolver = $resolver !== null ? Closure::fromCallable($resolver) : null;
+    }
+
+    public function register(DjotConverter $converter): void
+    {
+        $this->inlineParser = $converter->getParser()->getInlineParser();
+
+        $this->inlineParser->addInlinePattern(
+            '/\[((?:\s*[-+]?\@)[^\]]*)\](?![\(\[])/',
+            function (string $match, array $_groups, InlineParser $_parser): ?Span {
+                return $this->createCitationSpan($match);
+            },
+        );
+    }
+
+    public function beforeRender(Document $document): Document
+    {
+        if ($this->resolver === null) {
+            return $document;
+        }
+        $resolver = $this->resolver;
+
+        $spans = [];
+        $groups = [];
+        $this->collectCitationSpans($document, $spans, $groups);
+        if ($groups === []) {
+            return $document;
+        }
+
+        $resolvedById = $resolver(array_values($groups), $document);
+        foreach ($spans as $span) {
+            $id = $span->getAttribute('data-citation-id');
+            if ($id === null || !isset($resolvedById[$id])) {
+                continue;
+            }
+
+            $this->replaceSpanContents($span, $resolvedById[$id]);
+            $span->setAttribute('data-citation-rendered', 'resolved');
+        }
+
+        return $document;
+    }
+
+    protected function createCitationSpan(string $source): ?Span
+    {
+        $group = $this->parseCitationGroup($source);
+        if ($group === null) {
+            return null;
+        }
+
+        $span = new Span();
+        foreach (preg_split('/\s+/', trim($this->cssClass)) ?: [] as $class) {
+            if ($class !== '') {
+                $span->addClass($class);
+            }
+        }
+        $span->addClass(count($group->references) > 1 ? 'citation-multiple' : 'citation-single');
+        $span->setAttribute('data-citation-id', $group->id);
+        $span->setAttribute('data-citation-source', $group->source);
+        $span->setAttribute('data-citation-keys', implode(';', array_map(
+            static fn (CitationReference $reference): string => $reference->key,
+            $group->references,
+        )));
+        $span->setAttribute('data-citation-items', $this->encodeCitationGroup($group));
+        $span->appendChild(new Text($group->source));
+
+        return $span;
+    }
+
+    protected function parseCitationGroup(string $source): ?CitationGroup
+    {
+        if (!preg_match('/^\[(.*)\]$/s', $source, $matches)) {
+            return null;
+        }
+
+        $inner = trim($matches[1]);
+        if ($inner === '') {
+            return null;
+        }
+
+        $parts = preg_split('/\s*;\s*/', $inner) ?: [];
+        $references = [];
+
+        foreach ($parts as $part) {
+            if ($part === '') {
+                return null;
+            }
+
+            if (!preg_match('/^([+-]?)[ \t]*@([^,\s;\]]+)(?:\s*,\s*(.+))?$/s', $part, $itemMatch)) {
+                return null;
+            }
+
+            $mode = match ($itemMatch[1]) {
+                '+' => CitationReference::MODE_INTEGRAL,
+                '-' => CitationReference::MODE_SUPPRESS_AUTHOR,
+                default => CitationReference::MODE_PARENTHESES,
+            };
+
+            $references[] = new CitationReference(
+                $itemMatch[2],
+                $mode,
+                isset($itemMatch[3]) ? trim($itemMatch[3]) : null,
+            );
+        }
+
+        if ($references === []) {
+            return null;
+        }
+
+        return new CitationGroup(
+            'citation-' . $this->nextCitationId++,
+            $source,
+            $references,
+        );
+    }
+
+    /**
+     * @param array<int, \Djot\Node\Inline\Span> $spans
+     * @param array<string, \Djot\Extension\CitationGroup> $groups
+     */
+    protected function collectCitationSpans(Node $node, array &$spans, array &$groups): void
+    {
+        foreach ($node->getChildren() as $child) {
+            if ($child instanceof Span && $child->hasAttribute('data-citation-items')) {
+                $spans[] = $child;
+                $group = $this->decodeCitationGroup($child->getAttribute('data-citation-items'));
+                if ($group !== null) {
+                    $groups[$group->id] = $group;
+                }
+            }
+
+            $this->collectCitationSpans($child, $spans, $groups);
+        }
+    }
+
+    protected function replaceSpanContents(Span $span, string $rendered): void
+    {
+        while ($span->hasChildren()) {
+            $span->removeChildAt(0);
+        }
+
+        if ($this->inlineParser === null) {
+            $span->appendChild(new Text($rendered));
+
+            return;
+        }
+
+        $this->inlineParser->parse($span, $rendered);
+    }
+
+    protected function encodeCitationGroup(CitationGroup $group): string
+    {
+        try {
+            return json_encode($group->toArray(), JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return '';
+        }
+    }
+
+    protected function decodeCitationGroup(?string $json): ?CitationGroup
+    {
+        if ($json === null || $json === '') {
+            return null;
+        }
+
+        try {
+            /** @var array{id: string, source: string, references: list<array{key: string, mode?: string, suffix?: string|null}>} $data */
+            $data = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+
+            return CitationGroup::fromArray($data);
+        } catch (JsonException) {
+            return null;
+        }
+    }
+}

--- a/src/Extension/ExperimentalCitationsExtension.php
+++ b/src/Extension/ExperimentalCitationsExtension.php
@@ -162,6 +162,7 @@ class ExperimentalCitationsExtension implements ExtensionInterface, BeforeRender
     }
 
     /**
+     * @param \Djot\Node\Node $node
      * @param array<int, \Djot\Node\Inline\Span> $spans
      * @param array<string, \Djot\Extension\CitationGroup> $groups
      */

--- a/tests/TestCase/Extension/ExperimentalCitationsExtensionTest.php
+++ b/tests/TestCase/Extension/ExperimentalCitationsExtensionTest.php
@@ -7,6 +7,7 @@ namespace Djot\Test\TestCase\Extension;
 use Djot\DjotConverter;
 use Djot\Extension\CitationGroup;
 use Djot\Extension\ExperimentalCitationsExtension;
+use Djot\Node\Document;
 use PHPUnit\Framework\TestCase;
 
 class ExperimentalCitationsExtensionTest extends TestCase
@@ -64,7 +65,7 @@ class ExperimentalCitationsExtensionTest extends TestCase
     {
         $converter = new DjotConverter();
         $converter->addExtension(new ExperimentalCitationsExtension(
-            resolver: static function (array $groups): array {
+            resolver: static function (array $groups, Document $document): array {
                 $resolved = [];
                 foreach ($groups as $group) {
                     $keys = array_map(
@@ -90,7 +91,7 @@ class ExperimentalCitationsExtensionTest extends TestCase
 
         $converter = new DjotConverter();
         $converter->addExtension(new ExperimentalCitationsExtension(
-            resolver: static function (array $groups) use (&$seenIds): array {
+            resolver: static function (array $groups, Document $document) use (&$seenIds): array {
                 $resolved = [];
                 foreach ($groups as $group) {
                     $seenIds[] = $group->id;
@@ -134,7 +135,7 @@ class ExperimentalCitationsExtensionTest extends TestCase
 
         $converter = new DjotConverter();
         $converter->addExtension(new ExperimentalCitationsExtension(
-            resolver: static function (array $groups) use (&$captured): array {
+            resolver: static function (array $groups, Document $document) use (&$captured): array {
                 $captured = $groups;
 
                 return array_reduce(
@@ -155,5 +156,37 @@ class ExperimentalCitationsExtensionTest extends TestCase
         $this->assertSame('kuhn1962', $captured[0]->references[0]->key);
         $this->assertSame('suppress-author', $captured[0]->references[1]->mode);
         $this->assertSame('ch. 2', $captured[0]->references[1]->suffix);
+    }
+
+    public function testResolverReceivesDocumentContext(): void
+    {
+        $seenDocument = null;
+
+        $converter = new DjotConverter();
+        $converter->addExtension(new ExperimentalCitationsExtension(
+            resolver: static function (array $groups, Document $document) use (&$seenDocument): array {
+                $seenDocument = $document;
+
+                return [$groups[0]->id => $groups[0]->source];
+            },
+        ));
+
+        $converter->convert('# Heading' . "\n\n" . '[@kuhn1962]');
+
+        $this->assertInstanceOf(Document::class, $seenDocument);
+        $this->assertCount(2, $seenDocument->getChildren());
+    }
+
+    public function testResolverMayReturnEmptyMap(): void
+    {
+        $converter = new DjotConverter();
+        $converter->addExtension(new ExperimentalCitationsExtension(
+            resolver: static fn (array $groups, Document $document): array => [],
+        ));
+
+        $html = $converter->convert('[@kuhn1962]');
+
+        $this->assertStringContainsString('[@kuhn1962]', $html);
+        $this->assertStringNotContainsString('data-citation-rendered="resolved"', $html);
     }
 }

--- a/tests/TestCase/Extension/ExperimentalCitationsExtensionTest.php
+++ b/tests/TestCase/Extension/ExperimentalCitationsExtensionTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Test\TestCase\Extension;
+
+use Djot\DjotConverter;
+use Djot\Extension\CitationGroup;
+use Djot\Extension\ExperimentalCitationsExtension;
+use PHPUnit\Framework\TestCase;
+
+class ExperimentalCitationsExtensionTest extends TestCase
+{
+    public function testParentheticalCitation(): void
+    {
+        $converter = new DjotConverter();
+        $converter->addExtension(new ExperimentalCitationsExtension());
+
+        $html = $converter->convert('Parenthetical: [@kuhn1962].');
+
+        $this->assertStringContainsString('class="citation experimental-citation citation-single"', $html);
+        $this->assertStringContainsString('data-citation-source="[@kuhn1962]"', $html);
+        $this->assertStringContainsString('data-citation-keys="kuhn1962"', $html);
+        $this->assertStringContainsString('&quot;mode&quot;:&quot;parenthetical&quot;', $html);
+    }
+
+    public function testIntegralCitation(): void
+    {
+        $converter = new DjotConverter();
+        $converter->addExtension(new ExperimentalCitationsExtension());
+
+        $html = $converter->convert('[+@smith2010, p. 10] argues the point.');
+
+        $this->assertStringContainsString('data-citation-source="[+@smith2010, p. 10]"', $html);
+        $this->assertStringContainsString('&quot;mode&quot;:&quot;integral&quot;', $html);
+        $this->assertStringContainsString('&quot;suffix&quot;:&quot;p. 10&quot;', $html);
+    }
+
+    public function testSuppressAuthorCitation(): void
+    {
+        $converter = new DjotConverter();
+        $converter->addExtension(new ExperimentalCitationsExtension());
+
+        $html = $converter->convert('[-@watson1953, p. 737].');
+
+        $this->assertStringContainsString('&quot;mode&quot;:&quot;suppress-author&quot;', $html);
+    }
+
+    public function testMultiCitation(): void
+    {
+        $converter = new DjotConverter();
+        $converter->addExtension(new ExperimentalCitationsExtension());
+
+        $html = $converter->convert('[@kuhn1962; @watson1953, ch. 2]');
+
+        $this->assertStringContainsString('citation-multiple', $html);
+        $this->assertStringContainsString('data-citation-keys="kuhn1962;watson1953"', $html);
+        $this->assertStringContainsString('&quot;key&quot;:&quot;kuhn1962&quot;', $html);
+        $this->assertStringContainsString('&quot;key&quot;:&quot;watson1953&quot;', $html);
+        $this->assertStringContainsString('&quot;suffix&quot;:&quot;ch. 2&quot;', $html);
+    }
+
+    public function testCitationResolverCanReplaceRenderedText(): void
+    {
+        $converter = new DjotConverter();
+        $converter->addExtension(new ExperimentalCitationsExtension(
+            resolver: static function (array $groups): array {
+                $resolved = [];
+                foreach ($groups as $group) {
+                    $keys = array_map(
+                        static fn ($reference): string => strtoupper($reference->key),
+                        $group->references,
+                    );
+                    $resolved[$group->id] = '(' . implode('; ', $keys) . ')';
+                }
+
+                return $resolved;
+            },
+        ));
+
+        $html = $converter->convert('See [@kuhn1962; @watson1953].');
+
+        $this->assertStringContainsString('(KUHN1962; WATSON1953)', $html);
+        $this->assertStringContainsString('data-citation-rendered="resolved"', $html);
+    }
+
+    public function testResolverReceivesDistinctIdsForRepeatedCitationGroups(): void
+    {
+        $seenIds = [];
+
+        $converter = new DjotConverter();
+        $converter->addExtension(new ExperimentalCitationsExtension(
+            resolver: static function (array $groups) use (&$seenIds): array {
+                $resolved = [];
+                foreach ($groups as $group) {
+                    $seenIds[] = $group->id;
+                    $resolved[$group->id] = $group->source;
+                }
+
+                return $resolved;
+            },
+        ));
+
+        $converter->convert('[@kuhn1962] and again [@kuhn1962].');
+
+        $this->assertCount(2, $seenIds);
+        $this->assertNotSame($seenIds[0], $seenIds[1]);
+    }
+
+    public function testCitationLikeBracketFollowedByLinkDestinationStillParsesAsLink(): void
+    {
+        $converter = new DjotConverter();
+        $converter->addExtension(new ExperimentalCitationsExtension());
+
+        $html = $converter->convert('Read [+@kuhn1962](https://example.com).');
+
+        $this->assertStringContainsString('<a href="https://example.com">+@kuhn1962</a>', $html);
+        $this->assertStringNotContainsString('data-citation-source', $html);
+    }
+
+    public function testNonCitationBracketStaysPlainText(): void
+    {
+        $converter = new DjotConverter();
+        $converter->addExtension(new ExperimentalCitationsExtension());
+
+        $html = $converter->convert('[not a citation]');
+
+        $this->assertStringContainsString('<p>[not a citation]</p>', $html);
+    }
+
+    public function testResolverCanInspectStructuredGroups(): void
+    {
+        $captured = [];
+
+        $converter = new DjotConverter();
+        $converter->addExtension(new ExperimentalCitationsExtension(
+            resolver: static function (array $groups) use (&$captured): array {
+                $captured = $groups;
+
+                return array_reduce(
+                    $groups,
+                    static function (array $carry, CitationGroup $group): array {
+                        $carry[$group->id] = $group->source;
+
+                        return $carry;
+                    },
+                    [],
+                );
+            },
+        ));
+
+        $converter->convert('[@kuhn1962; -@watson1953, ch. 2]');
+
+        $this->assertCount(1, $captured);
+        $this->assertSame('kuhn1962', $captured[0]->references[0]->key);
+        $this->assertSame('suppress-author', $captured[0]->references[1]->mode);
+        $this->assertSame('ch. 2', $captured[0]->references[1]->suffix);
+    }
+}


### PR DESCRIPTION
## Summary
Add an opt-in `CitationsExtension` for draft Pandoc/Citum-style Djot citations.

## What this adds
- parse experimental citation forms like `[@key]`, `[+@key]`, `[-@key]`, `[@a; @b]`, and `[@key, p. 10]`
- render citation groups as semantic inline spans with structured `data-citation-*` attributes
- expose typed `CitationGroup` / `CitationReference` value objects to resolver callbacks
- support an optional document-level resolver that maps parsed citation groups to rendered inline strings
- document the extension and its current scope/limits

## Scope boundaries
- no CSL processor in core
- no bibliography engine in core
- syntax is explicitly experimental because upstream Djot citation syntax is still unsettled

This is only 1 piece of a bigger story:

  - Layer 1: parsing
    **CitationsExtension** (this PR)
  - Layer 2: bibliography provider
    Reads CSL-JSON / BibLaTeX / RIS / Citum YAML into an internal reference map
  - Layer 3: formatter adapter
    External engine boundary, ideally Citum-backed first
  - Layer 4: bibliography extension/pass
    Inserts bibliography into the AST
  - Layer 5: diagnostics
    Missing keys, unresolved references, unsupported patterns
