### PR TITLE
feat: add blocksInterruptParagraphs lever and deprecate significantNewlines

### DIFF
--- a/docs/guide/parser-options.md
+++ b/docs/guide/parser-options.md
@@ -15,7 +15,8 @@ $converter = new DjotConverter();
 // With options
 $converter = new DjotConverter(
     xhtml: true,
-    significantNewlines: true,
+    blocksInterruptParagraphs: true,
+    nestedBlocksInLists: true,
 );
 ```
 
@@ -35,7 +36,7 @@ use Djot\Renderer\HtmlRenderer;
 
 // Full control via create()
 $converter = DjotConverter::create(
-    new BlockParser(significantNewlines: true),
+    new BlockParser(blocksInterruptParagraphs: true),
     new HtmlRenderer(xhtml: true),
 );
 ```
@@ -101,6 +102,23 @@ And so are you</p>
 Note: Use `\` at end of line for hard breaks (always renders as `<br>`) regardless of soft break mode.
 
 ## Significant Newlines Mode
+
+::: warning Deprecated
+`significantNewlines` is now a convenience shorthand equal to enabling both
+`blocksInterruptParagraphs` and `nestedBlocksInLists` together. It is
+deprecated in favor of the two granular levers. Migrate as shown below.
+
+```php
+// Deprecated:
+$converter = DjotConverter::withSignificantNewlines();
+
+// Equivalent (preferred):
+$converter = new DjotConverter(
+    blocksInterruptParagraphs: true,
+    nestedBlocksInLists: true,
+);
+```
+:::
 
 By default, djot-php follows the djot specification where block elements (lists, blockquotes, headings) **cannot interrupt paragraphs** - they require a blank line before them.
 
@@ -344,3 +362,74 @@ Output:
 | Lists/blockquotes/headings interrupt top-level paragraphs | No | No                    | Yes                   |
 
 Note: `significantNewlines` implies `nestedBlocksInLists` - enabling the former turns on the latter automatically.
+
+## Block Interrupts Paragraphs Mode
+
+`blocksInterruptParagraphs` is the complementary counterpart to [Nested Blocks in Lists](#nested-blocks-in-lists-mode) mode. It allows top-level block elements — lists, blockquotes, headings, and fenced code — to interrupt a paragraph without a preceding blank line. It does **not** enable nesting inside list items (that is `nestedBlocksInLists`).
+
+Use it when you want markdown-like top-level interruption but otherwise spec-compliant djot: indented content inside a list item still requires a blank line.
+
+### Enabling Block Interrupts Paragraphs Mode
+
+```php
+use Djot\DjotConverter;
+use Djot\Parser\BlockParser;
+
+// Method 1: Factory method
+$converter = DjotConverter::withBlocksInterruptParagraphs();
+
+// Method 2: Constructor parameter
+$converter = new DjotConverter(blocksInterruptParagraphs: true);
+
+// Method 3: Directly on the parser
+$parser = new BlockParser(blocksInterruptParagraphs: true);
+$parser->setBlocksInterruptParagraphs(true);
+```
+
+### Behavior
+
+A block element can follow a paragraph without a blank line:
+
+```php
+$converter = DjotConverter::withBlocksInterruptParagraphs();
+$result = $converter->convert("Here:\n- one\n- two");
+```
+
+Output:
+```html
+<p>Here:</p>
+<ul>
+<li>
+one
+</li>
+<li>
+two
+</li>
+</ul>
+```
+
+But indented content inside a list item does **not** nest (this is what differs from significant newlines mode):
+
+```php
+$converter = DjotConverter::withBlocksInterruptParagraphs();
+$result = $converter->convert("- a\n  - b");
+```
+
+Output:
+```html
+<ul>
+<li>
+a
+- b
+</li>
+</ul>
+```
+
+### blocksInterruptParagraphs vs significantNewlines
+
+| Behavior                                              | Default | `blocksInterruptParagraphs` | `significantNewlines` |
+|------------------------------------------------------|---------|-----------------------------|-----------------------|
+| Lists/blockquotes/headings interrupt top-level paragraphs | No | **Yes**                | Yes                   |
+| Nested blocks in list items without a blank line     | No      | No                          | Yes                   |
+
+The two granular levers are independent. `blocksInterruptParagraphs` alone does not nest list items; `nestedBlocksInLists` alone does not interrupt top-level paragraphs. `significantNewlines` enables both simultaneously.

--- a/docs/guide/parser-options.md
+++ b/docs/guide/parser-options.md
@@ -130,13 +130,13 @@ The "significant newlines" mode provides markdown-like behavior where block elem
 use Djot\DjotConverter;
 use Djot\Parser\BlockParser;
 
-// Method 1: Factory method
+// Method 1: Factory method (deprecated)
 $converter = DjotConverter::withSignificantNewlines();
 
-// Method 2: Constructor parameter
+// Method 2: Constructor parameter (deprecated)
 $converter = new DjotConverter(significantNewlines: true);
 
-// Method 3: With other output formats
+// Method 3: With other output formats (deprecated)
 $converter = DjotConverter::markdown(
     new BlockParser(significantNewlines: true),
 );
@@ -282,7 +282,7 @@ use Djot\Renderer\SoftBreakMode;
 // Significant newlines with safe mode for user-generated content
 $converter = new DjotConverter(
     safeMode: new SafeMode(),
-    significantNewlines: true,
+    significantNewlines: true, // deprecated: prefer blocksInterruptParagraphs + nestedBlocksInLists
     softBreakMode: SoftBreakMode::Break, // Optional: visible line breaks
 );
 ```
