### PR TITLE
Fix PHPCS union type ordering

### DIFF
--- a/src/DjotConverter.php
+++ b/src/DjotConverter.php
@@ -135,7 +135,7 @@ class DjotConverter
         bool $xhtml = false,
         bool $warnings = false,
         bool $strict = false,
-        bool|SafeMode|null $safeMode = null,
+        SafeMode|bool|null $safeMode = null,
         ?Profile $profile = null,
         bool $significantNewlines = false,
         ?SoftBreakMode $softBreakMode = null,
@@ -209,7 +209,7 @@ class DjotConverter
         bool $xhtml = false,
         bool $warnings = false,
         bool $strict = false,
-        bool|SafeMode|null $safeMode = null,
+        SafeMode|bool|null $safeMode = null,
         ?Profile $profile = null,
         ?SoftBreakMode $softBreakMode = null,
         bool $roundTripMode = false,
@@ -236,7 +236,7 @@ class DjotConverter
         bool $xhtml = false,
         bool $warnings = false,
         bool $strict = false,
-        bool|SafeMode|null $safeMode = null,
+        SafeMode|bool|null $safeMode = null,
         ?Profile $profile = null,
         ?SoftBreakMode $softBreakMode = null,
         bool $roundTripMode = false,
@@ -272,7 +272,7 @@ class DjotConverter
         bool $xhtml = false,
         bool $warnings = false,
         bool $strict = false,
-        bool|SafeMode|null $safeMode = null,
+        SafeMode|bool|null $safeMode = null,
         ?Profile $profile = null,
         ?SoftBreakMode $softBreakMode = null,
         bool $roundTripMode = false,
@@ -294,7 +294,7 @@ class DjotConverter
      *
      * @param \Djot\SafeMode|bool|null $safeMode True for defaults, SafeMode for custom, null/false to disable
      */
-    public function setSafeMode(bool|SafeMode|null $safeMode): self
+    public function setSafeMode(SafeMode|bool|null $safeMode): self
     {
         if (!$this->renderer instanceof HtmlRenderer) {
             return $this;

--- a/src/Extension/AdmonitionExtension.php
+++ b/src/Extension/AdmonitionExtension.php
@@ -135,7 +135,7 @@ class AdmonitionExtension implements ExtensionInterface
         protected string $titleTag = 'p',
         protected string $titleClass = 'admonition-title',
         protected string $containerClass = 'admonition',
-        bool|array $icons = false,
+        array|bool $icons = false,
         protected string $iconClass = 'admonition-icon',
     ) {
         $this->resolvedIcons = $this->resolveIcons($icons);
@@ -148,7 +148,7 @@ class AdmonitionExtension implements ExtensionInterface
      *
      * @return array<string, string>
      */
-    protected function resolveIcons(bool|array $icons): array
+    protected function resolveIcons(array|bool $icons): array
     {
         if ($icons === false) {
             return [];

--- a/src/Extension/CitationsExtension.php
+++ b/src/Extension/CitationsExtension.php
@@ -42,7 +42,7 @@ class CitationsExtension implements ExtensionInterface, BeforeRenderExtensionInt
      * @param string $cssClass CSS classes added to parsed citation spans
      */
     public function __construct(
-        callable|Closure|null $resolver = null,
+        Closure|callable|null $resolver = null,
         protected string $cssClass = 'citation',
     ) {
         $this->resolver = $resolver !== null ? Closure::fromCallable($resolver) : null;


### PR DESCRIPTION
## Summary
- apply PHPCS auto-fixes for union type ordering after dependency update
- fix coding-standard drift in DjotConverter, AdmonitionExtension, and CitationsExtension

## Testing
- `composer update --no-interaction`
- `composer cs-fix`
- `composer cs-check`
- `composer test`