### PR TITLE
Fix numeric reference label warnings

### DIFF
--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -3407,7 +3407,7 @@ class BlockParser
             if (
                 !isset($this->usedReferences[$label])
                 && !str_starts_with($def->url, '#')
-                && !str_starts_with($label, '^')
+                && !str_starts_with((string)$label, '^')
             ) {
                 $this->addWarning(
                     "Reference '{$label}' defined but never used",

--- a/tests/TestCase/DjotConverterTest.php
+++ b/tests/TestCase/DjotConverterTest.php
@@ -3183,6 +3183,17 @@ DJOT;
         $this->assertSame('reference', $warnings[0]->getCategory());
     }
 
+    public function testUnusedNumericReferenceWarning(): void
+    {
+        $converter = new DjotConverter(warnings: true);
+        $converter->convert("Some text.\n\n[1]: https://example.com");
+
+        $warnings = $converter->getWarnings();
+        $this->assertCount(1, $warnings);
+        $this->assertStringContainsString("Reference '1' defined but never used", $warnings[0]->getMessage());
+        $this->assertSame('reference', $warnings[0]->getCategory());
+    }
+
     public function testNoUnusedWarningForUsedReference(): void
     {
         $converter = new DjotConverter(warnings: true);


### PR DESCRIPTION
## Summary
- cast reference labels to string before checking for footnote prefixes
- add regression coverage for unused numeric reference labels

## Why
PHP casts numeric string array keys to integers. A reference definition such as `[1]: https://example.com` can therefore make the reference label an `int` while validating unused references, causing `str_starts_with()` to throw on PHP 8+.

## Testing
- `composer test -- --filter UnusedNumericReferenceWarning`
- `composer test`
- `composer cs-check -- --standard=phpcs.xml src/Parser/BlockParser.php tests/TestCase/DjotConverterTest.php`