### PR TITLE
Reject reference definition URLs with internal whitespace

### DIFF
--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -461,8 +461,11 @@ class BlockParser
                 continue;
             }
 
-            // Match reference definition: [label]: url (requires whitespace after colon, url can be empty)
-            if (preg_match('/^\[([^\]]+)\]:(?:[ \t]+(.*))?[ \t]*$/', $line, $matches)) {
+            // Match reference definition: [label]: url
+            // - whitespace required after colon (jgm/djot.js#107)
+            // - URL must be a single non-whitespace token; trailing junk like Markdown
+            //   `"Title"` makes the line not a reference definition (matches djot.js)
+            if (preg_match('/^\[([^\]]+)\]:(?:[ \t]+(\S*))?[ \t]*$/', $line, $matches)) {
                 // Normalize label: collapse whitespace, trim
                 $label = preg_replace('/\s+/', ' ', trim($matches[1]));
                 $url = trim($matches[2] ?? '');
@@ -2958,8 +2961,9 @@ class BlockParser
     {
         $line = $lines[$start];
 
-        // Match reference definition: [label]: url (requires whitespace after colon, url can be empty)
-        if (!preg_match('/^\[([^\]]+)\]:(?:[ \t]+(.*))?[ \t]*$/', $line, $matches)) {
+        // Match reference definition: [label]: url
+        // URL must be a single non-whitespace token; see extractReferences().
+        if (!preg_match('/^\[([^\]]+)\]:(?:[ \t]+(\S*))?[ \t]*$/', $line, $matches)) {
             return null;
         }
 

--- a/tests/TestCase/Parser/BlockParserTest.php
+++ b/tests/TestCase/Parser/BlockParserTest.php
@@ -426,6 +426,28 @@ DJOT;
         $this->assertStringNotContainsString('<p>content', $html);
     }
 
+    public function testReferenceDefinitionRejectsTrailingTitle(): void
+    {
+        // Markdown-style trailing `"Title"` makes the line invalid as a djot
+        // reference definition (matches djot.js behavior). Previously the
+        // entire tail leaked into the URL.
+        $converter = new DjotConverter();
+        $html = $converter->convert("[bar]: http://x.com \"Title\"\n\n[link][bar]");
+
+        $this->assertStringNotContainsString('&quot;', $html);
+        $this->assertStringNotContainsString('href="http://x.com', $html);
+        $this->assertStringContainsString('[bar]: http://x.com', $html);
+    }
+
+    public function testReferenceDefinitionRejectsUrlWithInternalWhitespace(): void
+    {
+        // URL containing inline whitespace is not a valid reference definition.
+        $converter = new DjotConverter();
+        $html = $converter->convert("[bar]: http://x.com extra-stuff\n\n[link][bar]");
+
+        $this->assertStringNotContainsString('href="http://x.com', $html);
+    }
+
     public function testAbbreviationDefinitionRequiresWhitespaceAfterColon(): void
     {
         $converter = new DjotConverter();


### PR DESCRIPTION
## Summary

Follow-up to #199. Closes the remaining ref-def correctness bug surfaced during the upstream parity audit.

`[bar]: http://x.com "Title"` (or any single-line ref-def whose URL portion contains internal whitespace) previously had the entire tail concatenated into the URL, producing:

    <a href="http://x.com &quot;Title&quot;">link</a>

The djot reference implementation (djot.js) rejects such lines and renders them as paragraphs. This PR aligns with that behavior: the URL captured after `]:` must be a single non-whitespace token, otherwise the line is not a reference definition.

| Input | Before | After |
|---|---|---|
| `[bar]: http://x.com` | works | unchanged |
| `[bar]: http://x.com "Title"` | URL = `http://x.com "Title"` | not a ref def — rendered as paragraph |
| `[bar]: http://x.com extra` | URL = `http://x.com extra` | not a ref def — rendered as paragraph |
| `[bar]:` then indented `http://x.com/path` | continuation-line URL | unchanged |

Footnote (`[^a]: body`) and abbreviation (`*[ABBR]: full text`) definitions are untouched — their bodies legitimately contain whitespace.

## Files changed

- `src/Parser/BlockParser.php` — two ref-def regexes (extract + skip) tightened from `(.*)` to `(\S*)`.
- `tests/TestCase/Parser/BlockParserTest.php` — two new tests.