### PR TITLE
Add nestedListsWithoutBlankLine lever; make blocksInterruptParagraphs interrupt consistently in lists

### DIFF
--- a/docs/guide/parser-options.md
+++ b/docs/guide/parser-options.md
@@ -16,7 +16,7 @@ $converter = new DjotConverter();
 $converter = new DjotConverter(
     xhtml: true,
     blocksInterruptParagraphs: true,
-    nestedBlocksInLists: true,
+    nestedListsWithoutBlankLine: true,
 );
 ```
 
@@ -36,7 +36,7 @@ use Djot\Renderer\HtmlRenderer;
 
 // Full control via create()
 $converter = DjotConverter::create(
-    new BlockParser(blocksInterruptParagraphs: true, nestedBlocksInLists: true),
+    new BlockParser(blocksInterruptParagraphs: true, nestedListsWithoutBlankLine: true),
     new HtmlRenderer(xhtml: true),
 );
 ```
@@ -105,7 +105,7 @@ Note: Use `\` at end of line for hard breaks (always renders as `<br>`) regardle
 
 ::: warning Deprecated
 `significantNewlines` is now a convenience shorthand equal to enabling both
-`blocksInterruptParagraphs` and `nestedBlocksInLists` together. It is
+`blocksInterruptParagraphs` and `nestedListsWithoutBlankLine` together. It is
 deprecated in favor of the two granular levers. Migrate as shown below.
 
 ```php
@@ -115,7 +115,7 @@ $converter = DjotConverter::withSignificantNewlines();
 // Equivalent (preferred):
 $converter = new DjotConverter(
     blocksInterruptParagraphs: true,
-    nestedBlocksInLists: true,
+    nestedListsWithoutBlankLine: true,
 );
 ```
 :::
@@ -282,7 +282,7 @@ use Djot\Renderer\SoftBreakMode;
 // Significant newlines with safe mode for user-generated content
 $converter = new DjotConverter(
     safeMode: new SafeMode(),
-    significantNewlines: true, // deprecated: prefer blocksInterruptParagraphs + nestedBlocksInLists
+    significantNewlines: true, // deprecated: prefer blocksInterruptParagraphs + nestedListsWithoutBlankLine
     softBreakMode: SoftBreakMode::Break, // Optional: visible line breaks
 );
 ```
@@ -361,7 +361,7 @@ Output:
 | Nested blocks in list items without a blank line               | No      | **Yes**               | Yes                   |
 | Block elements interrupt top-level paragraphs                  | No      | No                    | Yes                   |
 
-Note: `significantNewlines` is deprecated; it enables both `blocksInterruptParagraphs` and `nestedBlocksInLists`. Prefer setting the two granular levers directly.
+Note: `significantNewlines` is deprecated; it enables both `blocksInterruptParagraphs` and `nestedListsWithoutBlankLine`. Prefer setting the two granular levers directly. (`nestedBlocksInLists` is a separate, also-deprecated broad lever - it is no longer what `significantNewlines` sets.)
 
 ## Block Interrupts Paragraphs Mode
 
@@ -412,7 +412,7 @@ A non-list block also nests inside a list item without a blank line. For example
 
 ```php
 $converter = DjotConverter::withBlocksInterruptParagraphs();
-$result = $converter->convert("- Item\n  > quote");
+$result = $converter->convert("- Item\n  > a\n  > b");
 ```
 
 Output:
@@ -421,13 +421,16 @@ Output:
 <li>
 Item
 <blockquote>