@@ -361,7 +361,7 @@ Output:
 | Nested blocks in list items without a blank line     | No      | **Yes**               | Yes                   |
 | Lists/blockquotes/headings interrupt top-level paragraphs | No | No                    | Yes                   |
 
-Note: `significantNewlines` implies `nestedBlocksInLists` - enabling the former turns on the latter automatically.
+Note: `significantNewlines` is deprecated; it enables both `blocksInterruptParagraphs` and `nestedBlocksInLists`. Prefer setting the two granular levers directly.
 
 ## Block Interrupts Paragraphs Mode
 

--- a/docs/guide/parser-options.md
+++ b/docs/guide/parser-options.md
@@ -36,7 +36,7 @@ use Djot\Renderer\HtmlRenderer;
 
 // Full control via create()
 $converter = DjotConverter::create(
-    new BlockParser(blocksInterruptParagraphs: true),
+    new BlockParser(blocksInterruptParagraphs: true, nestedBlocksInLists: true),
     new HtmlRenderer(xhtml: true),
 );
 ```
@@ -356,16 +356,16 @@ Output:
 
 ### nestedBlocksInLists vs significantNewlines
 
-| Behavior                                              | Default | `nestedBlocksInLists` | `significantNewlines` |
-|------------------------------------------------------|---------|-----------------------|-----------------------|
-| Nested blocks in list items without a blank line     | No      | **Yes**               | Yes                   |
-| Lists/blockquotes/headings interrupt top-level paragraphs | No | No                    | Yes                   |
+| Behavior                                                       | Default | `nestedBlocksInLists` | `significantNewlines` |
+|----------------------------------------------------------------|---------|-----------------------|-----------------------|
+| Nested blocks in list items without a blank line               | No      | **Yes**               | Yes                   |
+| Block elements interrupt top-level paragraphs                  | No      | No                    | Yes                   |
 
 Note: `significantNewlines` is deprecated; it enables both `blocksInterruptParagraphs` and `nestedBlocksInLists`. Prefer setting the two granular levers directly.
 
 ## Block Interrupts Paragraphs Mode
 
-`blocksInterruptParagraphs` is the complementary counterpart to [Nested Blocks in Lists](#nested-blocks-in-lists-mode) mode. It allows top-level block elements — lists, blockquotes, headings, and fenced code — to interrupt a paragraph without a preceding blank line. It does **not** enable nesting inside list items (that is `nestedBlocksInLists`).
+`blocksInterruptParagraphs` is the complementary counterpart to [Nested Blocks in Lists](#nested-blocks-in-lists-mode) mode. It allows top-level block elements — lists, blockquotes, headings, tables, thematic breaks, and code/div/comment fences — to interrupt a paragraph without a preceding blank line. It does **not** enable nesting inside list items (that is `nestedBlocksInLists`).
 
 Use it when you want markdown-like top-level interruption but otherwise spec-compliant djot: indented content inside a list item still requires a blank line.
 
@@ -427,9 +427,9 @@ a
 
 ### blocksInterruptParagraphs vs significantNewlines
 
-| Behavior                                              | Default | `blocksInterruptParagraphs` | `significantNewlines` |
-|------------------------------------------------------|---------|-----------------------------|-----------------------|
-| Lists/blockquotes/headings interrupt top-level paragraphs | No | **Yes**                | Yes                   |
-| Nested blocks in list items without a blank line     | No      | No                          | Yes                   |
+| Behavior                                                       | Default | `blocksInterruptParagraphs` | `significantNewlines` |
+|----------------------------------------------------------------|---------|-----------------------------|-----------------------|
+| Block elements interrupt top-level paragraphs                  | No      | **Yes**                     | Yes                   |
+| Nested blocks in list items without a blank line               | No      | No                          | Yes                   |
 
 The two granular levers are independent. `blocksInterruptParagraphs` alone does not nest list items; `nestedBlocksInLists` alone does not interrupt top-level paragraphs. `significantNewlines` enables both simultaneously.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -38,7 +38,7 @@ public function __construct(
 - `$significantNewlines`: **Deprecated.** Convenience shorthand for `blocksInterruptParagraphs: true, nestedBlocksInLists: true`. Prefer the two granular levers. See [Significant Newlines Mode](#significant-newlines-mode).
 - `$softBreakMode`: Override how soft breaks are rendered. When `null`, uses the renderer's default (newline for HTML).
 - `$roundTripMode`: When `true`, adds round-trip metadata for Djot→HTML→Djot workflows (HTML renderer only).
-- `$parser`: Optional pre-configured parser. When provided, inline parser constructor flags such as `warnings`, `strict`, and `significantNewlines` are ignored.
+- `$parser`: Optional pre-configured parser. When provided, inline parser constructor flags such as `warnings`, `strict`, and `significantNewlines` (deprecated) are ignored.
 - `$renderer`: Optional pre-configured renderer. When provided, inline renderer constructor flags such as `xhtml`, `safeMode`, `softBreakMode`, and `roundTripMode` are ignored.
 - `$nestedBlocksInLists`: When `true`, indentation alone introduces nested blocks inside list items without a blank line, while top-level paragraph interruption stays spec-compliant (see [Nested Blocks in Lists Mode](/guide/parser-options#nested-blocks-in-lists-mode)). Implied by `$significantNewlines`.
 - `$blocksInterruptParagraphs`: When `true`, top-level block elements (lists, blockquotes, headings, fences) can interrupt a paragraph without a preceding blank line, while list-item nesting stays spec-compliant (see [Block Interrupts Paragraphs Mode](/guide/parser-options#block-interrupts-paragraphs-mode)). Implied by `$significantNewlines`.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -38,10 +38,10 @@ public function __construct(
 - `$significantNewlines`: **Deprecated.** Convenience shorthand for `blocksInterruptParagraphs: true, nestedBlocksInLists: true`. Prefer the two granular levers. See [Significant Newlines Mode](#significant-newlines-mode).
 - `$softBreakMode`: Override how soft breaks are rendered. When `null`, uses the renderer's default (newline for HTML).
 - `$roundTripMode`: When `true`, adds round-trip metadata for Djot→HTML→Djot workflows (HTML renderer only).
-- `$parser`: Optional pre-configured parser. When provided, inline parser constructor flags such as `warnings`, `strict`, and `significantNewlines` (deprecated) are ignored.
+- `$parser`: Optional pre-configured parser. When provided, inline parser constructor flags such as `warnings`, `strict`, `significantNewlines` (deprecated), `nestedBlocksInLists`, and `blocksInterruptParagraphs` are ignored.
 - `$renderer`: Optional pre-configured renderer. When provided, inline renderer constructor flags such as `xhtml`, `safeMode`, `softBreakMode`, and `roundTripMode` are ignored.
 - `$nestedBlocksInLists`: When `true`, indentation alone introduces nested blocks inside list items without a blank line, while top-level paragraph interruption stays spec-compliant (see [Nested Blocks in Lists Mode](/guide/parser-options#nested-blocks-in-lists-mode)). Implied by `$significantNewlines`.
-- `$blocksInterruptParagraphs`: When `true`, top-level block elements (lists, blockquotes, headings, fences) can interrupt a paragraph without a preceding blank line, while list-item nesting stays spec-compliant (see [Block Interrupts Paragraphs Mode](/guide/parser-options#block-interrupts-paragraphs-mode)). Implied by `$significantNewlines`.
+- `$blocksInterruptParagraphs`: When `true`, top-level block elements (lists, blockquotes, headings, tables, thematic breaks, and code/div/comment fences) can interrupt a paragraph without a preceding blank line, while list-item nesting stays spec-compliant (see [Block Interrupts Paragraphs Mode](/guide/parser-options#block-interrupts-paragraphs-mode)). Implied by `$significantNewlines`.
 
 ### Factory Methods
 
@@ -93,7 +93,7 @@ public static function withBlocksInterruptParagraphs(
 ): self
 ```
 
