### PR TITLE
Escape leading colon markers in HtmlToDjot + roundtrip property net

### DIFF
--- a/src/Converter/HtmlToDjot.php
+++ b/src/Converter/HtmlToDjot.php
@@ -2276,8 +2276,8 @@ class HtmlToDjot
 
     /**
      * Escape a leading block-level marker so a paragraph that happens to begin
-     * with `-`, `+`, `#`, `>` or `1.` is not re-parsed as a list, heading or
-     * blockquote.
+     * with `-`, `+`, `#`, `>`, `:` or `1.` is not re-parsed as a list, heading,
+     * blockquote, definition list or fenced div.
      *
      * Runs after inline escaping, so a leading inline marker (for example `*`)
      * has already been neutralized and is no longer a block concern here.
@@ -2288,7 +2288,10 @@ class HtmlToDjot
             return $matches[1] . '\\' . substr($text, strlen($matches[1]));
         }
 
-        if (preg_match('/^[-+#>]/', $text) === 1) {
+        // A leading colon opens a definition-list item (`: term`) and a run of
+        // three or more opens a fenced div (`::: name`); escaping the first
+        // colon neutralizes both.
+        if (preg_match('/^[-+#>:]/', $text) === 1) {
             return '\\' . $text;
         }
 

--- a/tests/TestCase/Converter/HtmlToDjotRoundTripPropertyTest.php
+++ b/tests/TestCase/Converter/HtmlToDjotRoundTripPropertyTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Test\TestCase\Converter;
+
+use Djot\Converter\HtmlToDjot;
+use Djot\DjotConverter;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Property net for the HTML -> Djot -> HTML round-trip of externally-authored
+ * HTML (WYSIWYG editors, CMS exports, pasted content).
+ *
+ * For a paragraph of literal text, converting to Djot and back must not change
+ * the block structure (no list, heading, blockquote, div, definition list, rule
+ * or table injected) and must not lose the text. This sweep over Djot-significant
+ * leading tokens and inline markers is what catches "a literal marker silently
+ * became a block" regressions across positions, instead of one example at a time.
+ */
+class HtmlToDjotRoundTripPropertyTest extends TestCase
+{
+    protected HtmlToDjot $converter;
+
+    protected DjotConverter $renderer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->converter = new HtmlToDjot();
+        $this->renderer = new DjotConverter();
+    }
+
+    /**
+     * Tokens that, at the start of a line, can open a Djot block; plus inline
+     * markers embedded in the body that can open inline constructs.
+     *
+     * @return array<string, array{string}>
+     */
+    public static function literalParagraphProvider(): array
+    {
+        $leadingTokens = [
+            '-', '+', '*', '#', '##', '###', '>', '>>',
+            ':', '::', ':::', '1.', '1)', '2.', '---', '***', '___',
+            '~~~', '```', '|', '=',
+        ];
+        $bodies = [
+            'plain words here',
+            'with *stars* and _unders_ inline',
+            'a [link](http://x.test) and `code`',
+        ];
+        $wrappers = [
+            'bare' => static fn (string $inner): string => '<p>' . $inner . '</p>',
+            'span' => static fn (string $inner): string => '<p><span>' . $inner . '</span></p>',
+        ];
+
+        $cases = [];
+        foreach ($leadingTokens as $token) {
+            foreach ($bodies as $bi => $body) {
+                foreach ($wrappers as $wname => $wrap) {
+                    $text = $token . ' ' . $body;
+                    $inner = htmlspecialchars($text, ENT_QUOTES | ENT_HTML5);
+                    $cases["{$token} / b{$bi} / {$wname}"] = [$wrap($inner), $text];
+                }
+            }
+        }
+
+        return $cases;
+    }
+
+    #[DataProvider('literalParagraphProvider')]
+    public function testLiteralParagraphRoundTripIsStable(string $html, string $text): void
+    {
+        $djot = $this->converter->convert($html);
+        $out = $this->renderer->convert($djot);
+
+        $forbidden = [
+            '<ul', '<ol', '<hr', '<h1', '<h2', '<h3', '<h4', '<h5', '<h6',
+            '<blockquote', '<div', '<dl', '<table', '<section', '<pre',
+        ];
+        foreach ($forbidden as $tag) {
+            $this->assertStringNotContainsString(
+                $tag,
+                $out,
+                "Literal paragraph gained block `{$tag}`.\nInput: {$html}\nDjot: {$djot}\nOut: {$out}",
+            );
+        }
+
+        $this->assertStringContainsString('<p', $out, "Lost the paragraph.\nDjot: {$djot}\nOut: {$out}");
+
+        // Text must survive (alphanumerics only, to ignore smart punctuation and
+        // entity escaping). Catches data loss such as text captured into an
+        // attribute (`::: x` -> `<div class="x">`).
+        $outText = html_entity_decode(strip_tags($out), ENT_QUOTES | ENT_HTML5);
+        $this->assertSame(
+            $this->alnum($text),
+            $this->alnum($outText),
+            "Literal text was lost or altered.\nDjot: {$djot}\nOut: {$out}",
+        );
+    }
+
+    public function testDefinitionDescriptionLeadingColonStaysLiteral(): void
+    {
+        $html = '<dl><dt>term</dt><dd>: value</dd></dl>';
+        $out = $this->renderer->convert($this->converter->convert($html));
+
+        // Exactly one definition list: the leading colon must not open a nested one.
+        $this->assertSame(1, substr_count($out, '<dl'));
+        $this->assertStringContainsString('value', strip_tags($out));
+    }
+
+    public function testListItemLeadingColonStaysLiteral(): void
+    {
+        $html = '<ul><li>: not a definition</li></ul>';
+        $out = $this->renderer->convert($this->converter->convert($html));
+
+        $this->assertStringNotContainsString('<dl', $out);
+        $this->assertSame(1, substr_count($out, '<ul'));
+    }
+
+    protected function alnum(string $value): string
+    {
+        return strtolower((string)preg_replace('/[^a-z0-9]/i', '', $value));
+    }
+}


### PR DESCRIPTION
Follow-up to the HtmlToDjot escaping work (#202, #203).

## Problem (G1)

A paragraph of external HTML beginning with a colon was re-parsed as a different block on the next Djot parse:

```text
<p>: just text</p>     ->  : just text     ->  <dl><dt>just text</dt>...   (paragraph -> definition list)
<p>::: not a div</p>   ->  ::: not a div   ->  <div class="not a div"></div>   (text DESTROYED into a class)
<dd>: value</dd>       ->  ...             ->  nested <dl> corruption
```

The `:::` case is the worst: the content is captured into the div class name and the text is lost.

This is the same class as the leading `-`, `#`, `>` and `1.` markers already handled; `escapeLeadingBlockMarker` simply did not cover `:`.

## Fix

Add a leading colon to the block-marker escaping. Escaping the first colon neutralizes both a definition-list item (`: term`) and a fenced div (`::: name`), so the text stays literal: `\: just text`, `\::: not a div`.

## Property net (G4)

Adds a generated round-trip property test that, for externally-authored HTML, sweeps Djot-significant leading tokens (`-` `+` `*` `#` `>` `:` `:::` `1.` `1)` `---` `~~~` `` ``` `` `|` ...) and inline markers across paragraph and inline-wrapped (`<span>`) contexts, asserting:

- no block is injected (no list, heading, blockquote, div, definition list, rule, table, or section), and
- the text survives (alphanumeric content preserved, so data loss like the `:::` case is caught).

This sweep is what surfaced the colon gap, and it guards the whole "a literal marker silently became a block" class going forward instead of one example at a time. It also re-covers the markers fixed in #202.
