### PR TITLE
Fix sequential list item attributes

### DIFF
--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -1837,7 +1837,7 @@ class BlockParser
             // block inside the item. This keeps the list / item intact instead
             // of terminating it on a mid-item {...} line.
             $itemAttributes = [];
-            $attrPushedBack = false;
+            $parseItemLinesAsBlocks = false;
             if ($i < $count) {
                 $potentialAttrLine = $lines[$i];
                 $trimmedAttrLine = ltrim($potentialAttrLine);
@@ -1858,7 +1858,58 @@ class BlockParser
                         }
                     }
 
-                    if ($hasMoreItemContent) {
+                    // @todo #189: Default mode still treats tight nested-list
+                    // markers as continuation text here. nestedBlocksInLists
+                    // handles the natural nested-item/block-attribute case.
+                    $peekLineIsAttribute = $hasMoreItemContent
+                        && preg_match('/^\{([^{}]+)\}\s*$/', ltrim($lines[$i + 1]), $peekAttrMatch);
+
+                    if ($peekLineIsAttribute) {
+                        $itemAttributes = AttributeParser::parseAndMerge($itemAttributes, $attrMatch[1]);
+                        $itemAttributes = AttributeParser::parseAndMerge($itemAttributes, $peekAttrMatch[1]);
+                        $i += 2;
+
+                        while ($i < $count) {
+                            $contLine = $lines[$i];
+                            if (IndentationHelper::isBlankLine($contLine)) {
+                                break;
+                            }
+                            $contIndent = IndentationHelper::getLeadingSpaces($contLine);
+                            if ($contIndent < $contentIndent) {
+                                break;
+                            }
+                            $contTrimmed = ltrim($contLine);
+                            if (!preg_match('/^\{([^{}]+)\}\s*$/', $contTrimmed, $contAttrMatch)) {
+                                break;
+                            }
+                            $itemAttributes = AttributeParser::parseAndMerge($itemAttributes, $contAttrMatch[1]);
+                            $i++;
+                        }
+
+                        if ($i < $count && !IndentationHelper::isBlankLine($lines[$i])) {
+                            $contIndent = IndentationHelper::getLeadingSpaces($lines[$i]);
+                            if ($contIndent >= $contentIndent) {
+                                if ($itemLines !== [] && $itemLines[array_key_last($itemLines)] !== '') {
+                                    $itemLines[] = '';
+                                }
+                                $hasNonMarkerContinuation = true;
+                                $parseItemLinesAsBlocks = true;
+                                while ($i < $count) {
+                                    $contLine = $lines[$i];
+                                    if (IndentationHelper::isBlankLine($contLine)) {
+                                        break;
+                                    }
+                                    $contIndent = IndentationHelper::getLeadingSpaces($contLine);
+                                    if ($contIndent >= $contentIndent) {
+                                        $itemLines[] = IndentationHelper::stripLeadingIndent($contLine, $contentIndent);
+                                        $i++;
+                                    } else {
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    } elseif ($hasMoreItemContent) {
                         // {...} is not the item's attribute — it is a block
                         // attribute for the next block in the item. Push it back
                         // into itemLines (stripped of the item's content indent)
@@ -1874,7 +1925,7 @@ class BlockParser
                         }
                         $itemLines[] = IndentationHelper::stripLeadingIndent($potentialAttrLine, $contentIndent);
                         $hasNonMarkerContinuation = true;
-                        $attrPushedBack = true;
+                        $parseItemLinesAsBlocks = true;
                         $i++;
                         while ($i < $count) {
                             $contLine = $lines[$i];
@@ -1905,7 +1956,7 @@ class BlockParser
             // still allowing blockquotes, code blocks, etc. to be properly recognized.
             if ($hasNonMarkerContinuation) {
                 $firstLine = $itemLines[0];
-                if ($attrPushedBack || $this->isBlockElementStart($firstLine)) {
+                if ($parseItemLinesAsBlocks || $this->isBlockElementStart($firstLine)) {
                     // Content starts with a block element (blockquote, code fence,
                     // etc.) or we pushed a {...} back into itemLines that must be
                     // recognized as a block attribute for the next block.

--- a/tests/TestCase/DjotConverterTest.php
+++ b/tests/TestCase/DjotConverterTest.php
@@ -1092,6 +1092,24 @@ DJOT;
         $this->assertStringContainsString('<li class="x">', $result);
     }
 
+    public function testSequentialListItemAttributesAreMerged(): void
+    {
+        $djot = "- item\n  {.x}\n  {.y}\n";
+
+        $result = $this->converter->convert($djot);
+
+        $this->assertStringContainsString('<li class="x y">', $result);
+    }
+
+    public function testMultipleSequentialListItemAttributesAreMerged(): void
+    {
+        $djot = "- item\n  {.a}\n  {.b}\n  {.c}\n";
+
+        $result = $this->converter->convert($djot);
+
+        $this->assertStringContainsString('<li class="a b c">', $result);
+    }
+
     public function testListItemAttributesLooseListUnchanged(): void
     {
         // G2 regression guard: blank-line separator (loose item) keeps

--- a/tests/TestCase/NestedBlocksInListsOptionTest.php
+++ b/tests/TestCase/NestedBlocksInListsOptionTest.php
@@ -70,6 +70,17 @@ class NestedBlocksInListsOptionTest extends TestCase
         $this->assertInstanceOf(BlockQuote::class, $children[1]);
     }
 
+    public function testNestedListItemAttributeBeforeBlockquote(): void
+    {
+        $converter = DjotConverter::withNestedBlocksInLists();
+        $result = $converter->convert("- outer\n  - inner\n    {.x}\n    > q\n");
+
+        $this->assertSame(2, substr_count($result, '<ul>'));
+        $this->assertStringContainsString('<blockquote class="x">', $result);
+        $this->assertStringContainsString('<p>q</p>', $result);
+        $this->assertStringNotContainsString('&gt; q', $result);
+    }
+
     public function testConverterHelperKeepsTopLevelSpecBehavior(): void
     {
         $converter = DjotConverter::withNestedBlocksInLists();


### PR DESCRIPTION
## Summary
- merge consecutive list-item attribute lines onto the same `<li>` instead of dropping them as orphan pending attributes
- keep the existing single-attribute-followed-by-block behavior intact
- add regression coverage for the nestedBlocksInLists inner blockquote case and document the remaining default-mode tight nested-list TODO

Closes #189.

## Tests
- `vendor/bin/phpunit`
- `composer stan`
- `composer cs-check`
- `git diff --check`