### PR TITLE
Tighten ref/footnote/abbrev whitespace; support div attribute opener

### DIFF
--- a/src/Parser/Block/FencedBlockParser.php
+++ b/src/Parser/Block/FencedBlockParser.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Djot\Parser\Block;
 
+use Djot\Parser\Utility\AttributeParser;
+
 /**
  * Parser utilities for fenced blocks (code blocks, divs, raw blocks).
  *
@@ -75,9 +77,13 @@ class FencedBlockParser
     /**
      * Check if a line opens a div fence.
      *
+     * Supports two opener styles:
+     * - Bareword class: `::: foo` (spec)
+     * - Attribute block: `::: {#id .foo}` (extension, lenient parse)
+     *
      * @param string $line The line to check
      *
-     * @return array{fence: string, length: int, className: string}|null
+     * @return array{fence: string, length: int, className: string, attributes: array<string, string>}|null
      */
     public function parseDivFenceOpener(string $line): ?array
     {
@@ -86,15 +92,32 @@ class FencedBlockParser
             return null;
         }
 
-        // Match opening fence: 3+ colons with optional class
+        // Match opening fence: 3+ colons with optional class or attribute block
         if (!preg_match('/^(:{3,})\s*(.*)$/', $line, $matches)) {
             return null;
+        }
+
+        $tail = trim($matches[2]);
+        $className = '';
+        $attributes = [];
+
+        if ($tail !== '') {
+            if (str_starts_with($tail, '{') && str_ends_with($tail, '}')) {
+                $attributes = AttributeParser::parse(substr($tail, 1, -1));
+                if (isset($attributes['class'])) {
+                    $className = $attributes['class'];
+                    unset($attributes['class']);
+                }
+            } else {
+                $className = $tail;
+            }
         }
 
         return [
             'fence' => $matches[1],
             'length' => strlen($matches[1]),
-            'className' => trim($matches[2]),
+            'className' => $className,
+            'attributes' => $attributes,
         ];
     }
 

--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -453,11 +453,11 @@ class BlockParser
                 continue;
             }
 
