### PR TITLE
Escape Djot-significant characters when converting HTML text to Djot

### DIFF
--- a/docs/guide/converters.md
+++ b/docs/guide/converters.md
@@ -213,6 +213,12 @@ echo "Hello";
 **Behavior:**
 - Strips `<script>`, `<style>`, and `<noscript>` tags
 - Normalizes whitespace (multiple spaces/newlines become single space)
+- Escapes Djot-significant characters in text so literal content survives the
+  next parse. Text such as `a *b* c`, a leading `- item`, or `[text](url)` that
+  came from outside Djot (a WYSIWYG editor, CMS export, or pasted HTML) stays
+  literal instead of being re-interpreted as emphasis, a list, or a link.
+  Intraword underscores (`snake_case`) are left untouched, and verbatim contexts
+  (`<pre>`/code) are never escaped.
 - Preserves whitespace inside `<pre>` blocks
 - Detects code language from `class="language-xxx"` attribute
 - Converts `<span>` with class/id to Djot span syntax

--- a/src/Converter/HtmlToDjot.php
+++ b/src/Converter/HtmlToDjot.php
@@ -193,12 +193,16 @@ class HtmlToDjot
     {
         if ($node instanceof DOMText) {
             $text = $node->textContent;
-            if (!$this->inPre && !$this->preserveTextWhitespace) {
+            if ($this->inPre) {
+                // Verbatim code context: never normalize or escape.
+                return $text;
+            }
+            if (!$this->preserveTextWhitespace) {
                 // Normalize whitespace outside pre blocks
                 $text = preg_replace('/\s+/', ' ', $text) ?? $text;
             }
 
-            return $text;
+            return $this->escapeDjotText($text, $this->isBlockLineStart($node));
         }
 
         if (!($node instanceof DOMElement)) {
@@ -935,10 +939,13 @@ class HtmlToDjot
         $title = $node->getAttribute('title');
 
         if ($text === '') {
-            $text = $href;
+            // Raw href used as label still needs full escaping.
+            $text = $this->escapeLinkOrImageLabel($href);
+        } else {
+            // Child text was already escaped as inline content; only the
+            // label-closing bracket remains to be escaped here.
+            $text = str_replace(']', '\]', $text);
         }
-
-        $text = $this->escapeLinkOrImageLabel($text);
 
         // Check for @mention (round-trip support for MentionsExtension)
         if ($node->hasAttribute('data-username')) {
@@ -2242,6 +2249,97 @@ class HtmlToDjot
             ['\\\\', '\[', '\]'],
             $text,
         );
+    }
+
+    /**
+     * Escape text extracted from HTML so Djot-significant characters survive as
+     * literal text on the next Djot parse.
+     *
+     * HTML that originates outside Djot (WYSIWYG editors, CMS exports, pasted
+     * content) routinely carries characters such as `*`, `_`, `[` or a leading
+     * `-` as ordinary prose. Without escaping, the round-trip Djot would re-parse
+     * them as emphasis, links or list markers and silently change the document.
+     */
+    protected function escapeDjotText(string $text, bool $atLineStart): string
+    {
+        $escaped = preg_replace('/[\\\\`*\[{~^<]/', '\\\\$0', $text) ?? $text;
+
+        // Underscores only delimit emphasis at word boundaries; intraword `_`
+        // (snake_case, SCREAMING_CASE, file_name) is literal in Djot, so leave
+        // it unescaped to keep imported identifiers and URLs readable.
+        $escaped = preg_replace('/(?<![\p{L}\p{N}])_|_(?![\p{L}\p{N}])/u', '\\\\$0', $escaped) ?? $escaped;
+
+        if ($atLineStart) {
+            $escaped = $this->escapeLeadingBlockMarker($escaped);
+        }
+
+        return $escaped;
+    }
+
+    /**
+     * Escape a leading block-level marker so a paragraph that happens to begin
+     * with `-`, `+`, `#`, `>` or `1.` is not re-parsed as a list, heading or
+     * blockquote.
+     *
+     * Runs after inline escaping, so a leading inline marker (for example `*`)
+     * has already been neutralized and is no longer a block concern here.
+     */
+    protected function escapeLeadingBlockMarker(string $text): string
+    {
+        if (preg_match('/^(\d+)[.)](\s|$)/', $text, $matches) === 1) {
+            return $matches[1] . '\\' . substr($text, strlen($matches[1]));
+        }
+
+        if (preg_match('/^[-+#>]/', $text) === 1) {
+            return '\\' . $text;
+        }
+
+        return $text;
+    }
+
+    /**
+     * Determine whether a text node begins a Djot line at column zero, where a
+     * leading block marker would be significant. True only for the first inline
+     * child of a block container that renders its content flush left.
+     */
+    protected function isBlockLineStart(DOMText $node): bool
+    {
+        // Walk up through inline wrappers (`<span>`, `<em>`, ...): pasted HTML
+        // often opens a paragraph with `<span>- x</span>`, where the marker is
+        // still at column zero once the wrapper produces no leading syntax.
+        $current = $node;
+        while (true) {
+            if ($current->previousSibling !== null) {
+                return false;
+            }
+
+            $parent = $current->parentNode;
+            if (!$parent instanceof DOMElement) {
+                return false;
+            }
+
+            $tag = strtolower($parent->tagName);
+            if (!$this->isInlineWrapperTag($tag)) {
+                // First non-inline ancestor: a line start only if it lays its
+                // content out flush left (paragraph, list item, ...), not a
+                // heading or table cell whose Djot syntax prefixes the content.
+                return in_array($tag, [
+                    'p', 'li', 'dd', 'dt', 'div', 'section', 'blockquote',
+                    'article', 'main', 'aside', 'header', 'footer', 'figcaption',
+                ], true);
+            }
+
+            $current = $parent;
+        }
+    }
+
+    protected function isInlineWrapperTag(string $tag): bool
+    {
+        return in_array($tag, [
+            'span', 'a', 'em', 'strong', 'b', 'i', 'u', 's', 'strike', 'del',
+            'ins', 'mark', 'sub', 'sup', 'small', 'kbd', 'code', 'samp', 'var',
+            'dfn', 'abbr', 'q', 'cite', 'time', 'bdi', 'bdo', 'label', 'font',
+        ], true);
     }
 
     protected function requiresRawImageFallback(string $alt): bool

--- a/tests/TestCase/Converter/HtmlToDjotEscapeTest.php
+++ b/tests/TestCase/Converter/HtmlToDjotEscapeTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Test\TestCase\Converter;
+
+use Djot\Converter\HtmlToDjot;
+use Djot\DjotConverter;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Round-trip safety for HTML that originates outside Djot (WYSIWYG editors, CMS
+ * imports, pasted content).
+ *
+ * Such HTML carries literal text that happens to contain Djot-significant
+ * characters (`*`, `_`, `[`, leading `-`, ...). When HtmlToDjot emits that text
+ * verbatim, the next Djot parse re-interprets the characters as markup and the
+ * meaning of the document changes (a literal `*b*` becomes <strong>, a literal
+ * leading `-` becomes a list item).
+ *
+ * The invariant under test: rendering the produced Djot back to HTML must
+ * reproduce the original HTML. Characters that were literal text stay literal
+ * text.
+ */
+class HtmlToDjotEscapeTest extends TestCase
+{
+    protected HtmlToDjot $converter;
+
+    protected DjotConverter $renderer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->converter = new HtmlToDjot();
+        $this->renderer = new DjotConverter();
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function literalTextProvider(): array
+    {
+        return [
+            // Inline emphasis/strong markers.
+            'asterisk emphasis' => ['<p>a *b* c</p>'],
+            'underscore emphasis' => ['<p>a _b_ c</p>'],
+            // Inline code span.
+            'inline backticks' => ['<p>use a `code` here</p>'],
+            // Link / span brackets.
+            'link brackets' => ['<p>see [text](url) below</p>'],
+            'reference brackets' => ['<p>see [text][ref] below</p>'],
+            // Inline span / attribute braces.
+            'attribute braces' => ['<p>value {key=val} literal</p>'],
+            // Autolink angle brackets.
+            'autolink angles' => ['<p>visit &lt;http://x.test&gt; now</p>'],
+            // Sub/superscript markers.
+            'tilde subscript' => ['<p>H~2~O formula</p>'],
+            'caret superscript' => ['<p>x^2^ value</p>'],
+            // Block markers at line start.
+            'leading dash' => ['<p>- not a list item</p>'],
+            'leading plus' => ['<p>+ not a list item</p>'],
+            'leading asterisk' => ['<p>* not a list item</p>'],
+            'leading hash' => ['<p># not a heading</p>'],
+            'ordered dot' => ['<p>1. not an ordered list</p>'],
+            'ordered paren' => ['<p>1) not an ordered list</p>'],
+            'blockquote marker' => ['<p>&gt; not a quote</p>'],
+            // Escape character itself.
+            'literal backslash' => ['<p>a \\ b</p>'],
+        ];
+    }
+
+    #[DataProvider('literalTextProvider')]
+    public function testLiteralTextSurvivesRoundTrip(string $html): void
+    {
+        $djot = $this->converter->convert($html);
+        $reRendered = trim($this->renderer->convert($djot));
+
+        $this->assertSame(
+            $html,
+            $reRendered,
+            "Literal text changed meaning on round-trip.\nDjot intermediate: " . $djot,
+        );
+    }
+
+    /**
+     * Intraword underscores (`snake_case`) are literal in Djot and must not be
+     * escaped: emitting `snake\_case` is correct but noisy, and import output is
+     * full of identifiers, filenames and URLs that would otherwise be peppered
+     * with backslashes. Asterisks get no such exemption (Djot emphasis works
+     * intraword), nor do sub/superscript markers (`H~2~O` is a real subscript).
+     */
+    public function testIntrawordUnderscoreIsNotEscaped(): void
+    {
+        $this->assertSame(
+            'use snake_case and SCREAMING_CASE here',
+            trim($this->converter->convert('<p>use snake_case and SCREAMING_CASE here</p>')),
+        );
+    }
+
+    public function testBoundaryUnderscoreStillEscaped(): void
+    {
+        // Round-trip safety still holds for emphasis-capable underscores.
+        $html = '<p>a _b_ c</p>';
+        $this->assertSame($html, trim($this->renderer->convert($this->converter->convert($html))));
+    }
+
+    /**
+     * Pasted HTML often opens a paragraph with an inline wrapper such as
+     * `<span>- x</span>`. The wrapper itself carries no Djot syntax, so the
+     * marker is still at column zero and must be escaped; otherwise the
+     * paragraph re-parses as a list or heading.
+     *
+     * @return array<string, array{string, string}>
+     */
+    public static function wrappedLeadingMarkerProvider(): array
+    {
+        return [
+            'span dash' => ['<p><span>- x</span></p>', '<ul'],
+            'span hash' => ['<p><span># x</span></p>', '<h1'],
+            'em then span dash' => ['<p><em>a</em> <span>- x</span></p>', '<ul'],
+        ];
+    }
+
+    #[DataProvider('wrappedLeadingMarkerProvider')]
+    public function testWrappedLeadingMarkerStaysInline(string $html, string $forbiddenTag): void
+    {
+        $djot = $this->converter->convert($html);
+        $reRendered = $this->renderer->convert($djot);
+
+        // The wrapper element may be dropped (a bare span has no Djot form), but
+        // the block structure must not change.
+        $this->assertStringNotContainsString($forbiddenTag, $reRendered);
+        $this->assertStringContainsString('<p>', $reRendered);
+    }
+
+    /**
+     * A leading run of dashes must not be re-parsed as a thematic break (the
+     * structural break). Typographic normalization of the remaining dashes
+     * (smart en/em dashes) is acceptable and intentional, like smart quotes.
+     */
+    public function testLeadingDashesDoNotBecomeThematicBreak(): void
+    {
+        $djot = $this->converter->convert('<p>--- not a break</p>');
+        $reRendered = $this->renderer->convert($djot);
+
+        $this->assertStringNotContainsString('<hr', $reRendered);
+        $this->assertStringContainsString('not a break', $reRendered);
+    }
+}


### PR DESCRIPTION
## Problem

`HtmlToDjot` emitted text-node content verbatim (only normalizing whitespace). When the HTML originates **outside** Djot - WYSIWYG editors, CMS exports, pasted content, web scraping, the documented primary use case - that text routinely contains characters that are Djot markup. On the next parse they are re-interpreted as markup and the document silently changes meaning.

Concrete round-trips that were broken (`HTML -> Djot -> HTML`):

```text
<p>a *b* c</p>          ->  a *b* c          ->  <p>a <strong>b</strong> c</p>
<p>- not a list</p>     ->  - not a list     ->  <ul><li>not a list</li></ul>
<p>see [t](u) below</p> ->  see [t](u) below ->  <p>see <a href="u">t</a> below</p>
<p>a \ b</p>            ->  a \ b            ->  <p>a &nbsp;b</p>
```

A paragraph turning into a list or an emphasis appearing out of nowhere is a correctness bug, not cosmetic normalization.

## Fix

Escape Djot-significant characters when emitting HTML text as Djot, in `escapeDjotText()`:

- **Inline markers escaped anywhere:** `\` `` ` `` `*` `[` `{` `~` `^` `<`. These can open inline constructs (emphasis, code, links/spans, sub/superscript, autolinks, escapes).
- **Block markers escaped only at line start** (first inline child of a flush-left block container): leading `-` `+` `#` `>` and ordered-list markers `1.` / `1)`. This is what keeps a paragraph from becoming a list, heading or blockquote. A leading dash run also no longer becomes a thematic break.
- **Intraword underscore is left alone:** `snake_case`, `SCREAMING_CASE`, `file_name` stay literal. Djot only treats `_` as emphasis at word boundaries, so escaping intraword `_` is unnecessary noise - and import output is full of identifiers, filenames and URLs. Asterisks get no exemption (Djot emphasis works intraword); `~`/`^` get none either (`H~2~O` is a real subscript).
- **Link labels no longer double-escape.** `processLink` built its label from already-escaped child text and then ran the label escaper again, doubling backslashes. It now only escapes the label-closing `]` on child-derived text; a raw `href` used as the label still gets full escaping.

Verbatim contexts are untouched: text inside `<pre>`/code blocks is never escaped.

## Scope and non-goals

- Typographic normalization that does not change structure is intentionally **kept**, matching existing behavior: smart quotes, and `--`/`---` becoming en/em dashes. A leading dash run is still prevented from becoming a thematic break (the structural risk); only the inner dashes get smart-punctuation, exactly like smart quotes.
- This is escape-on-emit, independent of round-trip mode. It fixes external-origin HTML, which previously had no protection. Djot-origin round-trips already preserved author escapes via the round-trip data attributes and are unaffected.

## Examples after the fix

```text
<p>a *b* c</p>            ->  a \*b\* c          ->  <p>a *b* c</p>
<p>- not a list</p>       ->  \- not a list      ->  <p>- not a list</p>
<p>use snake_case</p>     ->  use snake_case     ->  <p>use snake_case</p>
<p><em>real</em> text</p> ->  _real_ text        ->  <p><em>real</em> text</p>
```
