### PR TITLE
Pad code-span content symmetrically in HtmlToDjot

### DIFF
--- a/src/Converter/HtmlToDjot.php
+++ b/src/Converter/HtmlToDjot.php
@@ -824,18 +824,16 @@ class HtmlToDjot
         $backticks = StringUtil::findSafeCodeFence($content, 1);
         $attrs = $this->formatInlineAttributes($node);
 
-        // Add spaces around content if needed to distinguish from fence
-        // Only add space if content starts/ends with backtick but NOT already a space
-        // (If there's already a space, it was preserved from the original)
+        // Separate the content from the fence when it begins or ends with a
+        // backtick. Djot only strips padding when both ends have a space, so the
+        // padding must be symmetric: a lone pad space would be kept as content
+        // and corrupt the value on the next parse.
         if (strlen($backticks) > 1) {
-            $needsStartSpace = str_starts_with($content, '`') && !str_starts_with($content, ' ');
-            $needsEndSpace = str_ends_with($content, '`') && !str_ends_with($content, ' ');
+            $needsSpace = (str_starts_with($content, '`') && !str_starts_with($content, ' '))
+                || (str_ends_with($content, '`') && !str_ends_with($content, ' '));
 
-            if ($needsStartSpace || $needsEndSpace) {
-                $start = $needsStartSpace ? ' ' : '';
-                $end = $needsEndSpace ? ' ' : '';
-
-                return $backticks . $start . $content . $end . $backticks . $attrs;
+            if ($needsSpace) {
+                return $backticks . ' ' . $content . ' ' . $backticks . $attrs;
             }
         }
 

--- a/tests/TestCase/Converter/HtmlToDjotCodeSpanTest.php
+++ b/tests/TestCase/Converter/HtmlToDjotCodeSpanTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Test\TestCase\Converter;
+
+use Djot\Converter\HtmlToDjot;
+use Djot\DjotConverter;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Inline code-span content must survive HTML -> Djot -> HTML untouched.
+ *
+ * Djot strips a single leading and trailing space from a code span only when
+ * both ends have one and the span is not all spaces. So content that begins or
+ * ends with a backtick (which needs a separating space) must be padded on both
+ * ends, not one; otherwise a lone pad space is kept and the content gains a
+ * space. Likewise, content that already begins or ends with a significant space
+ * must be padded so the strip rule restores it rather than eating it.
+ */
+class HtmlToDjotCodeSpanTest extends TestCase
+{
+    protected HtmlToDjot $converter;
+
+    protected DjotConverter $renderer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->converter = new HtmlToDjot();
+        $this->renderer = new DjotConverter();
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function codeContentProvider(): array
+    {
+        return [
+            'plain' => ['ls -la'],
+            'mid backtick' => ['a`b'],
+            'leading backtick' => ['`a'],
+            'trailing backtick' => ['a`'],
+            'both backticks' => ['`a`'],
+            'single backtick' => ['`'],
+            'leading space' => [' a'],
+            'trailing space' => ['a '],
+            'both spaces' => [' a '],
+            'all spaces' => ['   '],
+            'leading space and backtick' => [' `a'],
+        ];
+    }
+
+    #[DataProvider('codeContentProvider')]
+    public function testCodeSpanContentRoundTrips(string $content): void
+    {
+        $html = '<p>x <code>' . htmlspecialchars($content, ENT_QUOTES | ENT_HTML5) . '</code> y</p>';
+        $djot = $this->converter->convert($html);
+        $reRendered = $this->renderer->convert($djot);
+
+        preg_match('#<code>(.*?)</code>#s', $reRendered, $matches);
+        $got = html_entity_decode($matches[1] ?? '(no code element)', ENT_QUOTES | ENT_HTML5);
+
+        $this->assertSame($content, $got, 'Djot intermediate: ' . $djot);
+    }
+}


### PR DESCRIPTION
## Problem

`HtmlToDjot` corrupted inline code whose content begins or ends with a backtick. It added the fence-separating space to only the affected end:

```text
<code>`a</code>   ->  `` `a``     ->  <code> `a</code>   (gained a leading space)
<code>a`</code>   ->  ``a` ``     ->  <code>a` </code>   (gained a trailing space)
```

Djot removes a single leading and trailing space from a code span **only when both ends have one** and the span is not all spaces. A lone pad space therefore survives as content and changes the value on the next parse.

## Fix

When the content needs separating from the fence (it starts or ends with a backtick and not already a space), pad **both** ends. The strip rule then removes both and restores the exact content:

```text
<code>`a</code>   ->  `` `a ``    ->  <code>`a</code>
<code>a`</code>   ->  `` a` ``    ->  <code>a`</code>
```

Content that already starts or ends with a real space is untouched (the existing space already separates the fence, so no extra padding is added and the significant space is preserved). All-space content and the symmetric case (`` `a` ``) were already correct and stay correct.