-            // Match reference definition: [label]: url (url can be empty, on next line)
-            if (preg_match('/^\[([^\]]+)\]:\s*(.*)$/', $line, $matches)) {
+            // Match reference definition: [label]: url (requires whitespace after colon, url can be empty)
+            if (preg_match('/^\[([^\]]+)\]:(?:[ \t]+(.*))?[ \t]*$/', $line, $matches)) {
                 // Normalize label: collapse whitespace, trim
                 $label = preg_replace('/\s+/', ' ', trim($matches[1]));
-                $url = trim($matches[2]);
+                $url = trim($matches[2] ?? '');
 
                 // Collect continuation lines (URL can start on continuation line)
                 $j = $i + 1;
@@ -467,7 +467,7 @@ class BlockParser
                         break;
                     }
                     // Check if next line starts a new reference definition
-                    if (preg_match('/^\[([^\]]+)\]:/', $nextLine)) {
+                    if (preg_match('/^\[([^\]]+)\]:(?=[ \t]|$)/', $nextLine)) {
                         break;
                     }
                     if ($this->startsNewBlock($nextLine)) {
@@ -510,10 +510,10 @@ class BlockParser
         while ($i < $count) {
             $line = $lines[$i];
 
-            // Match footnote definition: [^label]: content
-            if (preg_match('/^\[\^([^\]]+)\]:\s*(.*)$/', $line, $matches)) {
+            // Match footnote definition: [^label]: content (requires whitespace after colon)
+            if (preg_match('/^\[\^([^\]]+)\]:(?:[ \t]+(.*))?[ \t]*$/', $line, $matches)) {
                 $label = $matches[1];
-                $content = $matches[2];
+                $content = $matches[2] ?? '';
 
                 // Determine base indentation (2 spaces for footnotes)
                 $baseIndent = 2;
@@ -584,10 +584,10 @@ class BlockParser
         while ($i < $count) {
             $line = $lines[$i];
 
-            // Match abbreviation definition: *[abbr]: definition
-            if (preg_match('/^\*\[([^\]]+)\]:\s*(.*)$/', $line, $matches)) {
+            // Match abbreviation definition: *[abbr]: definition (requires whitespace after colon)
+            if (preg_match('/^\*\[([^\]]+)\]:(?:[ \t]+(.*))?[ \t]*$/', $line, $matches)) {
                 $abbr = $matches[1];
-                $definition = trim($matches[2]);
+                $definition = trim($matches[2] ?? '');
 
                 // Collect continuation lines (indented)
                 $j = $i + 1;
@@ -597,7 +597,7 @@ class BlockParser
                         break;
                     }
                     // Check if next line starts a new abbreviation definition
-                    if (preg_match('/^\*\[([^\]]+)\]:/', $nextLine)) {
+                    if (preg_match('/^\*\[([^\]]+)\]:(?=[ \t]|$)/', $nextLine)) {
                         break;
                     }
                     if ($this->startsNewBlock($nextLine)) {
@@ -926,7 +926,7 @@ class BlockParser
             while ($nextIdx < $count && IndentationHelper::isBlankLine($lines[$nextIdx])) {
                 $nextIdx++;
             }
-            if ($nextIdx < $count && preg_match('/^\[([^\]]+)\]:/', $lines[$nextIdx])) {
+            if ($nextIdx < $count && preg_match('/^\[([^\]]+)\]:(?=[ \t]|$)/', $lines[$nextIdx])) {
                 // Attributes precede a reference definition, don't store them as block attrs
                 return 1;
             }
@@ -1284,10 +1284,15 @@ class BlockParser
 
         $fenceLength = $divInfo['length'];
         $className = $divInfo['className'];
+        $openerAttributes = $divInfo['attributes'];
 
         $div = new Div();
         if ($className !== '') {
-            $div->addClass($className);
+            foreach (preg_split('/\s+/', $className) ?: [] as $class) {
+                if ($class !== '') {
+                    $div->addClass($class);
+                }
+            }
         }
 
         // Save and clear pending attributes - they apply to the div, not inner content
@@ -1350,6 +1355,11 @@ class BlockParser
         $this->lineOffset = $previousOffset + $start + 1;
         $this->parseBlocks($div, $innerLines, 0);
         $this->lineOffset = $previousOffset;
+
+        // Apply opener-line attributes (from `::: {#id .class key=value}` syntax)
+        foreach ($openerAttributes as $name => $value) {
+            $div->setAttribute($name, $value);
+        }
 
         // Apply the saved attributes to the div, merging classes instead of replacing
         foreach ($divAttributes as $name => $value) {
@@ -2886,8 +2896,8 @@ class BlockParser
     {
         $line = $lines[$start];
 
-        // Match footnote definition: [^label]: content
-        if (!preg_match('/^\[\^([^\]]+)\]:\s*/', $line)) {
+        // Match footnote definition: [^label]: content (requires whitespace after colon)
+        if (!preg_match('/^\[\^([^\]]+)\]:(?=[ \t]|$)/', $line)) {
             return null;
         }
 
@@ -2922,8 +2932,8 @@ class BlockParser
     {
         $line = $lines[$start];
 
-        // Match reference definition: [label]: url (url can be empty, on next line)
-        if (!preg_match('/^\[([^\]]+)\]:\s*(.*)$/', $line, $matches)) {
+        // Match reference definition: [label]: url (requires whitespace after colon, url can be empty)
+        if (!preg_match('/^\[([^\]]+)\]:(?:[ \t]+(.*))?[ \t]*$/', $line, $matches)) {
             return null;
         }
 
@@ -2937,7 +2947,7 @@ class BlockParser
                 break;
             }
             // Check if next line starts a new reference definition
-            if (preg_match('/^\[([^\]]+)\]:/', $nextLine)) {
+            if (preg_match('/^\[([^\]]+)\]:(?=[ \t]|$)/', $nextLine)) {
                 break;
             }
             if ($this->startsNewBlock($nextLine)) {
@@ -2963,8 +2973,8 @@ class BlockParser
     {
         $line = $lines[$start];
 
-        // Match abbreviation definition: *[abbr]: definition
-        if (!preg_match('/^\*\[([^\]]+)\]:\s*/', $line)) {
+        // Match abbreviation definition: *[abbr]: definition (requires whitespace after colon)
+        if (!preg_match('/^\*\[([^\]]+)\]:(?=[ \t]|$)/', $line)) {
             return null;
         }
 
@@ -2978,7 +2988,7 @@ class BlockParser
                 break;
             }
             // Check if next line starts a new abbreviation definition
-            if (preg_match('/^\*\[([^\]]+)\]:/', $nextLine)) {
+            if (preg_match('/^\*\[([^\]]+)\]:(?=[ \t]|$)/', $nextLine)) {
                 break;
             }
             if ($this->startsNewBlock($nextLine)) {

--- a/tests/TestCase/Parser/BlockParserTest.php
+++ b/tests/TestCase/Parser/BlockParserTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Djot\Test\TestCase\Parser;
 
+use Djot\DjotConverter;
 use Djot\Node\Block\BlockQuote;
 use Djot\Node\Block\CodeBlock;
 use Djot\Node\Block\DefinitionList;
@@ -361,6 +362,77 @@ DJOT;
         // Nested div should have both 'warning' and 'custom-nested' merged
         $this->assertStringContainsString('warning', $nestedClass);
         $this->assertStringContainsString('custom-nested', $nestedClass);
+    }
+
+    public function testParseFencedDivWithAttributeBlockOnOpener(): void
+    {
+        // ::: {.foo} on the opener line should be parsed as attributes,
+        // not as a literal class name "{.foo}"
+        $doc = $this->parser->parse("::: {.note}\nContent\n:::");
+
+        $div = $doc->getChildren()[0];
+        $this->assertInstanceOf(Div::class, $div);
+        $this->assertSame('note', $div->getAttribute('class'));
+    }
+
+    public function testParseFencedDivWithIdAndClassOnOpener(): void
+    {
+        $doc = $this->parser->parse("::: {#warn .alert .red}\nContent\n:::");
+
+        $div = $doc->getChildren()[0];
+        $this->assertInstanceOf(Div::class, $div);
+        $this->assertSame('warn', $div->getAttribute('id'));
+        $class = $div->getAttribute('class') ?? '';
+        $this->assertStringContainsString('alert', $class);
+        $this->assertStringContainsString('red', $class);
+    }
+
+    public function testParseFencedDivWithKeyValueOnOpener(): void
+    {
+        $doc = $this->parser->parse("::: {.foo data-x=\"1\"}\nContent\n:::");
+
+        $div = $doc->getChildren()[0];
+        $this->assertInstanceOf(Div::class, $div);
+        $this->assertSame('foo', $div->getAttribute('class'));
+        $this->assertSame('1', $div->getAttribute('data-x'));
+    }
+
+    public function testReferenceDefinitionRequiresWhitespaceAfterColon(): void
+    {
+        // [foo]:bar (no whitespace) should NOT define a reference -
+        // it should be rendered as a paragraph instead.
+        $converter = new DjotConverter();
+        $html = $converter->convert("[foo]:bar\n\n[link][foo]");
+
+        $this->assertStringNotContainsString('href="bar"', $html);
+        $this->assertStringContainsString('[foo]:bar', $html);
+    }
+
+    public function testReferenceDefinitionAcceptsWhitespaceAfterColon(): void
+    {
+        $converter = new DjotConverter();
+        $html = $converter->convert("[foo]: bar\n\n[link][foo]");
+
+        $this->assertStringContainsString('href="bar"', $html);
+    }
+
+    public function testFootnoteDefinitionRequiresWhitespaceAfterColon(): void
+    {
+        // [^a]:content (no whitespace) should NOT define a footnote.
+        $converter = new DjotConverter();
+        $html = $converter->convert("Text[^a]\n\n[^a]:content");
+
+        // Without whitespace the line is not consumed as a footnote definition.
+        $this->assertStringNotContainsString('<p>content', $html);
+    }
+
+    public function testAbbreviationDefinitionRequiresWhitespaceAfterColon(): void
+    {
+        $converter = new DjotConverter();
+        $html = $converter->convert("Use ABBR here.\n\n*[ABBR]:no-space-here");
+
+        $this->assertStringNotContainsString('<abbr', $html);
+        $this->assertStringContainsString('*[ABBR]:no-space-here', $html);
     }
 
     public function testParseTable(): void


### PR DESCRIPTION
## Summary

Closes two upstream-parity gaps identified while auditing djot-php against recent jgm/djot activity.

### 1. Reference / footnote / abbreviation definitions now require whitespace after the colon

Aligns with [jgm/djot.js#107](https://github.com/jgm/djot.js/pull/107) (merged Feb 2025) and [jgm/djot#106](https://github.com/jgm/djot/issues/106).

| Input | Before | After |
|---|---|---|
| `[foo]:bar` | defines reference `foo` → `bar` | rendered as paragraph text |
| `[foo]: bar` | unchanged | unchanged |
| `[^a]:body` | defines footnote | rendered as paragraph text |
| `*[ABBR]:text` | defines abbreviation | rendered as paragraph text |

The continuation form (`[foo]:\n  http://example.com`) still works — empty URL on the definition line with the URL on the next indented line is allowed.

### 2. Fenced div opener accepts `{#id .class}` attribute block

Resolves the literal-attribute bug surfaced while reviewing [jgm/djot#292](https://github.com/jgm/djot/issues/292): `::: {.note}` previously produced `<div class="{.note}">`. Now parses through `AttributeParser`.

| Input | Before | After |
|---|---|---|
| `::: {.note}` | `<div class="{.note}">` | `<div class="note">` |
| `::: {#id .a .b}` | `<div class="{#id .a .b}">` | `<div id="id" class="a b">` |
| `::: {.foo data-x="1"}` | literal | `<div class="foo" data-x="1">` |
| `::: foo` (bareword) | `<div class="foo">` | unchanged |
| `{.foo}\n:::` (block-above) | `<div class="foo">` | unchanged |

This is a lenient extension on top of the spec (which only allows a bareword classname after `:::`). Users who already use the attribute-block-above form are unaffected; users who instinctively typed `::: {.note}` now get the expected result.

## Files changed

- `src/Parser/BlockParser.php` — 11 regex sites tightened (ref/footnote/abbrev definition and lookahead patterns); div opener attributes merged into the resulting `<div>`.
- `src/Parser/Block/FencedBlockParser.php` — `parseDivFenceOpener()` returns parsed attributes when the tail is `{...}`.
- `tests/TestCase/Parser/BlockParserTest.php` — 7 new tests covering both fixes.