### PR TITLE
Spike: experimental transclusion/fragment extension (parsed args via host resolver)

### DIFF
--- a/docs/extensions/index.md
+++ b/docs/extensions/index.md
@@ -23,6 +23,7 @@ Extensions provide a clean way to bundle related customizations together. Each e
 | [TabsExtension](#tabsextension) | Transforms divs into accessible tabbed content interfaces |
 | [WikilinksExtension](#wikilinksextension) | Converts `[[Page Name]]` patterns to wiki-style links |
 | [CitationsExtension](#citationsextension) | Parses experimental Pandoc/Citum-style citation groups into semantic inline spans |
+| [TransclusionExtension](#transclusionextension) | Experimental: expands {{name\|args}} fragment calls via a host resolver, with parsed arguments |
 
 ## Basic Usage
 
@@ -1625,6 +1626,88 @@ This extension follows Citum's current experimental Djot direction rather than a
 - Integration guide: https://docs.citum.org/guides/integrations/djot.html
 
 Because upstream Djot citation syntax is still unsettled, prefer this extension for opt-in experiments and integrations, not for long-term format guarantees.
+
+## TransclusionExtension
+
+Expands experimental `{{name|args}}` fragment calls through a host-supplied resolver. This extension is a proof of concept for carrying template arguments as parsed Djot child nodes rather than flat attribute strings. It is not part of the Djot specification; it exists to explore the approach discussed at https://github.com/jgm/djot/discussions/366.
+
+**Syntax:**
+
+```djot
+{{name|pos1|key=value}}
+```
+
+The first segment is the transclusion name. Later segments become `TransclusionArgument` nodes. Arguments can be positional (`pos1`) or named (`key=value`). Argument values are parsed as Djot inline content before the resolver receives them.
+
+This spike has deliberate syntax limits:
+
+- Nested `{{ }}` is not supported.
+- Literal braces inside arguments are not supported.
+- Raw `|` is always the argument separator, so a literal `|` inside an argument is not supported.
+
+**Basic usage:**
+
+```php
+use Djot\DjotConverter;
+use Djot\Extension\TransclusionExtension;
+use Djot\Node\Inline\Span;
+use Djot\Node\Node;
+
+$converter = new DjotConverter();
+$converter->addExtension(new TransclusionExtension(
+    resolver: function (string $name, array $args): ?Node {
+        if ($name !== 'badge') {
+            return null;
+        }
+
+        $span = new Span();
+        $span->addClass('badge');
+        foreach ($args[0]->getChildren() as $child) {
+            $span->appendChild($child);
+        }
+
+        return $span;
+    },
+));
+
+$html = $converter->convert('Status: {{badge|_Draft_}}');
+// Output: <p>Status: <span class="badge"><em>Draft</em></span></p>
+```
+
+### Resolver Contract
+
+The resolver signature is:
+
+```php
+Closure(string $name, array<int, \Djot\Node\Inline\TransclusionArgument> $args): ?\Djot\Node\Node
+```
+
+Return a Djot AST node to replace the invocation, or `null` to leave it unresolved.
+
+Each `TransclusionArgument` provides:
+
+- `getKey(): ?string` returns the named argument key, or `null` for positional arguments.
+- `getIndex(): int` returns the 0-based source-order index. Named and positional arguments both increment it.
+- `isNamed(): bool` returns whether the argument used `key=value` syntax.
+- `getChildren()` returns the parsed inline nodes for the argument value.
+
+Resolver output is not scanned again for nested transclusions in this spike.
+
+### Unresolved Fallback
+
+If no resolver is configured, or the resolver returns `null`, the extension replaces the call with a span containing the literal `{{name}}`:
+
+```html
+<span class="transclusion-unresolved">{{name}}</span>
+```
+
+Customize the fallback class with `unresolvedCssClass`:
+
+```php
+$converter->addExtension(new TransclusionExtension(
+    unresolvedCssClass: 'missing-fragment',
+));
+```
 
 ## Creating Custom Extensions
 

--- a/src/Extension/TransclusionExtension.php
+++ b/src/Extension/TransclusionExtension.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Extension;
+
+use Closure;
+use Djot\DjotConverter;
+use Djot\Node\Document;
+use Djot\Node\Inline\Span;
+use Djot\Node\Inline\Text;
+use Djot\Node\Inline\Transclusion;
+use Djot\Node\Inline\TransclusionArgument;
+use Djot\Node\Node;
+use Djot\Parser\InlineParser;
+
+/**
+ * Experimental transclusion / fragment invocation support for Djot.
+ *
+ * Parses `{{name|positional|key=value}}` calls into a transclusion node whose
+ * arguments contain parsed inline child nodes. Before rendering, a host
+ * resolver may expand the invocation into normal Djot AST nodes:
+ *
+ * ```php
+ * $converter->addExtension(new TransclusionExtension(
+ *     resolver: function (string $name, array $args): ?\Djot\Node\Node {
+ *         return $name === 'example' ? new \Djot\Node\Inline\Span() : null;
+ *     },
+ * ));
+ * ```
+ *
+ * This is an opt-in proof of concept, not official Djot syntax. It exists to
+ * explore template-like fragment calls for https://github.com/jgm/djot/discussions/366.
+ *
+ * Spike limitation: nested `{{ }}` and literal braces inside arguments are not
+ * supported. Raw `|` characters always split arguments.
+ */
+class TransclusionExtension implements BeforeRenderExtensionInterface
+{
+    /**
+     * @param \Closure(string, array<int, \Djot\Node\Inline\TransclusionArgument>): \Djot\Node\Node|null $resolver
+     *     Resolver called with the transclusion name and parsed argument nodes.
+     *     Return a replacement AST node, or null to use the unresolved fallback.
+     * @param string $unresolvedCssClass CSS class for unresolved fallback spans.
+     */
+    public function __construct(
+        protected ?Closure $resolver = null,
+        protected string $unresolvedCssClass = 'transclusion-unresolved',
+    ) {
+    }
+
+    public function register(DjotConverter $converter): void
+    {
+        $inlineParser = $converter->getParser()->getInlineParser();
+
+        $inlineParser->addInlinePattern(
+            '/\{\{([^{}]+)\}\}/',
+            function (string $match, array $groups, InlineParser $parser): Transclusion {
+                $segments = explode('|', $groups[1]);
+                $name = trim($segments[0]);
+                $node = new Transclusion($name);
+
+                foreach (array_slice($segments, 1) as $index => $segment) {
+                    $key = null;
+                    $value = $segment;
+
+                    if (preg_match('/^\s*([A-Za-z0-9_-]+)\s*=(.*)$/s', $segment, $matches)) {
+                        $key = $matches[1];
+                        $value = $matches[2];
+                    }
+
+                    $arg = new TransclusionArgument($key, $index);
+                    $parser->parse($arg, trim($value, " \t"));
+                    $node->appendChild($arg);
+                }
+
+                return $node;
+            },
+        );
+    }
+
+    public function beforeRender(Document $document): Document
+    {
+        $this->replaceTransclusions($document);
+
+        return $document;
+    }
+
+    protected function replaceTransclusions(Node $node): void
+    {
+        foreach ($node->getChildren() as $child) {
+            if ($child instanceof Transclusion) {
+                $node->replaceChildNode($child, $this->resolveTransclusion($child));
+
+                continue;
+            }
+
+            $this->replaceTransclusions($child);
+        }
+    }
+
+    protected function resolveTransclusion(Transclusion $node): Node
+    {
+        $args = $this->collectArguments($node);
+        $resolved = $this->resolver !== null ? ($this->resolver)($node->getName(), $args) : null;
+
+        if ($resolved instanceof Node) {
+            return $resolved;
+        }
+
+        return $this->createUnresolvedFallback($node);
+    }
+
+    /**
+     * @return array<int, \Djot\Node\Inline\TransclusionArgument>
+     */
+    protected function collectArguments(Transclusion $node): array
+    {
+        $args = [];
+        foreach ($node->getChildren() as $child) {
+            if ($child instanceof TransclusionArgument) {
+                $args[] = $child;
+            }
+        }
+
+        return $args;
+    }
+
+    protected function createUnresolvedFallback(Transclusion $node): Span
+    {
+        $span = new Span();
+        foreach (preg_split('/\s+/', trim($this->unresolvedCssClass)) ?: [] as $class) {
+            if ($class !== '') {
+                $span->addClass($class);
+            }
+        }
+        $span->appendChild(new Text('{{' . $node->getName() . '}}'));
+
+        return $span;
+    }
+}

--- a/src/Extension/TransclusionExtension.php
+++ b/src/Extension/TransclusionExtension.php
@@ -70,7 +70,8 @@ class TransclusionExtension implements BeforeRenderExtensionInterface
                     }
 
                     $arg = new TransclusionArgument($key, $index);
-                    $parser->parse($arg, trim($value, " \t"));
+                    $argParser = clone $parser;
+                    $argParser->parse($arg, trim($value));
                     $node->appendChild($arg);
                 }
 

--- a/src/Node/Inline/Transclusion.php
+++ b/src/Node/Inline/Transclusion.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Node\Inline;
+
+/**
+ * Transclusion {{name|args}}
+ */
+class Transclusion extends InlineNode
+{
+    public function __construct(protected string $name = '')
+    {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getType(): string
+    {
+        return 'transclusion';
+    }
+}

--- a/src/Node/Inline/TransclusionArgument.php
+++ b/src/Node/Inline/TransclusionArgument.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Node\Inline;
+
+/**
+ * Transclusion argument
+ */
+class TransclusionArgument extends InlineNode
+{
+    public function __construct(
+        protected ?string $key = null,
+        protected int $index = 0,
+    ) {
+    }
+
+    public function getKey(): ?string
+    {
+        return $this->key;
+    }
+
+    public function getIndex(): int
+    {
+        return $this->index;
+    }
+
+    public function isNamed(): bool
+    {
+        return $this->key !== null;
+    }
+
+    public function getType(): string
+    {
+        return 'transclusion_argument';
+    }
+}

--- a/tests/TestCase/Extension/TransclusionExtensionTest.php
+++ b/tests/TestCase/Extension/TransclusionExtensionTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Test\TestCase\Extension;
+
+use Djot\DjotConverter;
+use Djot\Extension\TransclusionExtension;
+use Djot\Node\ContentNodeInterface;
+use Djot\Node\Inline\Span;
+use Djot\Node\Inline\Text;
+use Djot\Node\Inline\TransclusionArgument;
+use Djot\Node\Node;
+use PHPUnit\Framework\TestCase;
+
+class TransclusionExtensionTest extends TestCase
+{
+    public function testPositionalArgs(): void
+    {
+        $seenArgs = [];
+
+        $converter = new DjotConverter();
+        $converter->addExtension(new TransclusionExtension(
+            /** @param array<int, \Djot\Node\Inline\TransclusionArgument> $args */
+            resolver: function (string $name, array $args) use (&$seenArgs): Node {
+                $seenArgs = $args;
+
+                $span = new Span();
+                $span->appendChild(new Text($this->plainText($args[0]) . ', '));
+                $span->appendChild(new Text($this->plainText($args[1])));
+
+                return $span;
+            },
+        ));
+
+        $html = $converter->convert('{{infobox|Berlin|Germany}}');
+
+        $this->assertStringContainsString('Berlin', $html);
+        $this->assertStringContainsString('Germany', $html);
+        $this->assertCount(2, $seenArgs);
+        $this->assertFalse($seenArgs[0]->isNamed());
+        $this->assertFalse($seenArgs[1]->isNamed());
+        $this->assertSame(0, $seenArgs[0]->getIndex());
+        $this->assertSame(1, $seenArgs[1]->getIndex());
+    }
+
+    public function testNamedArgs(): void
+    {
+        $seenArgs = [];
+
+        $converter = new DjotConverter();
+        $converter->addExtension(new TransclusionExtension(
+            /** @param array<int, \Djot\Node\Inline\TransclusionArgument> $args */
+            resolver: function (string $name, array $args) use (&$seenArgs): Node {
+                $seenArgs = $args;
+
+                $span = new Span();
+                $span->appendChild(new Text($this->plainText($args[0]) . ' '));
+                $span->appendChild(new Text($this->plainText($args[1])));
+
+                return $span;
+            },
+        ));
+
+        $html = $converter->convert('{{cite|author=Doe|year=1990}}');
+
+        $this->assertSame('author', $seenArgs[0]->getKey());
+        $this->assertSame('year', $seenArgs[1]->getKey());
+        $this->assertStringContainsString('Doe', $html);
+        $this->assertStringContainsString('1990', $html);
+    }
+
+    public function testMarkupBearingArgumentIsParsed(): void
+    {
+        $titleArg = null;
+
+        $converter = new DjotConverter();
+        $converter->addExtension(new TransclusionExtension(
+            /** @param array<int, \Djot\Node\Inline\TransclusionArgument> $args */
+            resolver: static function (string $name, array $args) use (&$titleArg): Node {
+                $titleArg = $args[0];
+
+                $span = new Span();
+                foreach ($args[0]->getChildren() as $child) {
+                    $span->appendChild($child);
+                }
+
+                return $span;
+            },
+        ));
+
+        $html = $converter->convert('{{cite|title=_Important_ book}}');
+
+        $this->assertStringContainsString('<em>Important</em>', $html);
+        $this->assertInstanceOf(TransclusionArgument::class, $titleArg);
+        $this->assertTrue($this->hasChildType($titleArg, 'emphasis'));
+    }
+
+    public function testUnresolvedFallbackWithoutResolver(): void
+    {
+        $converter = new DjotConverter();
+        $converter->addExtension(new TransclusionExtension());
+
+        $html = $converter->convert('See {{Tigers}} here');
+
+        $this->assertStringContainsString('class="transclusion-unresolved"', $html);
+        $this->assertStringContainsString('{{Tigers}}', $html);
+    }
+
+    public function testResolverReturnsNullUsesFallback(): void
+    {
+        $converter = new DjotConverter();
+        $converter->addExtension(new TransclusionExtension(
+            /** @param array<int, \Djot\Node\Inline\TransclusionArgument> $args */
+            resolver: static fn (string $name, array $args): ?Node => null,
+        ));
+
+        $html = $converter->convert('See {{Tigers}} here');
+
+        $this->assertStringContainsString('class="transclusion-unresolved"', $html);
+        $this->assertStringContainsString('{{Tigers}}', $html);
+    }
+
+    protected function hasChildType(TransclusionArgument $arg, string $type): bool
+    {
+        foreach ($arg->getChildren() as $child) {
+            if ($child->getType() === $type) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected function plainText(TransclusionArgument $arg): string
+    {
+        $text = '';
+        foreach ($arg->getChildren() as $child) {
+            if ($child instanceof ContentNodeInterface) {
+                $text .= $child->getContent();
+            }
+        }
+
+        return $text;
+    }
+}


### PR DESCRIPTION
## What

A spike (opt-in, experimental) that maps template/fragment invocations with **parsed** arguments onto Djot, using only the existing extension/AST infrastructure.

This is the djot-php-side experiment for the upstream discussion on documenting Djot extensions and mapping wikitext-style templates onto Djot: https://github.com/jgm/djot/discussions/366

## Why

Djot attributes are flat strings, so a markup-bearing template argument (a title containing emphasis, a link, or even another template) cannot live in an attribute. The discussion converges on a core question: there is good syntax for *unparsed* args (attributes), but no good mechanism for *parsed* args. This spike demonstrates one answer: a dedicated node whose arguments carry **parsed child nodes**, expanded by a host resolver before render, leaving the Djot core ignorant of template semantics.

## What it adds

- `Djot\Node\Inline\Transclusion` - node holding the invocation `name`.
- `Djot\Node\Inline\TransclusionArgument` - one argument; named or positional, value held as parsed inline children.
- `Djot\Extension\TransclusionExtension` - parses `{{name|positional|key=value}}` via the existing custom inline-pattern API, builds the node with parsed argument children, and on `beforeRender` calls a host-supplied resolver:
  - resolver returns a replacement node, spliced into the AST, or
  - returns null (or no resolver) and the call falls back to a visible `transclusion-unresolved` span containing the literal `{{name}}`.
- Docs entry in `docs/extensions/index.md` (table row + section with a resolver contract), marked experimental.

So `{{cite|title=_Important_ book}}` yields an emphasis node in the `title` slot, not a flat string - that is the whole point.

## Design notes

- Reuses existing infrastructure only: custom inline pattern API, mutable AST, `beforeRender` hook. No parser-core changes, no renderer changes (the resolver expands the node before the renderer ever sees it).
- The pipe-based surface syntax is deliberately throwaway. The contribution is the **AST model**: multiple named/positional parsed argument slots, with expansion delegated to the host. Whether the eventual surface form is this, or "named captions", or something else, the node shape is what matters.
- Nested invocation as an argument falls out for free: an argument's parsed children can themselves contain a `Transclusion` node.

## Spike limitations (intentional)

- Pattern is `{{...}}` with `[^{}]` inner, so nested braces / literal braces inside arguments are not supported, and a literal `|` inside an argument is not supported (pipe always splits).
- Resolver output is not re-scanned for nested transclusions.
- Surface syntax is exploratory, not proposed as spec.

## Status

Draft / spike for discussion. Not intended to merge as-is; opening it to make the AST-model argument concrete with running code.
