### PR TITLE
Nest sublists in list items under blocksInterruptParagraphs

### DIFF
--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -3414,11 +3414,13 @@ class BlockParser
      * open a nested block (vs. be folded in as plain continuation text).
      *
      * - nestedBlocksInLists (deprecated, broad): any block element.
-     * - nestedListsWithoutBlankLine: list markers only (compact sublists).
-     * - blocksInterruptParagraphs: non-list blocks (a block interrupts the
-     *   item's lead paragraph, mirroring top-level interruption including the
-     *   lone-marker lookahead). Sublists are intentionally NOT covered here -
-     *   they require nestedListsWithoutBlankLine.
+     * - nestedListsWithoutBlankLine: list markers only (compact sublists), the
+     *   narrow subset that always nests a sublist marker without lookahead.
+     * - blocksInterruptParagraphs: any block interrupts the item's lead
+     *   paragraph, mirroring top-level interruption including the lone-marker
+     *   lookahead. A list is a block, so sublists are covered here too (the
+     *   lookahead folds an ambiguous lone "- x" / "> x" in as continuation),
+     *   which makes nestedListsWithoutBlankLine a subset of this behavior.
      *
      * @param string $trimmed The left-trimmed candidate line.
      * @param array<string> $lines All lines being parsed (lookahead context).
@@ -3432,15 +3434,17 @@ class BlockParser
 
         $isListMarker = $this->listParser->parseListItemMarker($trimmed) !== null;
 
+        // Narrow subset: always nest a sublist marker, no lookahead.
         if ($this->nestedListsWithoutBlankLine && $isListMarker) {
             return true;
         }
 
-        if ($this->blocksInterruptParagraphs && !$isListMarker) {
+        if ($this->blocksInterruptParagraphs) {
             // Use the SAME lone-marker-aware decision the top-level
-            // paragraph-interruption path uses, so an indented "> 5" / "| x"
-            // under a list item is treated identically to top level, while
-            // unambiguous openers (#, code fence, :::, ---) still interrupt.
+            // paragraph-interruption path uses, so an indented "> 5" / "| x" / a
+            // sublist marker under a list item is treated identically to top
+            // level, while unambiguous openers (#, code fence, :::, ---) and
+            // real (multi-item) sublists interrupt.
             return $this->startsNewBlockSignificant($trimmed, $lines, $index);
         }
 

--- a/tests/TestCase/BlocksInterruptParagraphsOptionTest.php
+++ b/tests/TestCase/BlocksInterruptParagraphsOptionTest.php
@@ -182,9 +182,27 @@ class BlocksInterruptParagraphsOptionTest extends TestCase
         $this->assertInstanceOf(Heading::class, $children[1]);
     }
 
-    public function testSublistDoesNotNestWithInterruptionAlone(): void
+    public function testMultiItemSublistNestsInListItem(): void
     {
-        // A sublist needs nestedListsWithoutBlankLine, not blocksInterruptParagraphs.
+        // A list is a block, so a real (multi-item) sublist interrupts the
+        // item's lead paragraph and nests, the same as at top level.
+        $parser = new BlockParser(blocksInterruptParagraphs: true);
+        $doc = $parser->parse("- Item\n  - a\n  - b");
+
+        $item = $doc->getChildren()[0]->getChildren()[0];
+        $children = $item->getChildren();
+        $this->assertCount(2, $children);
+        $this->assertInstanceOf(Paragraph::class, $children[0]);
+        $this->assertInstanceOf(ListBlock::class, $children[1]);
+    }
+
+    public function testLoneSublistItemStaysLiteralLikeTopLevel(): void
+    {
+        // Consistency with top-level interruption: a lone "- x" line is
+        // ambiguous (operator vs list), so the same lone-marker lookahead keeps
+        // a single-item sublist literal inside a list item. Only a multi-item
+        // sublist nests (see test above). nestedListsWithoutBlankLine is the
+        // narrow subset that nests even this lone case.
         $parser = new BlockParser(blocksInterruptParagraphs: true);
         $doc = $parser->parse("- Item\n  - sub");
 
@@ -192,5 +210,36 @@ class BlocksInterruptParagraphsOptionTest extends TestCase
         foreach ($item->getChildren() as $child) {
             $this->assertNotInstanceOf(ListBlock::class, $child);
         }
+    }
+
+    public function testSublistMarkerSetMatchesTopLevelInterruption(): void
+    {
+        // Interruption deliberately recognizes the same list openers as the
+        // top-level path: bullets and 1./1) ordered (the CommonMark guard that
+        // keeps "2. apples" or "(1) note" prose). A "2." sublist therefore stays
+        // literal under interruption alone, exactly as it would at top level,
+        // keeping behavior identical across nesting levels.
+        $parser = new BlockParser(blocksInterruptParagraphs: true);
+        $doc = $parser->parse("- Item\n  2. a\n  3. b");
+
+        $item = $doc->getChildren()[0]->getChildren()[0];
+        foreach ($item->getChildren() as $child) {
+            $this->assertNotInstanceOf(ListBlock::class, $child);
+        }
+    }
+
+    public function testNestedListsOptionIsSubsetOfInterruption(): void
+    {
+        // The narrow lever nests a lone single-item sublist that interruption's
+        // lookahead folds in, confirming it as a distinct, blunter subset.
+        $narrow = (new BlockParser(nestedListsWithoutBlankLine: true))->parse("- Item\n  - sub");
+        $item = $narrow->getChildren()[0]->getChildren()[0];
+        $hasSublist = false;
+        foreach ($item->getChildren() as $child) {
+            if ($child instanceof ListBlock) {
+                $hasSublist = true;
+            }
+        }
+        $this->assertTrue($hasSublist);
     }
 }


### PR DESCRIPTION
## Problem

`blocksInterruptParagraphs` treated a sublist inconsistently across nesting levels. At the top level a list already interrupts a paragraph under this option, but inside a list item `allowsImmediateNestedBlock()` explicitly excluded list markers (`!$isListMarker`), so a blockquote, heading, fence or table nested in an item while a sublist did not. A list is a block, so the two cases should behave the same.

```
- Item
  - a
  - b
```
Under `blocksInterruptParagraphs` this used to fold `- a` / `- b` into the item as literal text; only `nestedListsWithoutBlankLine` would nest it.

## Change

The in-item path now delegates list markers to the same `startsNewBlockSignificant()` decision the top-level paragraph-interruption path uses. Behavior is now identical across nesting levels:

- A real (multi-item) sublist nests inside a list item.
- A lone single-item `- x` stays literal, via the same lone-marker lookahead that keeps `x = 5` / `- 3` as prose at the top level.
- Recognized openers match the top level exactly: bullets and `1.`/`1)` ordered (the CommonMark guard that keeps `2. apples` or `(1) note` as prose). A `2.` or `(1)` sublist stays literal under interruption alone, the same as at top level.

This makes `nestedListsWithoutBlankLine` a clear narrower subset: it still nests a lone sublist marker without lookahead, which interruption's lookahead folds in. The deprecated broad `nestedBlocksInLists` is unchanged.

## Notes

The recognized-marker set is intentionally restricted to match top-level interruption, not the canonical `parseListItemMarker` coverage. Broadening it would make in-item nesting more permissive than top-level interruption and reintroduce the very cross-level inconsistency this fixes; a regression test pins that parity.

Tests cover multi-item nesting, the lone-marker fold, the restricted marker set, and the subset relationship. Full suite green (2487 tests) including the official djot suite; phpstan and phpcs clean.