-<p>quote</p>
+<p>a
+b</p>
 </blockquote>
 </li>
 </ul>
 ```
 
-But a sublist does **not** nest with this flag alone (that requires [Nested Lists Without Blank Line](#nested-lists-without-blank-line-mode) mode):
+In-list interruption uses the **same** lone-marker lookahead as the top-level path: an ambiguous single-line marker (`>` comparison, `|`, a lone bullet) stays literal, while unambiguous openers (`#`, fenced code, `:::`, `---`) and real multi-line blocks nest. So `- Item\n  > quote` (a single `>` line) keeps `> quote` as literal text, exactly as `Foo\n> quote` does at the top level.
+
+A sublist does **not** nest with this flag alone (that requires [Nested Lists Without Blank Line](#nested-lists-without-blank-line-mode) mode):
 
 ```php
 $converter = DjotConverter::withBlocksInterruptParagraphs();

--- a/docs/guide/parser-options.md
+++ b/docs/guide/parser-options.md
@@ -365,9 +365,9 @@ Note: `significantNewlines` is deprecated; it enables both `blocksInterruptParag
 
 ## Block Interrupts Paragraphs Mode
 
-`blocksInterruptParagraphs` is the complementary counterpart to [Nested Blocks in Lists](#nested-blocks-in-lists-mode) mode. It allows top-level block elements — lists, blockquotes, headings, tables, thematic breaks, and code/div/comment fences — to interrupt a paragraph without a preceding blank line. It does **not** enable nesting inside list items (that is `nestedBlocksInLists`).
+`blocksInterruptParagraphs` allows top-level block elements - lists, blockquotes, headings, tables, thematic breaks, and code/div/comment fences - to interrupt a paragraph without a preceding blank line. It **also** interrupts a list item's lead paragraph, so an indented non-list block (blockquote, heading, fenced code, or thematic break) nests inside the open item without a blank line. It does **not** nest a sublist inside a list item - that requires [Nested Lists Without Blank Line](#nested-lists-without-blank-line-mode) mode.
 
-Use it when you want markdown-like top-level interruption but otherwise spec-compliant djot: indented content inside a list item still requires a blank line.
+Use it when you want markdown-like top-level interruption and non-list nesting in list items, but otherwise spec-compliant djot: a sublist under a list item still requires a blank line.
 
 ### Enabling Block Interrupts Paragraphs Mode
 
@@ -408,19 +408,38 @@ two
 </ul>
 ```
 
-But indented content inside a list item does **not** nest (this is what differs from significant newlines mode):
+A non-list block also nests inside a list item without a blank line. For example, a blockquote under the item:
 
 ```php
 $converter = DjotConverter::withBlocksInterruptParagraphs();
-$result = $converter->convert("- a\n  - b");
+$result = $converter->convert("- Item\n  > quote");
 ```
 
 Output:
 ```html
 <ul>
 <li>
-a
-- b
+Item
+<blockquote>
+<p>quote</p>
+</blockquote>
+</li>
+</ul>
+```
+
+But a sublist does **not** nest with this flag alone (that requires [Nested Lists Without Blank Line](#nested-lists-without-blank-line-mode) mode):
+
+```php
+$converter = DjotConverter::withBlocksInterruptParagraphs();
+$result = $converter->convert("- Item\n  - sub");
+```
+
+Output:
+```html
+<ul>
+<li>
+Item
+- sub
 </li>
 </ul>
 ```
@@ -430,6 +449,83 @@ a
 | Behavior                                                       | Default | `blocksInterruptParagraphs` | `significantNewlines` |
 |----------------------------------------------------------------|---------|-----------------------------|-----------------------|
 | Block elements interrupt top-level paragraphs                  | No      | **Yes**                     | Yes                   |
-| Nested blocks in list items without a blank line               | No      | No                          | Yes                   |
+| Non-list block nests in list item without a blank line         | No      | **Yes**                     | Yes                   |
+| Sublist nests in list item without a blank line                | No      | No                          | Yes                   |
 
-The two granular levers are independent. `blocksInterruptParagraphs` alone does not nest list items; `nestedBlocksInLists` alone does not interrupt top-level paragraphs. `significantNewlines` enables both simultaneously.
+The two granular levers are independent. `blocksInterruptParagraphs` alone does not nest sublists; `nestedListsWithoutBlankLine` alone does not interrupt top-level paragraphs or nest non-list blocks. `significantNewlines` enables both simultaneously.
+
+## Nested Lists Without Blank Line Mode
+
+`nestedListsWithoutBlankLine` lets a sublist nest inside a list item without a blank line, while leaving everything else at the spec default. It nests **only** sublists: a non-list block (blockquote, heading, thematic break) under the item stays literal, and top-level paragraphs are **not** interrupted.
+
+Use it when you want markdown-like nested lists but otherwise spec-compliant djot: top-level paragraphs still require a blank line before any block, and only sublists nest in list items.
+
+### Enabling Nested Lists Without Blank Line Mode
+
+```php
+use Djot\DjotConverter;
+use Djot\Parser\BlockParser;
+
+// Method 1: Factory method
+$converter = DjotConverter::withNestedListsWithoutBlankLine();
+
+// Method 2: Constructor parameter
+$converter = new DjotConverter(nestedListsWithoutBlankLine: true);
+
+// Method 3: Directly on the parser
+$parser = new BlockParser(nestedListsWithoutBlankLine: true);
+$parser->setNestedListsWithoutBlankLine(true);
+```
+
+### Behavior
+
+A sublist nests inside the open list item, even without a blank line:
+
+```php
+$converter = DjotConverter::withNestedListsWithoutBlankLine();
+$result = $converter->convert("- Item\n  - Nested one\n  - Nested two");
+```
+
+Output:
+```html
+<ul>
+<li>
+Item
+<ul>
+<li>
+Nested one
+</li>
+<li>
+Nested two
+</li>
+</ul>
+</li>
+</ul>
+```
+
+But a non-list block (such as a blockquote) under the item stays literal - it does **not** nest with this flag (that is `blocksInterruptParagraphs`):
+
+```php
+$converter = DjotConverter::withNestedListsWithoutBlankLine();
+$result = $converter->convert("- Item\n  > quote");
+```
+
+Output:
+```html
+<ul>
+<li>
+Item
+&gt; quote
+</li>
+</ul>
+```
+
+### nestedListsWithoutBlankLine vs blocksInterruptParagraphs
+
+| Behavior                                               | Default | `nestedListsWithoutBlankLine` | `blocksInterruptParagraphs` | both |
+|--------------------------------------------------------|---------|-------------------------------|-----------------------------|------|
+| Sublist nests in list item without a blank line        | No      | **Yes**                       | No                          | Yes  |
+| Non-list block nests in list item without a blank line | No      | No                            | **Yes**                     | Yes  |
+| Block elements interrupt top-level paragraphs          | No      | No                            | Yes                         | Yes  |
+
+Note: `blocksInterruptParagraphs` + `nestedListsWithoutBlankLine` together equal the deprecated `significantNewlines`; the deprecated `nestedBlocksInLists` enables the two in-list rows (sublist + non-list block) without top-level interruption.

--- a/docs/guide/syntax.md
+++ b/docs/guide/syntax.md
@@ -533,7 +533,7 @@ A list is loose if *any* item is separated by a blank line. One blank line makes
   - Nested item B
 ```
 
-With `significantNewlines` mode enabled, nested lists can appear immediately without a blank line:
+With `nestedListsWithoutBlankLine` mode enabled, nested lists can appear immediately without a blank line:
 
 ```djot
 - Parent item
@@ -541,7 +541,7 @@ With `significantNewlines` mode enabled, nested lists can appear immediately wit
   - Nested item B
 ```
 
-See the [API Reference](/reference/api#significant-newlines-mode) for more on `significantNewlines` mode.
+See the [Parser Options guide](/guide/parser-options#nested-lists-without-blank-line-mode) for more on `nestedListsWithoutBlankLine` mode.
 
 ### Definition Lists
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -27,6 +27,7 @@ public function __construct(
     ?RendererInterface $renderer = null,
     bool $nestedBlocksInLists = false,
     bool $blocksInterruptParagraphs = false,
+    bool $nestedListsWithoutBlankLine = false,
 )
 ```
 
@@ -38,10 +39,11 @@ public function __construct(
 - `$significantNewlines`: **Deprecated.** Convenience shorthand for `blocksInterruptParagraphs: true, nestedBlocksInLists: true`. Prefer the two granular levers. See [Significant Newlines Mode](#significant-newlines-mode).
 - `$softBreakMode`: Override how soft breaks are rendered. When `null`, uses the renderer's default (newline for HTML).
 - `$roundTripMode`: When `true`, adds round-trip metadata for Djot→HTML→Djot workflows (HTML renderer only).
-- `$parser`: Optional pre-configured parser. When provided, inline parser constructor flags such as `warnings`, `strict`, `significantNewlines` (deprecated), `nestedBlocksInLists`, and `blocksInterruptParagraphs` are ignored.
+- `$parser`: Optional pre-configured parser. When provided, inline parser constructor flags such as `warnings`, `strict`, `significantNewlines` (deprecated), `nestedBlocksInLists`, `blocksInterruptParagraphs`, and `nestedListsWithoutBlankLine` are ignored.
 - `$renderer`: Optional pre-configured renderer. When provided, inline renderer constructor flags such as `xhtml`, `safeMode`, `softBreakMode`, and `roundTripMode` are ignored.
 - `$nestedBlocksInLists`: When `true`, indentation alone introduces nested blocks inside list items without a blank line, while top-level paragraph interruption stays spec-compliant (see [Nested Blocks in Lists Mode](/guide/parser-options#nested-blocks-in-lists-mode)). Implied by `$significantNewlines`.
-- `$blocksInterruptParagraphs`: When `true`, top-level block elements (lists, blockquotes, headings, tables, thematic breaks, and code/div/comment fences) can interrupt a paragraph without a preceding blank line, while list-item nesting stays spec-compliant (see [Block Interrupts Paragraphs Mode](/guide/parser-options#block-interrupts-paragraphs-mode)). Implied by `$significantNewlines`.
+- `$blocksInterruptParagraphs`: When `true`, top-level block elements (lists, blockquotes, headings, tables, thematic breaks, and code/div/comment fences) can interrupt a paragraph without a preceding blank line. It **also** nests an indented non-list block (blockquote, heading, fenced code, thematic break) inside a list item without a blank line; it does not nest sublists (see [Block Interrupts Paragraphs Mode](/guide/parser-options#block-interrupts-paragraphs-mode)). Implied by `$significantNewlines`.
+- `$nestedListsWithoutBlankLine`: When `true`, a sublist nests inside a list item without a blank line. Only sublists nest; non-list blocks under the item stay literal and top-level paragraph interruption is unaffected (see [Nested Lists Without Blank Line Mode](/guide/parser-options#nested-lists-without-blank-line-mode)). Not set by `$significantNewlines` directly, but `$significantNewlines` produces the same sublist nesting through the deprecated `$nestedBlocksInLists`.
 
 ### Factory Methods
 
@@ -93,7 +95,23 @@ public static function withBlocksInterruptParagraphs(
 ): self
 ```
 
-Creates a converter that allows top-level block elements (lists, blockquotes, headings, tables, thematic breaks, and code/div/comment fences) to interrupt a paragraph without a preceding blank line, while list-item nesting stays spec-compliant. See [Block Interrupts Paragraphs Mode](/guide/parser-options#block-interrupts-paragraphs-mode).
+Creates a converter that allows top-level block elements (lists, blockquotes, headings, tables, thematic breaks, and code/div/comment fences) to interrupt a paragraph without a preceding blank line, and nests indented non-list blocks inside list items without a blank line. Sublist nesting stays spec-compliant. See [Block Interrupts Paragraphs Mode](/guide/parser-options#block-interrupts-paragraphs-mode).
+
+#### withNestedListsWithoutBlankLine()
+
+```php
+public static function withNestedListsWithoutBlankLine(
+    bool $xhtml = false,
+    bool $warnings = false,
+    bool $strict = false,
+    bool|SafeMode|null $safeMode = null,
+    ?Profile $profile = null,
+    ?SoftBreakMode $softBreakMode = null,
+    bool $roundTripMode = false,
+): self
+```
+
+Creates a converter that nests a sublist inside a list item without requiring a blank line. Only sublists nest; non-list blocks under the item stay literal and top-level paragraph interruption stays at the spec default. See [Nested Lists Without Blank Line Mode](/guide/parser-options#nested-lists-without-blank-line-mode).
 
 ### Methods
 
@@ -540,6 +558,7 @@ $parser = new BlockParser(
     significantNewlines: false,
     nestedBlocksInLists: false,
     blocksInterruptParagraphs: false,
+    nestedListsWithoutBlankLine: false,
 );
 $document = $parser->parse($djotString);
 
@@ -556,10 +575,16 @@ $isEnabled = $parser->getSignificantNewlines();
 $parser->setNestedBlocksInLists(true);
 $isEnabled = $parser->getNestedBlocksInLists();
 
-// Enable/disable top-level paragraph interruption only
+// Enable/disable top-level paragraph interruption and non-list
+// block nesting in list items
 // (significant newlines mode enables this implicitly)
 $parser->setBlocksInterruptParagraphs(true);
 $isEnabled = $parser->getBlocksInterruptParagraphs();
+
+// Enable/disable sublist nesting in list items only
+// (significant newlines mode enables this implicitly)
+$parser->setNestedListsWithoutBlankLine(true);
+$isEnabled = $parser->getNestedListsWithoutBlankLine();
 ```
 
 #### Custom Block Patterns

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -36,20 +36,20 @@ public function __construct(
 - `$strict`: When `true`, throws `ParseException` on parse errors (see [Error Handling](#error-handling)).
 - `$safeMode`: When `true` or a `SafeMode` instance, enables XSS protection (see [Safe Mode](#safe-mode)).
 - `$profile`: A `Profile` instance for feature restriction (see [Profiles](/guide/profiles)).
-- `$significantNewlines`: **Deprecated.** Convenience shorthand for `blocksInterruptParagraphs: true, nestedBlocksInLists: true`. Prefer the two granular levers. See [Significant Newlines Mode](#significant-newlines-mode).
+- `$significantNewlines`: **Deprecated.** Convenience shorthand for `blocksInterruptParagraphs: true, nestedListsWithoutBlankLine: true`. Prefer the two granular levers. See [Significant Newlines Mode](#significant-newlines-mode).
 - `$softBreakMode`: Override how soft breaks are rendered. When `null`, uses the renderer's default (newline for HTML).
 - `$roundTripMode`: When `true`, adds round-trip metadata for Djot→HTML→Djot workflows (HTML renderer only).
 - `$parser`: Optional pre-configured parser. When provided, inline parser constructor flags such as `warnings`, `strict`, `significantNewlines` (deprecated), `nestedBlocksInLists`, `blocksInterruptParagraphs`, and `nestedListsWithoutBlankLine` are ignored.
 - `$renderer`: Optional pre-configured renderer. When provided, inline renderer constructor flags such as `xhtml`, `safeMode`, `softBreakMode`, and `roundTripMode` are ignored.
-- `$nestedBlocksInLists`: When `true`, indentation alone introduces nested blocks inside list items without a blank line, while top-level paragraph interruption stays spec-compliant (see [Nested Blocks in Lists Mode](/guide/parser-options#nested-blocks-in-lists-mode)). Implied by `$significantNewlines`.
-- `$blocksInterruptParagraphs`: When `true`, top-level block elements (lists, blockquotes, headings, tables, thematic breaks, and code/div/comment fences) can interrupt a paragraph without a preceding blank line. It **also** nests an indented non-list block (blockquote, heading, fenced code, thematic break) inside a list item without a blank line; it does not nest sublists (see [Block Interrupts Paragraphs Mode](/guide/parser-options#block-interrupts-paragraphs-mode)). Implied by `$significantNewlines`.
-- `$nestedListsWithoutBlankLine`: When `true`, a sublist nests inside a list item without a blank line. Only sublists nest; non-list blocks under the item stay literal and top-level paragraph interruption is unaffected (see [Nested Lists Without Blank Line Mode](/guide/parser-options#nested-lists-without-blank-line-mode)). Not set by `$significantNewlines` directly, but `$significantNewlines` produces the same sublist nesting through the deprecated `$nestedBlocksInLists`.
+- `$nestedBlocksInLists`: **Deprecated.** When `true`, indentation alone introduces nested blocks of **any** type inside list items without a blank line (broad, eager - no lone-marker lookahead), while top-level paragraph interruption stays spec-compliant (see [Nested Blocks in Lists Mode](/guide/parser-options#nested-blocks-in-lists-mode)). Prefer `$blocksInterruptParagraphs` + `$nestedListsWithoutBlankLine`. No longer implied by `$significantNewlines`.
+- `$blocksInterruptParagraphs`: When `true`, top-level block elements (lists, blockquotes, headings, tables, thematic breaks, and code/div/comment fences) can interrupt a paragraph without a preceding blank line. It **also** interrupts a list item's lead paragraph, so an indented non-list block nests inside the item without a blank line, using the **same** lone-marker lookahead as the top level: unambiguous openers (`#`, fenced code, `:::`, `---`) and real multi-line blocks nest, while a single ambiguous marker line (`>`, `|`) stays literal. It does not nest sublists (see [Block Interrupts Paragraphs Mode](/guide/parser-options#block-interrupts-paragraphs-mode)). Implied by `$significantNewlines`.
+- `$nestedListsWithoutBlankLine`: When `true`, a sublist nests inside a list item without a blank line. Only sublists nest; non-list blocks under the item stay literal and top-level paragraph interruption is unaffected (see [Nested Lists Without Blank Line Mode](/guide/parser-options#nested-lists-without-blank-line-mode)). Implied by `$significantNewlines`.
 
 ### Factory Methods
 
 #### withSignificantNewlines()
 
-> **Deprecated.** Prefer using `new DjotConverter(blocksInterruptParagraphs: true, nestedBlocksInLists: true)` or the two dedicated factory methods. See [Significant Newlines Mode](/guide/parser-options#significant-newlines-mode).
+> **Deprecated.** Prefer using `new DjotConverter(blocksInterruptParagraphs: true, nestedListsWithoutBlankLine: true)` or the two dedicated factory methods. See [Significant Newlines Mode](/guide/parser-options#significant-newlines-mode).
 
 ```php
 public static function withSignificantNewlines(
@@ -63,7 +63,7 @@ public static function withSignificantNewlines(
 ): self
 ```
 
-Creates a converter with significant newlines mode enabled (equivalent to `blocksInterruptParagraphs: true` + `nestedBlocksInLists: true`). See [Significant Newlines Mode](/guide/parser-options#significant-newlines-mode).
+Creates a converter with significant newlines mode enabled (equivalent to `blocksInterruptParagraphs: true` + `nestedListsWithoutBlankLine: true`). See [Significant Newlines Mode](/guide/parser-options#significant-newlines-mode).
 
 #### withNestedBlocksInLists()
 
@@ -938,7 +938,7 @@ $node->addClass(string $class): void
 ## Significant Newlines Mode
 
 > **Deprecated.** `significantNewlines` is a convenience shorthand for
-> `blocksInterruptParagraphs: true` + `nestedBlocksInLists: true`.
+> `blocksInterruptParagraphs: true` + `nestedListsWithoutBlankLine: true`.
 > Prefer the two granular levers or their factory methods.
 
 An optional parsing mode for chat messages, comments, and quick notes where markdown-like behavior is more intuitive.
@@ -955,7 +955,7 @@ $converter = new DjotConverter(significantNewlines: true);
 // Preferred: use the two granular levers
 $converter = new DjotConverter(
     blocksInterruptParagraphs: true,
-    nestedBlocksInLists: true,
+    nestedListsWithoutBlankLine: true,
 );
 
 // Via parser directly (deprecated)

--- a/docs/reference/enhancements.md
+++ b/docs/reference/enhancements.md
@@ -14,7 +14,8 @@ They are either on the way to get incorporated upstream - or may be incorporated
 - [Symbol Parsing in Time Formats](#symbol-parsing-in-time-formats)
 - [Em/En Dash with Unmatched Braces](#em-en-dash-with-unmatched-braces)
 - [Optional Modes](#optional-modes)
-  - [Significant Newlines Mode](#significant-newlines-mode)
+  - [Block Interrupts Paragraphs Mode](#block-interrupts-paragraphs-mode)
+  - [Nested Lists Without Blank Line Mode](#nested-lists-without-blank-line-mode)
 - [Language Features Beyond Spec](#language-features-beyond-spec)
   - [Task List Underscore Notation](#task-list-underscore-notation)
   - [List Item Attributes](#list-item-attributes)
@@ -288,32 +289,20 @@ Unmatched `{-` does not prevent em/en-dash conversion:
 
 These are optional parser modes that deviate from spec behavior for specific use cases.
 
-### Significant Newlines Mode
+### Block Interrupts Paragraphs Mode
 
 **Related:** [jgm/djot#161](https://github.com/jgm/djot/issues/161)
 
 **Status:** Implemented in djot-php (opt-in)
 
-An optional mode for chat messages, comments, and quick notes where markdown-like behavior is more intuitive.
+Lets a block element interrupt a paragraph without a preceding blank line. This applies both to top-level paragraphs and to a list item's lead paragraph, so an indented non-list block (blockquote, heading, fenced code, or thematic break) nests inside the item without a blank line. It does not nest sublists - use [Nested Lists Without Blank Line Mode](#nested-lists-without-blank-line-mode) for that.
 
 **Enable via:**
 ```php
-// Factory method
-$converter = DjotConverter::withSignificantNewlines();
-
-// Constructor parameter
-$converter = new DjotConverter(significantNewlines: true);
-
-// Parser directly
-$parser = new BlockParser(significantNewlines: true);
+$converter = DjotConverter::withBlocksInterruptParagraphs();
+$converter = new DjotConverter(blocksInterruptParagraphs: true);
+$parser = new BlockParser(blocksInterruptParagraphs: true);
 ```
-
-**Changes from spec:**
-
-| Behavior | Standard Mode | Significant Newlines Mode |
-|----------|---------------|---------------------------|
-| Block elements interrupt paragraphs | No (blank line required) | Yes |
-| Nested lists need blank lines | Yes | No |
 
 Note: Soft break rendering is controlled separately via `SoftBreakMode` and is not affected by this setting.
 
@@ -331,12 +320,16 @@ Here is a list:
 - item two</p>
 ```
 
-**Significant newlines mode output:**
+**Block interrupts paragraphs mode output:**
 ```html
 <p>Here is a list:</p>
 <ul>
-<li>item one</li>
-<li>item two</li>
+<li>
+item one
+</li>
+<li>
+item two
+</li>
 </ul>
 ```
 
@@ -345,6 +338,21 @@ Here is a list:
 They said:
 \> This is not a blockquote
 ```
+
+### Nested Lists Without Blank Line Mode
+
+**Status:** Implemented in djot-php (opt-in)
+
+Lets a sublist nest inside a list item without a blank line between the item's content and the sublist. Only sublists are affected; other block types stay spec-strict (use [Block Interrupts Paragraphs Mode](#block-interrupts-paragraphs-mode) for non-list blocks).
+
+**Enable via:**
+```php
+$converter = DjotConverter::withNestedListsWithoutBlankLine();
+$converter = new DjotConverter(nestedListsWithoutBlankLine: true);
+$parser = new BlockParser(nestedListsWithoutBlankLine: true);
+```
+
+> **Deprecated:** `significantNewlines` (equivalent to enabling both levers) and `nestedBlocksInLists` (broad in-list nesting of all block types). Prefer the two granular levers above. See the [Parser Options guide](/guide/parser-options).
 
 ---
 
@@ -1002,9 +1010,10 @@ vendor/bin/phpunit
 
 ### Optional Modes
 
-| Mode                  | Upstream Issue                              | Status            |
-|-----------------------|---------------------------------------------|-------------------|
-| Significant newlines  | [#161](https://github.com/jgm/djot/issues/161) | djot-php (opt-in) |
+| Mode                          | Upstream Issue                                 | Status            |
+|-------------------------------|------------------------------------------------|-------------------|
+| Block interrupts paragraphs   | [#161](https://github.com/jgm/djot/issues/161) | djot-php (opt-in) |
+| Nested lists without blank line | -                                            | djot-php (opt-in) |
 
 These enhancements may be adopted into the official spec. We track upstream discussions and adjust our implementation accordingly.
 

--- a/src/DjotConverter.php
+++ b/src/DjotConverter.php
@@ -128,7 +128,7 @@ class DjotConverter
      * @param bool $roundTripMode Add data attributes for Djot→HTML→Djot round-trips (HTML renderer only)
      * @param \Djot\Parser\BlockParser|null $parser Pre-configured parser (ignores warnings/strict/significantNewlines/nestedBlocksInLists/blocksInterruptParagraphs/nestedListsWithoutBlankLine if set)
      * @param \Djot\Renderer\RendererInterface|null $renderer Pre-configured renderer (ignores xhtml/safeMode/softBreakMode/roundTripMode if set)
-     * @param bool $nestedBlocksInLists Allow nested blocks in list items without blank lines
+     * @param bool $nestedBlocksInLists Allow nested blocks in list items without blank lines (deprecated; prefer blocksInterruptParagraphs + nestedListsWithoutBlankLine)
      * @param bool $blocksInterruptParagraphs Allow top-level block elements to interrupt paragraphs without a blank line
      * @param bool $nestedListsWithoutBlankLine Allow sublists to nest in list items without a blank line
      */
@@ -197,7 +197,7 @@ class DjotConverter
      * or the softBreakMode parameter if you also want visible line breaks.
      *
      * @deprecated Use withBlocksInterruptParagraphs() and/or
-     *   withNestedBlocksInLists(). significantNewlines is the union of both.
+     *   withNestedListsWithoutBlankLine(). significantNewlines is the union of both.
      *
      * @param bool $xhtml Whether to use XHTML-compatible output
      * @param bool $warnings Whether to collect warnings during parsing
@@ -225,6 +225,8 @@ class DjotConverter
      * Paragraph interruption remains standard djot behavior, but indentation
      * alone can introduce nested sublists, blockquotes, and fenced blocks
      * inside an already-open list item.
+     *
+     * @deprecated Broad nesting of all block types in list items. Prefer withBlocksInterruptParagraphs() (non-list blocks) and/or withNestedListsWithoutBlankLine() (sublists).
      *
      * @param bool $xhtml Whether to use XHTML-compatible output
      * @param bool $warnings Whether to collect warnings during parsing

--- a/src/DjotConverter.php
+++ b/src/DjotConverter.php
@@ -126,7 +126,7 @@ class DjotConverter
      * @param bool $significantNewlines Enable significant newlines mode (markdown-like paragraph interruption)
      * @param \Djot\Renderer\SoftBreakMode|null $softBreakMode How to render soft breaks (HTML renderer only)
      * @param bool $roundTripMode Add data attributes for Djot→HTML→Djot round-trips (HTML renderer only)
-     * @param \Djot\Parser\BlockParser|null $parser Pre-configured parser (ignores warnings/strict/significantNewlines/nestedBlocksInLists/blocksInterruptParagraphs if set)
+     * @param \Djot\Parser\BlockParser|null $parser Pre-configured parser (ignores warnings/strict/significantNewlines/nestedBlocksInLists/blocksInterruptParagraphs/nestedListsWithoutBlankLine if set)
      * @param \Djot\Renderer\RendererInterface|null $renderer Pre-configured renderer (ignores xhtml/safeMode/softBreakMode/roundTripMode if set)
      * @param bool $nestedBlocksInLists Allow nested blocks in list items without blank lines
      * @param bool $blocksInterruptParagraphs Allow top-level block elements to interrupt paragraphs without a blank line
@@ -296,8 +296,9 @@ class DjotConverter
      *
      * A sublist may follow its parent item without a blank line (markdown-style
      * compact lists). Every other block type, and top-level paragraph
-     * interruption, stays standard djot. Focused successor to the deprecated
-     * withNestedBlocksInLists().
+     * interruption, stays standard djot.
+     * This is the list-only counterpart of the deprecated withNestedBlocksInLists();
+     * for the broad behavior, combine withBlocksInterruptParagraphs() with this.
      *
      * @param bool $xhtml Whether to use XHTML-compatible output
      * @param bool $warnings Whether to collect warnings during parsing

--- a/src/DjotConverter.php
+++ b/src/DjotConverter.php
@@ -130,6 +130,7 @@ class DjotConverter
      * @param \Djot\Renderer\RendererInterface|null $renderer Pre-configured renderer (ignores xhtml/safeMode/softBreakMode/roundTripMode if set)
      * @param bool $nestedBlocksInLists Allow nested blocks in list items without blank lines
      * @param bool $blocksInterruptParagraphs Allow top-level block elements to interrupt paragraphs without a blank line
+     * @param bool $nestedListsWithoutBlankLine Allow sublists to nest in list items without a blank line
      */
     public function __construct(
         bool $xhtml = false,
@@ -144,6 +145,7 @@ class DjotConverter
         ?RendererInterface $renderer = null,
         bool $nestedBlocksInLists = false,
         bool $blocksInterruptParagraphs = false,
+        bool $nestedListsWithoutBlankLine = false,
     ) {
         $this->collectWarnings = $warnings;
         $this->strictMode = $strict;
@@ -152,7 +154,7 @@ class DjotConverter
         if ($parser !== null) {
             $this->parser = $parser;
         } else {
-            $this->parser = new BlockParser($warnings, $strict, $significantNewlines, $nestedBlocksInLists, $blocksInterruptParagraphs);
+            $this->parser = new BlockParser($warnings, $strict, $significantNewlines, $nestedBlocksInLists, $blocksInterruptParagraphs, $nestedListsWithoutBlankLine);
         }
 
         // Use provided renderer or create one from parameters
@@ -286,6 +288,43 @@ class DjotConverter
             softBreakMode: $softBreakMode,
             roundTripMode: $roundTripMode,
             blocksInterruptParagraphs: true,
+        );
+    }
+
+    /**
+     * Create a converter that only enables nested lists in list items.
+     *
+     * A sublist may follow its parent item without a blank line (markdown-style
+     * compact lists). Every other block type, and top-level paragraph
+     * interruption, stays standard djot. Focused successor to the deprecated
+     * withNestedBlocksInLists().
+     *
+     * @param bool $xhtml Whether to use XHTML-compatible output
+     * @param bool $warnings Whether to collect warnings during parsing
+     * @param bool $strict Whether to throw exceptions on parse errors
+     * @param \Djot\SafeMode|bool|null $safeMode Enable safe mode
+     * @param \Djot\Profile|null $profile Profile for feature restriction
+     * @param \Djot\Renderer\SoftBreakMode|null $softBreakMode How to render soft breaks (HTML renderer only)
+     * @param bool $roundTripMode Add data attributes for round-trips (HTML renderer only)
+     */
+    public static function withNestedListsWithoutBlankLine(
+        bool $xhtml = false,
+        bool $warnings = false,
+        bool $strict = false,
+        SafeMode|bool|null $safeMode = null,
+        ?Profile $profile = null,
+        ?SoftBreakMode $softBreakMode = null,
+        bool $roundTripMode = false,
+    ): self {
+        return new self(
+            xhtml: $xhtml,
+            warnings: $warnings,
+            strict: $strict,
+            safeMode: $safeMode,
+            profile: $profile,
+            softBreakMode: $softBreakMode,
+            roundTripMode: $roundTripMode,
+            nestedListsWithoutBlankLine: true,
         );
     }
 

--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -183,10 +183,11 @@ class BlockParser
     ) {
         $this->collectWarnings = $collectWarnings;
         $this->strictMode = $strictMode;
-        // significantNewlines is the deprecated union of the two granular levers.
+        // significantNewlines is the deprecated union of blocksInterruptParagraphs
+        // and nestedListsWithoutBlankLine (NOT the broad nestedBlocksInLists).
         $this->blocksInterruptParagraphs = $blocksInterruptParagraphs || $significantNewlines;
-        $this->nestedBlocksInLists = $nestedBlocksInLists || $significantNewlines;
-        $this->nestedListsWithoutBlankLine = $nestedListsWithoutBlankLine;
+        $this->nestedBlocksInLists = $nestedBlocksInLists;
+        $this->nestedListsWithoutBlankLine = $nestedListsWithoutBlankLine || $significantNewlines;
         $this->inlineParser = new InlineParser($this);
         $this->listParser = new ListParser();
         $this->tableParser = new TableParser();
@@ -202,7 +203,7 @@ class BlockParser
     public function setSignificantNewlines(bool $value): self
     {
         $this->blocksInterruptParagraphs = $value;
-        $this->nestedBlocksInLists = $value;
+        $this->nestedListsWithoutBlankLine = $value;
 
         return $this;
     }
@@ -1884,7 +1885,7 @@ class BlockParser
                 if ($nextIndent >= $contentIndent) {
                     // If the active list-nesting mode treats this indented line
                     // as a nested block, break out so normal nesting handles it.
-                    if ($this->allowsImmediateNestedBlock($nextTrimmed)) {
+                    if ($this->allowsImmediateNestedBlock($nextTrimmed, $lines, $i)) {
                         break;
                     }
                     // Properly indented continuation - include with original indentation relative to content
@@ -2053,7 +2054,7 @@ class BlockParser
                 // when the leading line actually opens a nestable block.
                 $enterNesting = $nextIndent >= $contentIndent;
                 if ($enterNesting && !$this->nestedBlocksInLists) {
-                    $enterNesting = $this->allowsImmediateNestedBlock(ltrim($nextLine));
+                    $enterNesting = $this->allowsImmediateNestedBlock(ltrim($nextLine), $lines, $i);
                 }
 
                 // If there's indented content that could be a nested block
@@ -3415,14 +3416,15 @@ class BlockParser
      * - nestedBlocksInLists (deprecated, broad): any block element.
      * - nestedListsWithoutBlankLine: list markers only (compact sublists).
      * - blocksInterruptParagraphs: non-list blocks (a block interrupts the
-     *   item's lead paragraph, mirroring top-level interruption). Sublists are
-     *   intentionally NOT covered here - they require nestedListsWithoutBlankLine.
-     *
-     * @todo The blocksInterruptParagraphs branch uses single-line isBlockElementStart() rather than the top-level lone-marker lookahead (startsNewBlockSignificant()), so a lone-marker line such as "> 5" indented under a list item nests as a block, while the same line at top level stays literal. Reconcile if real-world reports justify it.
+     *   item's lead paragraph, mirroring top-level interruption including the
+     *   lone-marker lookahead). Sublists are intentionally NOT covered here -
+     *   they require nestedListsWithoutBlankLine.
      *
      * @param string $trimmed The left-trimmed candidate line.
+     * @param array<string> $lines All lines being parsed (lookahead context).
+     * @param int $index Index of the candidate line within $lines.
      */
-    protected function allowsImmediateNestedBlock(string $trimmed): bool
+    protected function allowsImmediateNestedBlock(string $trimmed, array $lines, int $index): bool
     {
         if ($this->nestedBlocksInLists) {
             return $this->isBlockElementStart($trimmed);
@@ -3434,8 +3436,12 @@ class BlockParser
             return true;
         }
 
-        if ($this->blocksInterruptParagraphs && !$isListMarker && $this->isBlockElementStart($trimmed)) {
-            return true;
+        if ($this->blocksInterruptParagraphs && !$isListMarker) {
+            // Use the SAME lone-marker-aware decision the top-level
+            // paragraph-interruption path uses, so an indented "> 5" / "| x"
+            // under a list item is treated identically to top level, while
+            // unambiguous openers (#, code fence, :::, ---) still interrupt.
+            return $this->startsNewBlockSignificant($trimmed, $lines, $index);
         }
 
         return false;

--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -1875,13 +1875,10 @@ class BlockParser
                 // Unless nested blocks in lists are enabled, indented block markers
                 // are treated as plain continuation text here.
                 if ($nextIndent >= $contentIndent) {
-                    // Check if list nesting mode allows immediate nested blocks
-                    if ($this->nestedBlocksInLists) {
-                        // Check for any block starter (list, blockquote, code fence, div)
-                        if ($this->isBlockElementStart($nextTrimmed)) {
-                            // This is a nested block - break out to let normal nesting handle it
-                            break;
-                        }
+                    // If the active list-nesting mode treats this indented line
+                    // as a nested block, break out so normal nesting handles it.
+                    if ($this->allowsImmediateNestedBlock($nextTrimmed)) {
+                        break;
                     }
                     // Properly indented continuation - include with original indentation relative to content
                     $itemLines[] = IndentationHelper::stripLeadingIndent($nextLine, $contentIndent);
@@ -2035,14 +2032,25 @@ class BlockParser
                 $this->parseBlocks($listItem, $itemLines, 0);
             }
 
-            // When nested blocks in lists are enabled, check for immediate
-            // nested content after the initial item paragraph.
-            if ($this->nestedBlocksInLists && $i < $count) {
+            // When a list-nesting mode is active, check for immediate nested
+            // content after the initial item paragraph.
+            $nestingModeActive = $this->nestedBlocksInLists
+                || $this->nestedListsWithoutBlankLine
+                || $this->blocksInterruptParagraphs;
+            if ($nestingModeActive && $i < $count) {
                 $nextLine = $lines[$i];
                 $nextIndent = IndentationHelper::getLeadingSpaces($nextLine);
 
+                // Broad nestedBlocksInLists collects any indented content (its
+                // original behavior). The granular levers only enter nesting
+                // when the leading line actually opens a nestable block.
+                $enterNesting = $nextIndent >= $contentIndent;
+                if ($enterNesting && !$this->nestedBlocksInLists) {
+                    $enterNesting = $this->allowsImmediateNestedBlock(ltrim($nextLine));
+                }
+
                 // If there's indented content that could be a nested block
-                if ($nextIndent >= $contentIndent) {
+                if ($enterNesting) {
                     $subLines = [];
                     $nestedIndent = $nextIndent;
                     while ($i < $count) {
@@ -3391,6 +3399,37 @@ class BlockParser
             'table' => isset($t[0]) && $t[0] === '|',
             default => true,
         };
+    }
+
+    /**
+     * Decide whether an indented line under an already-open list item should
+     * open a nested block (vs. be folded in as plain continuation text).
+     *
+     * - nestedBlocksInLists (deprecated, broad): any block element.
+     * - nestedListsWithoutBlankLine: list markers only (compact sublists).
+     * - blocksInterruptParagraphs: non-list blocks (a block interrupts the
+     *   item's lead paragraph, mirroring top-level interruption). Sublists are
+     *   intentionally NOT covered here - they require nestedListsWithoutBlankLine.
+     *
+     * @param string $trimmed The left-trimmed candidate line.
+     */
+    protected function allowsImmediateNestedBlock(string $trimmed): bool
+    {
+        if ($this->nestedBlocksInLists) {
+            return $this->isBlockElementStart($trimmed);
+        }
+
+        $isListMarker = $this->listParser->parseListItemMarker($trimmed) !== null;
+
+        if ($this->nestedListsWithoutBlankLine && $isListMarker) {
+            return true;
+        }
+
+        if ($this->blocksInterruptParagraphs && !$isListMarker && $this->isBlockElementStart($trimmed)) {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -160,6 +160,9 @@ class BlockParser
     /**
      * When true, indentation alone can introduce nested blocks inside list items
      * without enabling global paragraph interruption.
+     *
+     * @deprecated Broad deprecated lever superseded by the two granular levers
+     *   blocksInterruptParagraphs (non-list blocks) and nestedListsWithoutBlankLine (sublists).
      */
     protected bool $nestedBlocksInLists = false;
 
@@ -194,7 +197,7 @@ class BlockParser
      * Enable or disable significant newlines mode.
      *
      * @deprecated Use setBlocksInterruptParagraphs() and/or
-     *   setNestedBlocksInLists(). significantNewlines is the union of both.
+     *   setNestedListsWithoutBlankLine(). significantNewlines is the union of both.
      */
     public function setSignificantNewlines(bool $value): self
     {
@@ -207,7 +210,7 @@ class BlockParser
     /**
      * Check if significant newlines mode is enabled.
      *
-     * @deprecated Use getBlocksInterruptParagraphs() / getNestedBlocksInLists().
+     * @deprecated Use getBlocksInterruptParagraphs() / getNestedListsWithoutBlankLine().
      *   Returns the top-level interruption bit for backward compatibility.
      */
     public function getSignificantNewlines(): bool
@@ -235,6 +238,8 @@ class BlockParser
 
     /**
      * Enable or disable nested blocks in list items without blank lines.
+     *
+     * @deprecated Broad nesting of all block types in list items. Prefer setBlocksInterruptParagraphs() (non-list blocks) and/or setNestedListsWithoutBlankLine() (sublists).
      */
     public function setNestedBlocksInLists(bool $value): self
     {
@@ -245,6 +250,8 @@ class BlockParser
 
     /**
      * Check if nested blocks in list items are enabled.
+     *
+     * @deprecated Prefer getBlocksInterruptParagraphs() / getNestedListsWithoutBlankLine().
      */
     public function getNestedBlocksInLists(): bool
     {
@@ -3410,6 +3417,8 @@ class BlockParser
      * - blocksInterruptParagraphs: non-list blocks (a block interrupts the
      *   item's lead paragraph, mirroring top-level interruption). Sublists are
      *   intentionally NOT covered here - they require nestedListsWithoutBlankLine.
+     *
+     * @todo The blocksInterruptParagraphs branch uses single-line isBlockElementStart() rather than the top-level lone-marker lookahead (startsNewBlockSignificant()), so a lone-marker line such as "> 5" indented under a list item nests as a block, while the same line at top level stays literal. Reconcile if real-world reports justify it.
      *
      * @param string $trimmed The left-trimmed candidate line.
      */

--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -163,18 +163,27 @@ class BlockParser
      */
     protected bool $nestedBlocksInLists = false;
 
+    /**
+     * When true, indentation alone can introduce a nested *list* inside a list
+     * item without a blank line, while every other block type stays
+     * spec-strict. Focused successor to the deprecated nestedBlocksInLists.
+     */
+    protected bool $nestedListsWithoutBlankLine = false;
+
     public function __construct(
         bool $collectWarnings = false,
         bool $strictMode = false,
         bool $significantNewlines = false,
         bool $nestedBlocksInLists = false,
         bool $blocksInterruptParagraphs = false,
+        bool $nestedListsWithoutBlankLine = false,
     ) {
         $this->collectWarnings = $collectWarnings;
         $this->strictMode = $strictMode;
         // significantNewlines is the deprecated union of the two granular levers.
         $this->blocksInterruptParagraphs = $blocksInterruptParagraphs || $significantNewlines;
         $this->nestedBlocksInLists = $nestedBlocksInLists || $significantNewlines;
+        $this->nestedListsWithoutBlankLine = $nestedListsWithoutBlankLine;
         $this->inlineParser = new InlineParser($this);
         $this->listParser = new ListParser();
         $this->tableParser = new TableParser();
@@ -240,6 +249,24 @@ class BlockParser
     public function getNestedBlocksInLists(): bool
     {
         return $this->nestedBlocksInLists;
+    }
+
+    /**
+     * Enable or disable nested lists in list items without blank lines.
+     */
+    public function setNestedListsWithoutBlankLine(bool $value): self
+    {
+        $this->nestedListsWithoutBlankLine = $value;
+
+        return $this;
+    }
+
+    /**
+     * Check if nested lists in list items without blank lines are enabled.
+     */
+    public function getNestedListsWithoutBlankLine(): bool
+    {
+        return $this->nestedListsWithoutBlankLine;
     }
 
     /**

--- a/tests/TestCase/BlocksInterruptParagraphsOptionTest.php
+++ b/tests/TestCase/BlocksInterruptParagraphsOptionTest.php
@@ -84,7 +84,8 @@ class BlocksInterruptParagraphsOptionTest extends TestCase
     {
         $parser = new BlockParser(significantNewlines: true);
         $this->assertTrue($parser->getBlocksInterruptParagraphs());
-        $this->assertTrue($parser->getNestedBlocksInLists());
+        $this->assertTrue($parser->getNestedListsWithoutBlankLine());
+        $this->assertFalse($parser->getNestedBlocksInLists());
     }
 
     public function testSetSignificantNewlinesFalseDisablesBoth(): void
@@ -92,7 +93,7 @@ class BlocksInterruptParagraphsOptionTest extends TestCase
         $parser = new BlockParser(significantNewlines: true);
         $parser->setSignificantNewlines(false);
         $this->assertFalse($parser->getBlocksInterruptParagraphs());
-        $this->assertFalse($parser->getNestedBlocksInLists());
+        $this->assertFalse($parser->getNestedListsWithoutBlankLine());
     }
 
     public function testGetSignificantNewlinesReflectsInterruptionBit(): void
@@ -142,15 +143,31 @@ class BlocksInterruptParagraphsOptionTest extends TestCase
 
     public function testBlockquoteNestsInListItem(): void
     {
-        // Semantic expansion: a blockquote interrupts the item's lead paragraph.
+        // Semantic expansion: a real (multi-line) blockquote interrupts the
+        // item's lead paragraph and nests, the same as at top level.
         $parser = new BlockParser(blocksInterruptParagraphs: true);
-        $doc = $parser->parse("- Item\n  > quoted");
+        $doc = $parser->parse("- Item\n  > a\n  > b");
 
         $item = $doc->getChildren()[0]->getChildren()[0];
         $children = $item->getChildren();
         $this->assertCount(2, $children);
         $this->assertInstanceOf(Paragraph::class, $children[0]);
         $this->assertInstanceOf(BlockQuote::class, $children[1]);
+    }
+
+    public function testSingleLineBlockquoteInItemStaysLiteralLikeTopLevel(): void
+    {
+        // Consistency with top-level interruption: a lone "> ..." line is
+        // ambiguous (comparison vs quote), so the same lone-marker lookahead
+        // the top-level path uses keeps a single-line quote literal inside a
+        // list item too. Only a multi-line quote nests (see test above).
+        $parser = new BlockParser(blocksInterruptParagraphs: true);
+        $doc = $parser->parse("- Item\n  > quoted");
+
+        $item = $doc->getChildren()[0]->getChildren()[0];
+        foreach ($item->getChildren() as $child) {
+            $this->assertNotInstanceOf(BlockQuote::class, $child);
+        }
     }
 
     public function testHeadingNestsInListItem(): void

--- a/tests/TestCase/BlocksInterruptParagraphsOptionTest.php
+++ b/tests/TestCase/BlocksInterruptParagraphsOptionTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Djot\Test\TestCase;
 
 use Djot\DjotConverter;
+use Djot\Node\Block\BlockQuote;
+use Djot\Node\Block\Heading;
 use Djot\Node\Block\ListBlock;
 use Djot\Node\Block\Paragraph;
 use Djot\Parser\BlockParser;
@@ -136,5 +138,42 @@ class BlocksInterruptParagraphsOptionTest extends TestCase
 
         // significantNewlines still nests: two <ul>.
         $this->assertSame(2, substr_count($result, '<ul>'));
+    }
+
+    public function testBlockquoteNestsInListItem(): void
+    {
+        // Semantic expansion: a blockquote interrupts the item's lead paragraph.
+        $parser = new BlockParser(blocksInterruptParagraphs: true);
+        $doc = $parser->parse("- Item\n  > quoted");
+
+        $item = $doc->getChildren()[0]->getChildren()[0];
+        $children = $item->getChildren();
+        $this->assertCount(2, $children);
+        $this->assertInstanceOf(Paragraph::class, $children[0]);
+        $this->assertInstanceOf(BlockQuote::class, $children[1]);
+    }
+
+    public function testHeadingNestsInListItem(): void
+    {
+        $parser = new BlockParser(blocksInterruptParagraphs: true);
+        $doc = $parser->parse("- Item\n  # Head");
+
+        $item = $doc->getChildren()[0]->getChildren()[0];
+        $children = $item->getChildren();
+        $this->assertCount(2, $children);
+        $this->assertInstanceOf(Paragraph::class, $children[0]);
+        $this->assertInstanceOf(Heading::class, $children[1]);
+    }
+
+    public function testSublistDoesNotNestWithInterruptionAlone(): void
+    {
+        // A sublist needs nestedListsWithoutBlankLine, not blocksInterruptParagraphs.
+        $parser = new BlockParser(blocksInterruptParagraphs: true);
+        $doc = $parser->parse("- Item\n  - sub");
+
+        $item = $doc->getChildren()[0]->getChildren()[0];
+        foreach ($item->getChildren() as $child) {
+            $this->assertNotInstanceOf(ListBlock::class, $child);
+        }
     }
 }

--- a/tests/TestCase/NestedListsWithoutBlankLineOptionTest.php
+++ b/tests/TestCase/NestedListsWithoutBlankLineOptionTest.php
@@ -134,40 +134,33 @@ class NestedListsWithoutBlankLineOptionTest extends TestCase
 
     public function testBothLeversComposeAdditively(): void
     {
-        // Both granular levers on: sublist nests (list flag) AND blockquote
-        // nests (interrupt flag) inside the same item.
+        // Both granular levers on: sublist nests (list flag) AND a real
+        // multi-line blockquote nests (interrupt flag) inside list items.
         $converter = new DjotConverter(
             blocksInterruptParagraphs: true,
             nestedListsWithoutBlankLine: true,
         );
-        $result = $converter->convert("- Item\n  - sub\n\n- Two\n  > quoted");
+        $result = $converter->convert("- Item\n  - sub\n\n- Two\n  > a\n  > b");
 
         $this->assertSame(2, substr_count($result, '<ul>'));
         $this->assertStringContainsString('<blockquote>', $result);
     }
 
-    public function testLoneMarkerInItemUnderInterruptionIsScoped(): void
+    public function testLoneMarkerInItemStaysLiteralLikeTopLevel(): void
     {
-        // Behavior-locking test (documents current SCOPED behavior, not an
-        // endorsement): the in-list interrupt path uses a single-line block
-        // check, so a lone-marker-style line under a list item with
-        // blocksInterruptParagraphs is handled by the current implementation.
-        // This test pins whatever the current output is so future changes to
-        // the lone-marker handling are caught deliberately rather than by
-        // accident. Assert against the ACTUAL current output.
+        // Consistency: the in-list interrupt path uses the SAME lone-marker
+        // lookahead as the top-level path, so a lone "> 5" comparison line
+        // under a list item stays literal (it does NOT nest as a blockquote),
+        // exactly as "if x\n> 5 then" stays literal at top level.
         $parser = new BlockParser(blocksInterruptParagraphs: true);
         $doc = $parser->parse("- if x\n  > 5 then");
 
         $list = $doc->getChildren()[0];
         $this->assertInstanceOf(ListBlock::class, $list);
 
-        // Observed current behavior: under blocksInterruptParagraphs the
-        // "  > 5 then" line nests as a BlockQuote inside the item (it is NOT
-        // kept as literal paragraph text). Item children are [Paragraph, BlockQuote].
         $item = $list->getChildren()[0];
-        $children = $item->getChildren();
-        $this->assertCount(2, $children);
-        $this->assertInstanceOf(Paragraph::class, $children[0]);
-        $this->assertInstanceOf(BlockQuote::class, $children[1]);
+        foreach ($item->getChildren() as $child) {
+            $this->assertNotInstanceOf(BlockQuote::class, $child);
+        }
     }
 }

--- a/tests/TestCase/NestedListsWithoutBlankLineOptionTest.php
+++ b/tests/TestCase/NestedListsWithoutBlankLineOptionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Djot\Test\TestCase;
 
+use Djot\DjotConverter;
 use Djot\Node\Block\ListBlock;
 use Djot\Node\Block\Paragraph;
 use Djot\Parser\BlockParser;
@@ -72,5 +73,29 @@ class NestedListsWithoutBlankLineOptionTest extends TestCase
         $children = $doc->getChildren();
         $this->assertCount(1, $children);
         $this->assertInstanceOf(Paragraph::class, $children[0]);
+    }
+
+    public function testConverterConstructorParameter(): void
+    {
+        $converter = new DjotConverter(nestedListsWithoutBlankLine: true);
+        $result = $converter->convert("- Item\n  - Nested A\n  - Nested B");
+
+        $this->assertSame(2, substr_count($result, '<ul>'));
+    }
+
+    public function testConverterFactory(): void
+    {
+        $converter = DjotConverter::withNestedListsWithoutBlankLine();
+        $result = $converter->convert("- Item\n  - Nested A");
+
+        $this->assertSame(2, substr_count($result, '<ul>'));
+    }
+
+    public function testConverterFactoryDoesNotNestBlockquote(): void
+    {
+        $converter = DjotConverter::withNestedListsWithoutBlankLine();
+        $result = $converter->convert("- Item\n  > quoted");
+
+        $this->assertStringNotContainsString('<blockquote>', $result);
     }
 }

--- a/tests/TestCase/NestedListsWithoutBlankLineOptionTest.php
+++ b/tests/TestCase/NestedListsWithoutBlankLineOptionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Test\TestCase;
+
+use Djot\Node\Block\ListBlock;
+use Djot\Node\Block\Paragraph;
+use Djot\Parser\BlockParser;
+use PHPUnit\Framework\TestCase;
+
+class NestedListsWithoutBlankLineOptionTest extends TestCase
+{
+    public function testConstructorParameter(): void
+    {
+        $parser = new BlockParser(nestedListsWithoutBlankLine: true);
+        $this->assertTrue($parser->getNestedListsWithoutBlankLine());
+        $this->assertFalse($parser->getNestedBlocksInLists());
+        $this->assertFalse($parser->getBlocksInterruptParagraphs());
+    }
+
+    public function testSetterAndGetter(): void
+    {
+        $parser = new BlockParser();
+        $result = $parser->setNestedListsWithoutBlankLine(true);
+        $this->assertSame($parser, $result);
+        $this->assertTrue($parser->getNestedListsWithoutBlankLine());
+    }
+}

--- a/tests/TestCase/NestedListsWithoutBlankLineOptionTest.php
+++ b/tests/TestCase/NestedListsWithoutBlankLineOptionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Djot\Test\TestCase;
 
 use Djot\DjotConverter;
+use Djot\Node\Block\BlockQuote;
 use Djot\Node\Block\ListBlock;
 use Djot\Node\Block\Paragraph;
 use Djot\Parser\BlockParser;
@@ -97,5 +98,76 @@ class NestedListsWithoutBlankLineOptionTest extends TestCase
         $result = $converter->convert("- Item\n  > quoted");
 
         $this->assertStringNotContainsString('<blockquote>', $result);
+    }
+
+    public function testBothLeversReproduceSignificantNewlines(): void
+    {
+        $input = "Here is a list:\n- one\n- two\n\n- Item\n  - Nested\n  > quoted";
+
+        $granular = (new DjotConverter(
+            blocksInterruptParagraphs: true,
+            nestedListsWithoutBlankLine: true,
+        ))->convert($input);
+
+        $significant = DjotConverter::withSignificantNewlines()->convert($input);
+
+        $this->assertSame($significant, $granular);
+    }
+
+    public function testDeprecatedNestedBlocksInListsStillNestsAllBlockTypes(): void
+    {
+        // Regression guard for the broad deprecated flag.
+        $converter = DjotConverter::withNestedBlocksInLists();
+        $result = $converter->convert("- Item\n  > quoted");
+
+        $this->assertStringContainsString('<blockquote>', $result);
+    }
+
+    public function testSignificantNewlinesOutputUnchanged(): void
+    {
+        // Regression guard: broad behavior still nests sublists.
+        $converter = DjotConverter::withSignificantNewlines();
+        $result = $converter->convert("- a\n  - b");
+
+        $this->assertSame(2, substr_count($result, '<ul>'));
+    }
+
+    public function testBothLeversComposeAdditively(): void
+    {
+        // Both granular levers on: sublist nests (list flag) AND blockquote
+        // nests (interrupt flag) inside the same item.
+        $converter = new DjotConverter(
+            blocksInterruptParagraphs: true,
+            nestedListsWithoutBlankLine: true,
+        );
+        $result = $converter->convert("- Item\n  - sub\n\n- Two\n  > quoted");
+
+        $this->assertSame(2, substr_count($result, '<ul>'));
+        $this->assertStringContainsString('<blockquote>', $result);
+    }
+
+    public function testLoneMarkerInItemUnderInterruptionIsScoped(): void
+    {
+        // Behavior-locking test (documents current SCOPED behavior, not an
+        // endorsement): the in-list interrupt path uses a single-line block
+        // check, so a lone-marker-style line under a list item with
+        // blocksInterruptParagraphs is handled by the current implementation.
+        // This test pins whatever the current output is so future changes to
+        // the lone-marker handling are caught deliberately rather than by
+        // accident. Assert against the ACTUAL current output.
+        $parser = new BlockParser(blocksInterruptParagraphs: true);
+        $doc = $parser->parse("- if x\n  > 5 then");
+
+        $list = $doc->getChildren()[0];
+        $this->assertInstanceOf(ListBlock::class, $list);
+
+        // Observed current behavior: under blocksInterruptParagraphs the
+        // "  > 5 then" line nests as a BlockQuote inside the item (it is NOT
+        // kept as literal paragraph text). Item children are [Paragraph, BlockQuote].
+        $item = $list->getChildren()[0];
+        $children = $item->getChildren();
+        $this->assertCount(2, $children);
+        $this->assertInstanceOf(Paragraph::class, $children[0]);
+        $this->assertInstanceOf(BlockQuote::class, $children[1]);
     }
 }

--- a/tests/TestCase/NestedListsWithoutBlankLineOptionTest.php
+++ b/tests/TestCase/NestedListsWithoutBlankLineOptionTest.php
@@ -26,4 +26,51 @@ class NestedListsWithoutBlankLineOptionTest extends TestCase
         $this->assertSame($parser, $result);
         $this->assertTrue($parser->getNestedListsWithoutBlankLine());
     }
+
+    public function testSublistNestsWithoutBlankLine(): void
+    {
+        $parser = new BlockParser(nestedListsWithoutBlankLine: true);
+        $doc = $parser->parse("- Item\n  - Nested A\n  - Nested B");
+
+        $list = $doc->getChildren()[0];
+        $this->assertInstanceOf(ListBlock::class, $list);
+        $item = $list->getChildren()[0];
+        $children = $item->getChildren();
+        $this->assertCount(2, $children);
+        $this->assertInstanceOf(Paragraph::class, $children[0]);
+        $this->assertInstanceOf(ListBlock::class, $children[1]);
+    }
+
+    public function testBlockquoteInItemStaysLiteral(): void
+    {
+        // Narrow flag = sublists only; a blockquote under the item must NOT nest.
+        $parser = new BlockParser(nestedListsWithoutBlankLine: true);
+        $doc = $parser->parse("- Item\n  > quoted");
+
+        $item = $doc->getChildren()[0]->getChildren()[0];
+        foreach ($item->getChildren() as $child) {
+            $this->assertInstanceOf(Paragraph::class, $child);
+        }
+    }
+
+    public function testHeadingInItemStaysLiteral(): void
+    {
+        $parser = new BlockParser(nestedListsWithoutBlankLine: true);
+        $doc = $parser->parse("- Item\n  # Head");
+
+        $item = $doc->getChildren()[0]->getChildren()[0];
+        foreach ($item->getChildren() as $child) {
+            $this->assertInstanceOf(Paragraph::class, $child);
+        }
+    }
+
+    public function testTopLevelParagraphNotInterrupted(): void
+    {
+        $parser = new BlockParser(nestedListsWithoutBlankLine: true);
+        $doc = $parser->parse("Here is a list:\n- one\n- two");
+
+        $children = $doc->getChildren();
+        $this->assertCount(1, $children);
+        $this->assertInstanceOf(Paragraph::class, $children[0]);
+    }
 }

--- a/tests/TestCase/Parser/BlockParserTest.php
+++ b/tests/TestCase/Parser/BlockParserTest.php
@@ -613,8 +613,11 @@ DJOT;
 
     public function testSignificantNewlinesBlockquoteInList(): void
     {
+        // A real (multi-line) blockquote nests in a list item under
+        // significantNewlines. A lone single-line "> ..." stays literal via the
+        // shared lone-marker lookahead (consistent with top-level interruption).
         $parser = new BlockParser(significantNewlines: true);
-        $doc = $parser->parse("- Item\n  > quoted");
+        $doc = $parser->parse("- Item\n  > a\n  > b");
 
         $list = $doc->getChildren()[0];
         $item = $list->getChildren()[0];

--- a/tests/TestCase/SignificantNewlinesTest.php
+++ b/tests/TestCase/SignificantNewlinesTest.php
@@ -175,8 +175,10 @@ class SignificantNewlinesTest extends TestCase
 
     public function testBlockquoteInListWithoutBlankLine(): void
     {
+        // A real (multi-line) blockquote nests; a lone single-line "> ..." line
+        // stays literal via the shared lone-marker lookahead (matches top level).
         $parser = new BlockParser(significantNewlines: true);
-        $doc = $parser->parse("- Item\n  > quoted");
+        $doc = $parser->parse("- Item\n  > a\n  > b");
 
         $list = $doc->getChildren()[0];
         $item = $list->getChildren()[0];


### PR DESCRIPTION
## Summary

Adds two composable, opt-in list-nesting levers and deprecates the broad one, so paragraph interruption behaves the same at the top level and inside list items.

- **New `nestedListsWithoutBlankLine` lever:** a sublist nests inside a list item without a blank line (markdown-style compact lists). Nothing else nests. Available as a constructor flag, `setNestedListsWithoutBlankLine()`, and `DjotConverter::withNestedListsWithoutBlankLine()`.
- **`blocksInterruptParagraphs` made consistent:** it now also interrupts a list item's lead paragraph, so an indented non-list block nests inside the item, using the **same** lone-marker lookahead as the top level. Unambiguous openers (`#`, fenced code, `:::`, `---`) and real multi-line blocks nest; an ambiguous single-line marker (`>` comparison, `|`) stays literal. A lone `> 5` indented under a list item now behaves exactly like it does at the top level.
- **`significantNewlines` redefined:** now equivalent to `blocksInterruptParagraphs` + `nestedListsWithoutBlankLine`, and deprecated. The broad `nestedBlocksInLists` is also deprecated (kept working, unchanged eager nesting).

All levers are opt-in; no default behavior changes.

## Implementation

- A single gate `BlockParser::allowsImmediateNestedBlock()` drives both in-list nesting sites; the interrupt branch routes through the existing `startsNewBlockSignificant()` lookahead so in-list and top-level interruption share one rule.
- Docs updated to match: parser-options guide (new mode section + comparison tables), API reference, enhancements (optional-modes now lead with the granular levers), and the syntax guide.
