### PR TITLE
Apply adjacent-inline separator on all inline buffers in HtmlToDjot

### DIFF
--- a/src/Converter/HtmlToDjot.php
+++ b/src/Converter/HtmlToDjot.php
@@ -269,19 +269,29 @@ class HtmlToDjot
     {
         $output = '';
         foreach ($node->childNodes as $child) {
-            $piece = $this->processNode($child);
-            if ($piece === '') {
-                continue;
-            }
-
-            if ($output !== '' && $this->needsInlineSeparator($output, $piece)) {
-                $output .= '{}';
-            }
-
-            $output .= $piece;
+            $output = $this->appendInline($output, $this->processNode($child));
         }
 
         return $output;
+    }
+
+    /**
+     * Append an inline piece to a buffer, inserting a separator first when the
+     * junction would otherwise merge two same-delimiter runs. Shared by every
+     * site that concatenates inline output (paragraphs, implicit blocks, list
+     * items) so the round-trip behaves the same everywhere.
+     */
+    protected function appendInline(string $buffer, string $piece): string
+    {
+        if ($piece === '') {
+            return $buffer;
+        }
+
+        if ($buffer !== '' && $this->needsInlineSeparator($buffer, $piece)) {
+            $buffer .= '{}';
+        }
+
+        return $buffer . $piece;
     }
 
     /**
@@ -342,7 +352,7 @@ class HtmlToDjot
                 $content .= $this->processNode($child);
             } else {
                 // Accumulate inline content
-                $inlineBuffer .= $this->processNode($child);
+                $inlineBuffer = $this->appendInline($inlineBuffer, $this->processNode($child));
             }
         }
 
@@ -1326,10 +1336,10 @@ class HtmlToDjot
                                 $contentParts[] = $content;
                             }
                         } else {
-                            $inlineBuffer .= $this->processNode($liChild);
+                            $inlineBuffer = $this->appendInline($inlineBuffer, $this->processNode($liChild));
                         }
                     } else {
-                        $inlineBuffer .= $this->processNode($liChild);
+                        $inlineBuffer = $this->appendInline($inlineBuffer, $this->processNode($liChild));
                     }
                 }
 

--- a/tests/TestCase/Converter/HtmlToDjotRoundTripPropertyTest.php
+++ b/tests/TestCase/Converter/HtmlToDjotRoundTripPropertyTest.php
@@ -152,6 +152,42 @@ class HtmlToDjotRoundTripPropertyTest extends TestCase
         $this->assertSame($html, $out, 'Djot intermediate: ' . $djot);
     }
 
+    /**
+     * The same-delimiter separator must apply on every inline concatenation
+     * path, not only paragraphs: bare top-level inline (processBlock buffer) and
+     * list items (processListItemContent) buffer inline output manually.
+     *
+     * @return array<string, array{string, string}>
+     */
+    public static function adjacentInlineContextProvider(): array
+    {
+        $cases = [];
+        foreach (['em', 'strong', 'sub', 'sup', 'code'] as $tag) {
+            $pair = "<{$tag}>a</{$tag}><{$tag}>b</{$tag}>";
+            $clean = "<{$tag}>a</{$tag}><{$tag}>b</{$tag}>";
+            $cases["bare {$tag}"] = [$pair, $clean];
+            $cases["list {$tag}"] = ["<ul><li>{$pair}</li></ul>", $clean];
+        }
+
+        return $cases;
+    }
+
+    #[DataProvider('adjacentInlineContextProvider')]
+    public function testAdjacentInlineSeparatedInAllContexts(string $html, string $cleanPair): void
+    {
+        $djot = $this->converter->convert($html);
+        $out = $this->renderer->convert($djot);
+
+        // Normalize whitespace between tags so list/paragraph wrapping is ignored.
+        $normalized = (string)preg_replace('/>\s+</', '><', trim($out));
+
+        $this->assertStringContainsString(
+            $cleanPair,
+            $normalized,
+            "Adjacent inline merged.\nDjot: {$djot}\nOut: {$out}",
+        );
+    }
+
     protected function alnum(string $value): string
     {
         return strtolower((string)preg_replace('/[^a-z0-9]/i', '', $value));


### PR DESCRIPTION
Follow-up to #205, which fixed adjacent same-delimiter inline runs but only on the `processChildren()` path.

## Problem

The separator in #205 covered paragraphs, but two other code paths buffer inline output by hand and so still produced the malformed token:

```text
<em>a</em><em>b</em>                       ->  _a__b_     ->  <em>a_</em>b_     (processBlock buffer)
<ul><li><em>a</em><em>b</em></li></ul>     ->  - _a__b_   ->  <em>a_</em>b_     (processList buffer)
```

(Paragraph-wrapped input was already correct after #205.)

## Fix

Extract the inline join into a shared `appendInline()` helper that inserts the `{}` separator when two pieces would merge a same-delimiter run, and use it on all three concatenation paths: `processChildren()`, the `processBlock()` inline buffer, and the `processList()` list-item buffer. Table cells already delegate to those, so they are covered too.

The property test gains bare-top-level and list-item adjacency cases across `em`, `strong`, `sub`, `sup` and `code`, asserting (whitespace-normalized) that the two runs stay separate regardless of the surrounding block.