-Creates a converter that allows top-level block elements (lists, blockquotes, headings, fences) to interrupt a paragraph without a preceding blank line, while list-item nesting stays spec-compliant. See [Block Interrupts Paragraphs Mode](/guide/parser-options#block-interrupts-paragraphs-mode).
+Creates a converter that allows top-level block elements (lists, blockquotes, headings, tables, thematic breaks, and code/div/comment fences) to interrupt a paragraph without a preceding blank line, while list-item nesting stays spec-compliant. See [Block Interrupts Paragraphs Mode](/guide/parser-options#block-interrupts-paragraphs-mode).
 
 ### Methods
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -26,6 +26,7 @@ public function __construct(
     ?BlockParser $parser = null,
     ?RendererInterface $renderer = null,
     bool $nestedBlocksInLists = false,
+    bool $blocksInterruptParagraphs = false,
 )
 ```
 
@@ -34,16 +35,19 @@ public function __construct(
 - `$strict`: When `true`, throws `ParseException` on parse errors (see [Error Handling](#error-handling)).
 - `$safeMode`: When `true` or a `SafeMode` instance, enables XSS protection (see [Safe Mode](#safe-mode)).
 - `$profile`: A `Profile` instance for feature restriction (see [Profiles](/guide/profiles)).
-- `$significantNewlines`: When `true`, enables markdown-like parsing where block elements can interrupt paragraphs (see [Significant Newlines Mode](#significant-newlines-mode)).
+- `$significantNewlines`: **Deprecated.** Convenience shorthand for `blocksInterruptParagraphs: true, nestedBlocksInLists: true`. Prefer the two granular levers. See [Significant Newlines Mode](#significant-newlines-mode).
 - `$softBreakMode`: Override how soft breaks are rendered. When `null`, uses the renderer's default (newline for HTML).
 - `$roundTripMode`: When `true`, adds round-trip metadata for Djot→HTML→Djot workflows (HTML renderer only).
 - `$parser`: Optional pre-configured parser. When provided, inline parser constructor flags such as `warnings`, `strict`, and `significantNewlines` are ignored.
 - `$renderer`: Optional pre-configured renderer. When provided, inline renderer constructor flags such as `xhtml`, `safeMode`, `softBreakMode`, and `roundTripMode` are ignored.
 - `$nestedBlocksInLists`: When `true`, indentation alone introduces nested blocks inside list items without a blank line, while top-level paragraph interruption stays spec-compliant (see [Nested Blocks in Lists Mode](/guide/parser-options#nested-blocks-in-lists-mode)). Implied by `$significantNewlines`.
+- `$blocksInterruptParagraphs`: When `true`, top-level block elements (lists, blockquotes, headings, fences) can interrupt a paragraph without a preceding blank line, while list-item nesting stays spec-compliant (see [Block Interrupts Paragraphs Mode](/guide/parser-options#block-interrupts-paragraphs-mode)). Implied by `$significantNewlines`.
 
 ### Factory Methods
 
 #### withSignificantNewlines()
+
+> **Deprecated.** Prefer using `new DjotConverter(blocksInterruptParagraphs: true, nestedBlocksInLists: true)` or the two dedicated factory methods. See [Significant Newlines Mode](/guide/parser-options#significant-newlines-mode).
 
 ```php
 public static function withSignificantNewlines(
@@ -57,7 +61,7 @@ public static function withSignificantNewlines(
 ): self
 ```
 
-Creates a converter with significant newlines mode enabled. See [Significant Newlines Mode](#significant-newlines-mode).
+Creates a converter with significant newlines mode enabled (equivalent to `blocksInterruptParagraphs: true` + `nestedBlocksInLists: true`). See [Significant Newlines Mode](/guide/parser-options#significant-newlines-mode).
 
 #### withNestedBlocksInLists()
 
@@ -74,6 +78,22 @@ public static function withNestedBlocksInLists(
 ```
 
 Creates a converter that enables nested blocks in list items without requiring blank lines, while leaving top-level paragraph interruption at the spec default. See [Nested Blocks in Lists Mode](/guide/parser-options#nested-blocks-in-lists-mode).
+
+#### withBlocksInterruptParagraphs()
+
+```php
+public static function withBlocksInterruptParagraphs(
+    bool $xhtml = false,
+    bool $warnings = false,
+    bool $strict = false,
+    bool|SafeMode|null $safeMode = null,
+    ?Profile $profile = null,
+    ?SoftBreakMode $softBreakMode = null,
+    bool $roundTripMode = false,
+): self
+```
+
+Creates a converter that allows top-level block elements (lists, blockquotes, headings, fences) to interrupt a paragraph without a preceding blank line, while list-item nesting stays spec-compliant. See [Block Interrupts Paragraphs Mode](/guide/parser-options#block-interrupts-paragraphs-mode).
 
 ### Methods
 
@@ -519,6 +539,7 @@ $parser = new BlockParser(
     strictMode: false,
     significantNewlines: false,
     nestedBlocksInLists: false,
+    blocksInterruptParagraphs: false,
 );
 $document = $parser->parse($djotString);
 
@@ -526,7 +547,7 @@ $document = $parser->parse($djotString);
 // Get exception on errors (if strictMode: true)
 $warnings = $parser->getWarnings();
 
-// Enable/disable significant newlines mode
+// Enable/disable significant newlines mode (deprecated: enables both levers below)
 $parser->setSignificantNewlines(true);
 $isEnabled = $parser->getSignificantNewlines();
 
@@ -534,6 +555,11 @@ $isEnabled = $parser->getSignificantNewlines();
 // (significant newlines mode enables this implicitly)
 $parser->setNestedBlocksInLists(true);
 $isEnabled = $parser->getNestedBlocksInLists();
+
+// Enable/disable top-level paragraph interruption only
+// (significant newlines mode enables this implicitly)
+$parser->setBlocksInterruptParagraphs(true);
+$isEnabled = $parser->getBlocksInterruptParagraphs();
 ```
 
 #### Custom Block Patterns
@@ -886,18 +912,28 @@ $node->addClass(string $class): void
 
 ## Significant Newlines Mode
 
+> **Deprecated.** `significantNewlines` is a convenience shorthand for
+> `blocksInterruptParagraphs: true` + `nestedBlocksInLists: true`.
+> Prefer the two granular levers or their factory methods.
+
 An optional parsing mode for chat messages, comments, and quick notes where markdown-like behavior is more intuitive.
 
 ### Enabling
 
 ```php
-// Via factory method (recommended)
+// Via factory method (deprecated)
 $converter = DjotConverter::withSignificantNewlines();
 
-// Via constructor parameter
+// Via constructor parameter (deprecated)
 $converter = new DjotConverter(significantNewlines: true);
 
-// Via parser directly
+// Preferred: use the two granular levers
+$converter = new DjotConverter(
+    blocksInterruptParagraphs: true,
+    nestedBlocksInLists: true,
+);
+
+// Via parser directly (deprecated)
 $parser = new BlockParser(significantNewlines: true);
 
 // Via setter (for runtime switching)

--- a/src/DjotConverter.php
+++ b/src/DjotConverter.php
@@ -129,6 +129,7 @@ class DjotConverter
      * @param \Djot\Parser\BlockParser|null $parser Pre-configured parser (ignores warnings/strict/significantNewlines if set)
      * @param \Djot\Renderer\RendererInterface|null $renderer Pre-configured renderer (ignores xhtml/safeMode/softBreakMode/roundTripMode if set)
      * @param bool $nestedBlocksInLists Allow nested blocks in list items without blank lines
+     * @param bool $blocksInterruptParagraphs Allow top-level block elements to interrupt paragraphs without a blank line
      */
     public function __construct(
         bool $xhtml = false,
@@ -142,6 +143,7 @@ class DjotConverter
         ?BlockParser $parser = null,
         ?RendererInterface $renderer = null,
         bool $nestedBlocksInLists = false,
+        bool $blocksInterruptParagraphs = false,
     ) {
         $this->collectWarnings = $warnings;
         $this->strictMode = $strict;
@@ -150,7 +152,7 @@ class DjotConverter
         if ($parser !== null) {
             $this->parser = $parser;
         } else {
-            $this->parser = new BlockParser($warnings, $strict, $significantNewlines, $nestedBlocksInLists);
+            $this->parser = new BlockParser($warnings, $strict, $significantNewlines, $nestedBlocksInLists, $blocksInterruptParagraphs);
         }
 
         // Use provided renderer or create one from parameters
@@ -191,6 +193,9 @@ class DjotConverter
      *
      * Note: This does NOT change how soft breaks are rendered. Use setSoftBreakMode()
      * or the softBreakMode parameter if you also want visible line breaks.
+     *
+     * @deprecated Use withBlocksInterruptParagraphs() and/or
+     *   withNestedBlocksInLists(). significantNewlines is the union of both.
      *
      * @param bool $xhtml Whether to use XHTML-compatible output
      * @param bool $warnings Whether to collect warnings during parsing
@@ -245,6 +250,42 @@ class DjotConverter
             softBreakMode: $softBreakMode,
             roundTripMode: $roundTripMode,
             nestedBlocksInLists: true,
+        );
+    }
+
+    /**
+     * Create a converter that only enables top-level paragraph interruption.
+     *
+     * Block elements (lists, blockquotes, headings, fences) can interrupt a
+     * paragraph without a preceding blank line, but list items still require a
+     * blank line to nest.
+     *
+     * @param bool $xhtml Whether to use XHTML-compatible output
+     * @param bool $warnings Whether to collect warnings during parsing
+     * @param bool $strict Whether to throw exceptions on parse errors
+     * @param \Djot\SafeMode|bool|null $safeMode Enable safe mode
+     * @param \Djot\Profile|null $profile Profile for feature restriction
+     * @param \Djot\Renderer\SoftBreakMode|null $softBreakMode How to render soft breaks (HTML renderer only)
+     * @param bool $roundTripMode Add data attributes for round-trips (HTML renderer only)
+     */
+    public static function withBlocksInterruptParagraphs(
+        bool $xhtml = false,
+        bool $warnings = false,
+        bool $strict = false,
+        bool|SafeMode|null $safeMode = null,
+        ?Profile $profile = null,
+        ?SoftBreakMode $softBreakMode = null,
+        bool $roundTripMode = false,
+    ): self {
+        return new self(
+            xhtml: $xhtml,
+            warnings: $warnings,
+            strict: $strict,
+            safeMode: $safeMode,
+            profile: $profile,
+            softBreakMode: $softBreakMode,
+            roundTripMode: $roundTripMode,
+            blocksInterruptParagraphs: true,
         );
     }
 

--- a/src/DjotConverter.php
+++ b/src/DjotConverter.php
@@ -67,7 +67,7 @@ class DjotConverter
      *
      * // Custom parser
      * $converter = DjotConverter::create(
-     *     parser: new BlockParser(blocksInterruptParagraphs: true),
+     *     parser: new BlockParser(blocksInterruptParagraphs: true, nestedBlocksInLists: true),
      *     renderer: new HtmlRenderer(xhtml: true),
      * );
      * ```
@@ -126,7 +126,7 @@ class DjotConverter
      * @param bool $significantNewlines Enable significant newlines mode (markdown-like paragraph interruption)
      * @param \Djot\Renderer\SoftBreakMode|null $softBreakMode How to render soft breaks (HTML renderer only)
      * @param bool $roundTripMode Add data attributes for Djot→HTML→Djot round-trips (HTML renderer only)
-     * @param \Djot\Parser\BlockParser|null $parser Pre-configured parser (ignores warnings/strict/significantNewlines if set)
+     * @param \Djot\Parser\BlockParser|null $parser Pre-configured parser (ignores warnings/strict/significantNewlines/nestedBlocksInLists/blocksInterruptParagraphs if set)
      * @param \Djot\Renderer\RendererInterface|null $renderer Pre-configured renderer (ignores xhtml/safeMode/softBreakMode/roundTripMode if set)
      * @param bool $nestedBlocksInLists Allow nested blocks in list items without blank lines
      * @param bool $blocksInterruptParagraphs Allow top-level block elements to interrupt paragraphs without a blank line
@@ -256,9 +256,9 @@ class DjotConverter
     /**
      * Create a converter that only enables top-level paragraph interruption.
      *
-     * Block elements (lists, blockquotes, headings, fences) can interrupt a
-     * paragraph without a preceding blank line, but list items still require a
-     * blank line to nest.
+     * Block elements (lists, blockquotes, headings, tables, thematic breaks,
+     * and code/div/comment fences) can interrupt a paragraph without a
+     * preceding blank line, but list items still require a blank line to nest.
      *
      * @param bool $xhtml Whether to use XHTML-compatible output
      * @param bool $warnings Whether to collect warnings during parsing

--- a/src/DjotConverter.php
+++ b/src/DjotConverter.php
@@ -67,7 +67,7 @@ class DjotConverter
      *
      * // Custom parser
      * $converter = DjotConverter::create(
-     *     parser: new BlockParser(significantNewlines: true),
+     *     parser: new BlockParser(blocksInterruptParagraphs: true),
      *     renderer: new HtmlRenderer(xhtml: true),
      * );
      * ```

--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -142,10 +142,11 @@ class BlockParser
     protected array $customBlockPatterns = [];
 
     /**
-     * When true, a top-level block element (list, blockquote, heading, fence)
-     * may interrupt a paragraph without a preceding blank line. This is the
-     * behavior the now-deprecated significantNewlines flag exposed for the
-     * top level; it also governs the lone-marker rule.
+     * When true, a top-level block element (lists, blockquotes, headings,
+     * tables, thematic breaks, and code/div/comment fences) may interrupt a
+     * paragraph without a preceding blank line. This is the behavior the
+     * now-deprecated significantNewlines flag exposed for the top level; it
+     * also governs the lone-marker rule.
      */
     protected bool $blocksInterruptParagraphs = false;
 

--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -142,15 +142,12 @@ class BlockParser
     protected array $customBlockPatterns = [];
 
     /**
-     * When true, enables "significant newlines" mode:
-     * - Block elements can interrupt paragraphs without blank lines
-     * - Nested blocks in lists don't need blank lines
-     * - More markdown-like, chat-friendly parsing
-     *
-     * This deviates from djot spec but provides more intuitive behavior
-     * for chat messages, comments, and quick notes.
+     * When true, a top-level block element (list, blockquote, heading, fence)
+     * may interrupt a paragraph without a preceding blank line. This is the
+     * behavior the now-deprecated significantNewlines flag exposed for the
+     * top level; it also governs the lone-marker rule.
      */
-    protected bool $significantNewlines = false;
+    protected bool $blocksInterruptParagraphs = false;
 
     /**
      * When true, indentation alone can introduce nested blocks inside list items
@@ -163,10 +160,12 @@ class BlockParser
         bool $strictMode = false,
         bool $significantNewlines = false,
         bool $nestedBlocksInLists = false,
+        bool $blocksInterruptParagraphs = false,
     ) {
         $this->collectWarnings = $collectWarnings;
         $this->strictMode = $strictMode;
-        $this->significantNewlines = $significantNewlines;
+        // significantNewlines is the deprecated union of the two granular levers.
+        $this->blocksInterruptParagraphs = $blocksInterruptParagraphs || $significantNewlines;
         $this->nestedBlocksInLists = $nestedBlocksInLists || $significantNewlines;
         $this->inlineParser = new InlineParser($this);
         $this->listParser = new ListParser();
@@ -175,31 +174,46 @@ class BlockParser
     }
 
     /**
-     * Enable or disable significant newlines mode
+     * Enable or disable significant newlines mode.
      *
-     * When enabled:
-     * - Lists, blockquotes, code blocks can interrupt paragraphs
-     * - Nested blocks in list items don't need preceding blank lines
-     * - Indentation alone triggers block nesting
-     *
-     * This provides markdown-like behavior for chat and quick note use cases.
+     * @deprecated Use setBlocksInterruptParagraphs() and/or
+     *   setNestedBlocksInLists(). significantNewlines is the union of both.
      */
     public function setSignificantNewlines(bool $value): self
     {
-        $this->significantNewlines = $value;
-        if ($value) {
-            $this->nestedBlocksInLists = true;
-        }
+        $this->blocksInterruptParagraphs = $value;
+        $this->nestedBlocksInLists = $value;
 
         return $this;
     }
 
     /**
-     * Check if significant newlines mode is enabled
+     * Check if significant newlines mode is enabled.
+     *
+     * @deprecated Use getBlocksInterruptParagraphs() / getNestedBlocksInLists().
+     *   Returns the top-level interruption bit for backward compatibility.
      */
     public function getSignificantNewlines(): bool
     {
-        return $this->significantNewlines;
+        return $this->blocksInterruptParagraphs;
+    }
+
+    /**
+     * Enable or disable top-level paragraph interruption by block elements.
+     */
+    public function setBlocksInterruptParagraphs(bool $value): self
+    {
+        $this->blocksInterruptParagraphs = $value;
+
+        return $this;
+    }
+
+    /**
+     * Check if top-level paragraph interruption is enabled.
+     */
+    public function getBlocksInterruptParagraphs(): bool
+    {
+        return $this->blocksInterruptParagraphs;
     }
 
     /**
@@ -3132,8 +3146,8 @@ class BlockParser
             return true;
         }
 
-        // In significantNewlines mode, block elements can interrupt paragraphs
-        if ($this->significantNewlines) {
+        // When enabled, block elements can interrupt paragraphs without a blank line
+        if ($this->blocksInterruptParagraphs) {
             return $this->startsNewBlockSignificant($line, $lines, $index);
         }
 

--- a/tests/TestCase/BlocksInterruptParagraphsOptionTest.php
+++ b/tests/TestCase/BlocksInterruptParagraphsOptionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Djot\Test\TestCase;
 
+use Djot\DjotConverter;
 use Djot\Node\Block\ListBlock;
 use Djot\Node\Block\Paragraph;
 use Djot\Parser\BlockParser;
@@ -100,5 +101,40 @@ class BlocksInterruptParagraphsOptionTest extends TestCase
         $parser->setNestedBlocksInLists(false);
         $this->assertTrue($parser->getSignificantNewlines());
         $this->assertFalse($parser->getNestedBlocksInLists());
+    }
+
+    public function testConverterConstructorParameter(): void
+    {
+        $converter = new DjotConverter(blocksInterruptParagraphs: true);
+        $result = $converter->convert("Here:\n- one\n- two");
+
+        $this->assertStringContainsString('<p>Here:</p>', $result);
+        $this->assertStringContainsString('<ul>', $result);
+    }
+
+    public function testConverterFactory(): void
+    {
+        $converter = DjotConverter::withBlocksInterruptParagraphs();
+        $result = $converter->convert("Here:\n- one\n- two");
+
+        $this->assertStringContainsString('<ul>', $result);
+    }
+
+    public function testConverterFactoryDoesNotNest(): void
+    {
+        $converter = DjotConverter::withBlocksInterruptParagraphs();
+        $result = $converter->convert("- a\n  - b");
+
+        // Interruption-only must not nest: exactly one <ul>.
+        $this->assertSame(1, substr_count($result, '<ul>'));
+    }
+
+    public function testWithSignificantNewlinesStillEnablesBoth(): void
+    {
+        $converter = DjotConverter::withSignificantNewlines();
+        $result = $converter->convert("- a\n  - b");
+
+        // significantNewlines still nests: two <ul>.
+        $this->assertSame(2, substr_count($result, '<ul>'));
     }
 }

--- a/tests/TestCase/BlocksInterruptParagraphsOptionTest.php
+++ b/tests/TestCase/BlocksInterruptParagraphsOptionTest.php
@@ -40,6 +40,18 @@ class BlocksInterruptParagraphsOptionTest extends TestCase
         $this->assertInstanceOf(ListBlock::class, $children[1]);
     }
 
+    public function testParagraphNotInterruptedWhenDisabled(): void
+    {
+        // Default: blocksInterruptParagraphs is off, so a list after prose
+        // (no blank line) stays inside the paragraph.
+        $parser = new BlockParser();
+        $doc = $parser->parse("Here:\n- one\n- two");
+
+        $children = $doc->getChildren();
+        $this->assertCount(1, $children);
+        $this->assertInstanceOf(Paragraph::class, $children[0]);
+    }
+
     public function testInterruptionWithoutNesting(): void
     {
         // blocksInterruptParagraphs alone must NOT enable list nesting:

--- a/tests/TestCase/BlocksInterruptParagraphsOptionTest.php
+++ b/tests/TestCase/BlocksInterruptParagraphsOptionTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Test\TestCase;
+
+use Djot\Node\Block\ListBlock;
+use Djot\Node\Block\Paragraph;
+use Djot\Parser\BlockParser;
+use PHPUnit\Framework\TestCase;
+
+class BlocksInterruptParagraphsOptionTest extends TestCase
+{
+    public function testConstructorParameter(): void
+    {
+        $parser = new BlockParser(blocksInterruptParagraphs: true);
+        $this->assertTrue($parser->getBlocksInterruptParagraphs());
+        $this->assertFalse($parser->getNestedBlocksInLists());
+        // Deprecated getter returns the interruption bit (pure rename).
+        $this->assertTrue($parser->getSignificantNewlines());
+    }
+
+    public function testSetterAndGetter(): void
+    {
+        $parser = new BlockParser();
+        $result = $parser->setBlocksInterruptParagraphs(true);
+        $this->assertSame($parser, $result);
+        $this->assertTrue($parser->getBlocksInterruptParagraphs());
+        $this->assertFalse($parser->getNestedBlocksInLists());
+    }
+
+    public function testTopLevelParagraphInterruptionEnabled(): void
+    {
+        $parser = new BlockParser(blocksInterruptParagraphs: true);
+        $doc = $parser->parse("Here:\n- one\n- two");
+
+        $children = $doc->getChildren();
+        $this->assertCount(2, $children);
+        $this->assertInstanceOf(Paragraph::class, $children[0]);
+        $this->assertInstanceOf(ListBlock::class, $children[1]);
+    }
+
+    public function testInterruptionWithoutNesting(): void
+    {
+        // blocksInterruptParagraphs alone must NOT enable list nesting:
+        // "- a\n  - b" stays a single list (b is continuation text).
+        $parser = new BlockParser(blocksInterruptParagraphs: true);
+        $doc = $parser->parse("- a\n  - b");
+
+        $list = $doc->getChildren()[0];
+        $this->assertInstanceOf(ListBlock::class, $list);
+        $item = $list->getChildren()[0];
+        foreach ($item->getChildren() as $child) {
+            $this->assertNotInstanceOf(ListBlock::class, $child);
+        }
+    }
+
+    public function testLoneMarkerRuleStillApplies(): void
+    {
+        $parser = new BlockParser(blocksInterruptParagraphs: true);
+        $doc = $parser->parse("x = 5\n- 3 + 17");
+
+        $children = $doc->getChildren();
+        $this->assertCount(1, $children);
+        $this->assertInstanceOf(Paragraph::class, $children[0]);
+    }
+
+    public function testSignificantNewlinesEnablesBothLevers(): void
+    {
+        $parser = new BlockParser(significantNewlines: true);
+        $this->assertTrue($parser->getBlocksInterruptParagraphs());
+        $this->assertTrue($parser->getNestedBlocksInLists());
+    }
+
+    public function testSetSignificantNewlinesFalseDisablesBoth(): void
+    {
+        $parser = new BlockParser(significantNewlines: true);
+        $parser->setSignificantNewlines(false);
+        $this->assertFalse($parser->getBlocksInterruptParagraphs());
+        $this->assertFalse($parser->getNestedBlocksInLists());
+    }
+
+    public function testGetSignificantNewlinesReflectsInterruptionBit(): void
+    {
+        // BC: significantNewlines then turning nesting off must keep the
+        // deprecated getter returning true (it tracks the interruption bit).
+        $parser = new BlockParser(significantNewlines: true);
+        $parser->setNestedBlocksInLists(false);
+        $this->assertTrue($parser->getSignificantNewlines());
+        $this->assertFalse($parser->getNestedBlocksInLists());
+    }
+}


### PR DESCRIPTION
## Summary

Split the parser's `significantNewlines` option into independent levers and soft-deprecate the wrapper. This follows up #192, which extracted `nestedBlocksInLists`.

## Changes

- Add a `blocksInterruptParagraphs` parser lever: top-level block elements (lists, blockquotes, headings, fences) can interrupt a paragraph without a blank line — the lone-marker rule applies here too.
- `blocksInterruptParagraphs` and `nestedBlocksInLists` are now fully independent levers (each works without the other).
- `significantNewlines` becomes a soft-deprecated convenience equal to both granular levers:
  - Still works; deprecation is a docblock annotation only (no runtime warning).
  - Constructor/setter enable both flags; `setSignificantNewlines(false)` disables both.
  - `getSignificantNewlines()` returns the interruption bit (pure rename of the old field) for backward compatibility.
- New `DjotConverter::withBlocksInterruptParagraphs()` factory and constructor parameter; `BlockParser::setBlocksInterruptParagraphs()` / `getBlocksInterruptParagraphs()`.

## Docs

- New "Block Interrupts Paragraphs Mode" section in `docs/guide/parser-options.md`, with verified output and an independence example.
- API reference updated (constructor param, factory, BlockParser accessors).
- Deprecation note and migration snippet added for `significantNewlines` (`significantNewlines: true` becomes `blocksInterruptParagraphs: true, nestedBlocksInLists: true`).

## Backward compatibility

No breaking change. Existing `significantNewlines` users see identical behavior; the new lever is opt-in and appended last in both constructors.
