### PR TITLE
Separate adjacent same-delimiter inline runs in HtmlToDjot + doc fixes

### DIFF
--- a/docs/guide/converters.md
+++ b/docs/guide/converters.md
@@ -227,7 +227,7 @@ echo "Hello";
 
 ### Round-Trip Mode
 
-For perfect Djot→HTML→Djot round-trips, enable round-trip mode. This adds data attributes to preserve Djot-specific syntax that would otherwise be lost:
+For lossless Djot→HTML→Djot round-trips of supported constructs, enable round-trip mode. This adds data attributes to preserve Djot-specific syntax that would otherwise be lost. Round-trips preserve semantics and Djot-specific syntax markers; purely cosmetic details (such as the exact fence length of a code block) are normalized.
 
 ```php
 use Djot\DjotConverter;
@@ -263,7 +263,7 @@ $back = $htmlToDjot->convert($html);
 | Shifted headings | `data-djot-source-level` | Preserves original Djot heading level during HTML round-trips |
 | Inline footnotes | `data-djot-inline-footnote-*` | Preserves inline-footnote syntax and custom footnote class |
 | Table separator widths | `data-djot-col-widths` | Preserves original table separator widths during HTML round-trips |
-| Code blocks | `data-djot-src` | Preserves fence length, language, and content |
+| Code blocks | `data-djot-src` | Preserves language and content (fence length is normalized to the shortest safe length) |
 | Mermaid diagrams | `data-djot-src` | Preserves full mermaid source |
 | Code groups | `data-djot-src` | Preserves code group structure |
 | Tabs | `data-djot-src` | Preserves tab structure |

--- a/src/Converter/HtmlToDjot.php
+++ b/src/Converter/HtmlToDjot.php
@@ -269,10 +269,40 @@ class HtmlToDjot
     {
         $output = '';
         foreach ($node->childNodes as $child) {
-            $output .= $this->processNode($child);
+            $piece = $this->processNode($child);
+            if ($piece === '') {
+                continue;
+            }
+
+            if ($output !== '' && $this->needsInlineSeparator($output, $piece)) {
+                $output .= '{}';
+            }
+
+            $output .= $piece;
         }
 
         return $output;
+    }
+
+    /**
+     * Two adjacent inline runs that share a delimiter (`_a__b_`, `*a**b*`,
+     * `` `a``b` ``) merge into a single malformed token on the next parse. An
+     * empty attribute group `{}` between them keeps them separate without
+     * affecting the rendered output.
+     */
+    protected function needsInlineSeparator(string $left, string $right): bool
+    {
+        $last = substr($left, -1);
+        if ($last === '' || $last !== $right[0]) {
+            return false;
+        }
+
+        if (!in_array($last, ['_', '*', '~', '^', '`'], true)) {
+            return false;
+        }
+
+        // A trailing escaped delimiter (`\_`) is literal text, not a real one.
+        return substr($left, -2) !== '\\' . $last;
     }
 
     /**

--- a/tests/TestCase/Converter/HtmlToDjotRoundTripPropertyTest.php
+++ b/tests/TestCase/Converter/HtmlToDjotRoundTripPropertyTest.php
@@ -120,6 +120,38 @@ class HtmlToDjotRoundTripPropertyTest extends TestCase
         $this->assertSame(1, substr_count($out, '<ul'));
     }
 
+    /**
+     * Two adjacent inline elements that share a Djot delimiter must not merge
+     * into one malformed token on the round-trip. `<em>a</em><em>b</em>` has to
+     * stay two emphasis runs, not collapse to `_a__b_` -> `<em>a_</em>b_`.
+     *
+     * @return array<string, array{string}>
+     */
+    public static function adjacentInlineProvider(): array
+    {
+        $tags = ['em', 'strong', 'sub', 'sup', 'code', 'del', 'mark', 'ins'];
+
+        $cases = [];
+        foreach ($tags as $tag) {
+            $cases["two {$tag}"] = ["<p><{$tag}>a</{$tag}><{$tag}>b</{$tag}></p>"];
+            $cases["three {$tag}"] = ["<p><{$tag}>a</{$tag}><{$tag}>b</{$tag}><{$tag}>c</{$tag}></p>"];
+        }
+        // Mixed delimiters already serialize unambiguously; guard against regressions.
+        $cases['em then strong'] = ['<p><em>a</em><strong>b</strong></p>'];
+        $cases['em space em'] = ['<p><em>a</em> <em>b</em></p>'];
+
+        return $cases;
+    }
+
+    #[DataProvider('adjacentInlineProvider')]
+    public function testAdjacentInlineElementsRoundTrip(string $html): void
+    {
+        $djot = $this->converter->convert($html);
+        $out = trim($this->renderer->convert($djot));
+
+        $this->assertSame($html, $out, 'Djot intermediate: ' . $djot);
+    }
+
     protected function alnum(string $value): string
     {
         return strtolower((string)preg_replace('/[^a-z0-9]/i', '', $value));


### PR DESCRIPTION
Follow-up to the HtmlToDjot round-trip work (#202, #203, #204).

## Problem (G2)

Two adjacent inline elements that share a Djot delimiter merged into a single malformed token on the round-trip:

```text
<em>a</em><em>b</em>                  ->  _a__b_   ->  <em>a_</em>b_
<strong>a</strong><strong>b</strong>  ->  *a**b*   ->  <strong>a*</strong>b*
<code>a</code><code>b</code>          ->  `a``b`   ->  <code>a``b</code>
```

Same for `<sub>` and `<sup>`. Brace-delimited inlines (`<del>`, `<mark>`, `<ins>`) and mixed delimiters (`<em>` then `<strong>`) were already fine.

## Fix

When concatenating inline children, insert an empty attribute group `{}` between two pieces where the left ends and the right begins with the same delimiter (`_`, `*`, `~`, `^`, or backtick). `{}` renders to nothing, so the content is unchanged while the two runs stay distinct:

```text
<em>a</em><em>b</em>  ->  _a_{}_b_  ->  <em>a</em><em>b</em>
```

A trailing escaped delimiter (`\_`, produced for literal text) is recognized and left alone, so genuine literal characters are not affected.

The round-trip property test gains an adjacency sweep over `em`, `strong`, `sub`, `sup`, `code`, `del`, `mark`, `ins` (pairs and triples), plus the mixed-delimiter and space-separated cases as regression guards.

## Docs (G3)

Fixes two overclaims in the converter guide:

- Round-trip mode is described as "lossless for supported constructs" instead of "perfect" (HTML is many-to-one with Djot, so perfect round-trips of arbitrary input are not possible).
- Code blocks preserve language and content; the fence length is normalized to the shortest safe length, not preserved. The table entry now says so.
