### PR TITLE
Drop lone-marker guard: markers interrupt under blocksInterruptParagraphs

### DIFF
--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -3318,36 +3318,23 @@ class BlockParser
             case '-':
             case '*':
             case '+':
-                // Unordered lists or thematic breaks
+                // Unordered lists or thematic breaks. blocksInterruptParagraphs
+                // is an opt-in markdown/chat-like mode, so a line-leading marker
+                // interrupts without a blank line (it would otherwise drop a
+                // genuine single-line or lazily-wrapped list).
                 if (isset($line[1]) && $line[1] === ' ') {
-                    // A lone marker line in flowing prose is almost always an
-                    // operator ("x = 5\n* 3 + 17", "10\n- 3 ist 7"), not a list.
-                    // When prose lookahead is available, only interrupt for a
-                    // real block: 2+ markers or an indented continuation.
-                    if ($lines !== null) {
-                        return $this->significantMarkerHasBlockContinuation('bullet', $lines, $index);
-                    }
-
                     return true; // Unordered list
                 }
 
                 // Thematic breaks: *\s*\*\s*\* or -\s*-\s*-
                 return preg_match('/^(\*\s*\*\s*\*|-\s*-\s*-)/', $line) === 1;
             case '|':
-                // Tables — a single "| ..." line is not a valid table; in prose
-                // require a real table (next line also a row, e.g. delimiter).
-                if ($lines !== null) {
-                    return $this->significantMarkerHasBlockContinuation('table', $lines, $index);
-                }
-
-                return true;
+                // Tables: a single "| a | b |" row is already a valid table, but
+                // a pipe in prose ("a\n| b als Oder.") is not a row, so validate
+                // before interrupting to avoid splitting prose into stray blocks.
+                return $this->tableParser->isTableRow($line);
             case '>':
-                // Block quotes — a lone ">" in prose ("if x\n> 5 then") is a
-                // comparison, not a quote; require a real (multi-line) quote.
-                if ($lines !== null) {
-                    return $this->significantMarkerHasBlockContinuation('quote', $lines, $index);
-                }
-
+                // Block quotes (single-line and lazily-wrapped quotes interrupt).
                 return true;
             case '`':
                 // Code fences: `{3,}
@@ -3367,46 +3354,6 @@ class BlockParser
 
                 return false;
         }
-    }
-
-    /**
-     * In significantNewlines mode, decide whether a lone marker line in flowing
-     * prose really begins a block, or is just an operator/punctuation that
-     * happens to start a hard-wrapped line ("x = 5\n* 3 + 17", "if x\n> 5").
-     *
-     * A real block requires the immediately following line to either continue
-     * the block (another same-kind marker, i.e. 2+ markers) or be an indented
-     * continuation. A single isolated marker line stays paragraph text.
-     *
-     * @param string $kind One of 'bullet', 'quote', 'table'
-     * @param array<string> $lines All source lines
-     * @param int $index Index of the marker line within $lines
-     */
-    private function significantMarkerHasBlockContinuation(string $kind, array $lines, int $index): bool
-    {
-        $next = $lines[$index + 1] ?? null;
-
-        // Lone marker as the last line (e.g. "Total: 5\n- 3") is not a block.
-        if ($next === null || IndentationHelper::isBlankLine($next)) {
-            return false;
-        }
-
-        // Indented continuation of a multi-line first item ("- item\n  more").
-        // Only meaningful for lists; quotes/tables need their own marker.
-        if ($kind === 'bullet' && preg_match('/^\s/', $next) === 1) {
-            return true;
-        }
-
-        $t = ltrim($next);
-
-        return match ($kind) {
-            'bullet' => isset($t[0], $t[1])
-                && ($t[0] === '-' || $t[0] === '*' || $t[0] === '+')
-                && $t[1] === ' ',
-            'quote' => isset($t[0]) && $t[0] === '>',
-            'table' => isset($t[0]) && $t[0] === '|',
-            default => true,
-        };
     }
 
     /**

--- a/tests/TestCase/BlocksInterruptParagraphsOptionTest.php
+++ b/tests/TestCase/BlocksInterruptParagraphsOptionTest.php
@@ -55,29 +55,39 @@ class BlocksInterruptParagraphsOptionTest extends TestCase
         $this->assertInstanceOf(Paragraph::class, $children[0]);
     }
 
-    public function testInterruptionWithoutNesting(): void
+    public function testInterruptionNestsSublist(): void
     {
-        // blocksInterruptParagraphs alone must NOT enable list nesting:
-        // "- a\n  - b" stays a single list (b is continuation text).
+        // A marker interrupts at every level, so blocksInterruptParagraphs nests
+        // an indented sublist inside a list item ("- a\n  - b" => two lists).
+        // nestedListsWithoutBlankLine remains the smaller subset (sublists only,
+        // no other-block interruption).
         $parser = new BlockParser(blocksInterruptParagraphs: true);
         $doc = $parser->parse("- a\n  - b");
 
         $list = $doc->getChildren()[0];
         $this->assertInstanceOf(ListBlock::class, $list);
         $item = $list->getChildren()[0];
+        $hasSublist = false;
         foreach ($item->getChildren() as $child) {
-            $this->assertNotInstanceOf(ListBlock::class, $child);
+            if ($child instanceof ListBlock) {
+                $hasSublist = true;
+            }
         }
+        $this->assertTrue($hasSublist);
     }
 
-    public function testLoneMarkerRuleStillApplies(): void
+    public function testWrappedMarkerInterrupts(): void
     {
+        // Opt-in aggressive mode: a line-leading marker interrupts the paragraph,
+        // so a wrapped "x = 5\n- 3 + 17" is read as a list (the bargain for
+        // keeping genuine single-line and lazily-wrapped lists).
         $parser = new BlockParser(blocksInterruptParagraphs: true);
         $doc = $parser->parse("x = 5\n- 3 + 17");
 
         $children = $doc->getChildren();
-        $this->assertCount(1, $children);
+        $this->assertCount(2, $children);
         $this->assertInstanceOf(Paragraph::class, $children[0]);
+        $this->assertInstanceOf(ListBlock::class, $children[1]);
     }
 
     public function testSignificantNewlinesEnablesBothLevers(): void
@@ -123,13 +133,13 @@ class BlocksInterruptParagraphsOptionTest extends TestCase
         $this->assertStringContainsString('<ul>', $result);
     }
 
-    public function testConverterFactoryDoesNotNest(): void
+    public function testConverterFactoryNestsSublist(): void
     {
         $converter = DjotConverter::withBlocksInterruptParagraphs();
         $result = $converter->convert("- a\n  - b");
 
-        // Interruption-only must not nest: exactly one <ul>.
-        $this->assertSame(1, substr_count($result, '<ul>'));
+        // A marker interrupts at every level, so the sublist nests: two <ul>.
+        $this->assertSame(2, substr_count($result, '<ul>'));
     }
 
     public function testWithSignificantNewlinesStillEnablesBoth(): void
@@ -155,19 +165,21 @@ class BlocksInterruptParagraphsOptionTest extends TestCase
         $this->assertInstanceOf(BlockQuote::class, $children[1]);
     }
 
-    public function testSingleLineBlockquoteInItemStaysLiteralLikeTopLevel(): void
+    public function testSingleLineBlockquoteNestsInListItem(): void
     {
-        // Consistency with top-level interruption: a lone "> ..." line is
-        // ambiguous (comparison vs quote), so the same lone-marker lookahead
-        // the top-level path uses keeps a single-line quote literal inside a
-        // list item too. Only a multi-line quote nests (see test above).
+        // A marker interrupts at every level, so even a single-line quote nests
+        // inside a list item (consistent with top-level interruption).
         $parser = new BlockParser(blocksInterruptParagraphs: true);
         $doc = $parser->parse("- Item\n  > quoted");
 
         $item = $doc->getChildren()[0]->getChildren()[0];
+        $hasQuote = false;
         foreach ($item->getChildren() as $child) {
-            $this->assertNotInstanceOf(BlockQuote::class, $child);
+            if ($child instanceof BlockQuote) {
+                $hasQuote = true;
+            }
         }
+        $this->assertTrue($hasQuote);
     }
 
     public function testHeadingNestsInListItem(): void
@@ -196,20 +208,21 @@ class BlocksInterruptParagraphsOptionTest extends TestCase
         $this->assertInstanceOf(ListBlock::class, $children[1]);
     }
 
-    public function testLoneSublistItemStaysLiteralLikeTopLevel(): void
+    public function testLoneSublistItemNestsInListItem(): void
     {
-        // Consistency with top-level interruption: a lone "- x" line is
-        // ambiguous (operator vs list), so the same lone-marker lookahead keeps
-        // a single-item sublist literal inside a list item. Only a multi-item
-        // sublist nests (see test above). nestedListsWithoutBlankLine is the
-        // narrow subset that nests even this lone case.
+        // A marker interrupts at every level, so even a single-item sublist nests
+        // inside a list item (consistent with top-level interruption).
         $parser = new BlockParser(blocksInterruptParagraphs: true);
         $doc = $parser->parse("- Item\n  - sub");
 
         $item = $doc->getChildren()[0]->getChildren()[0];
+        $hasSublist = false;
         foreach ($item->getChildren() as $child) {
-            $this->assertNotInstanceOf(ListBlock::class, $child);
+            if ($child instanceof ListBlock) {
+                $hasSublist = true;
+            }
         }
+        $this->assertTrue($hasSublist);
     }
 
     public function testSublistMarkerSetMatchesTopLevelInterruption(): void
@@ -228,18 +241,24 @@ class BlocksInterruptParagraphsOptionTest extends TestCase
         }
     }
 
-    public function testNestedListsOptionIsSubsetOfInterruption(): void
+    public function testNestedListsOptionIsSmallerSubset(): void
     {
-        // The narrow lever nests a lone single-item sublist that interruption's
-        // lookahead folds in, confirming it as a distinct, blunter subset.
-        $narrow = (new BlockParser(nestedListsWithoutBlankLine: true))->parse("- Item\n  - sub");
+        // nestedListsWithoutBlankLine is the smaller subset: it nests a sublist
+        // in a list item but, unlike blocksInterruptParagraphs, does NOT let a
+        // non-list block (here a blockquote) interrupt the item's paragraph.
+        $narrow = (new BlockParser(nestedListsWithoutBlankLine: true))->parse("- Item\n  - sub\n  > quote");
         $item = $narrow->getChildren()[0]->getChildren()[0];
         $hasSublist = false;
+        $hasQuote = false;
         foreach ($item->getChildren() as $child) {
             if ($child instanceof ListBlock) {
                 $hasSublist = true;
             }
+            if ($child instanceof BlockQuote) {
+                $hasQuote = true;
+            }
         }
         $this->assertTrue($hasSublist);
+        $this->assertFalse($hasQuote);
     }
 }

--- a/tests/TestCase/NestedListsWithoutBlankLineOptionTest.php
+++ b/tests/TestCase/NestedListsWithoutBlankLineOptionTest.php
@@ -146,12 +146,12 @@ class NestedListsWithoutBlankLineOptionTest extends TestCase
         $this->assertStringContainsString('<blockquote>', $result);
     }
 
-    public function testLoneMarkerInItemStaysLiteralLikeTopLevel(): void
+    public function testLoneMarkerInItemInterruptsWithBlocksInterrupt(): void
     {
-        // Consistency: the in-list interrupt path uses the SAME lone-marker
-        // lookahead as the top-level path, so a lone "> 5" comparison line
-        // under a list item stays literal (it does NOT nest as a blockquote),
-        // exactly as "if x\n> 5 then" stays literal at top level.
+        // blocksInterruptParagraphs is the aggressive opt-in mode: a line-leading
+        // ">" interrupts at every level, so it nests as a blockquote inside the
+        // item (consistent with top-level interruption). nestedListsWithoutBlankLine
+        // alone would leave it literal (it nests only sublists).
         $parser = new BlockParser(blocksInterruptParagraphs: true);
         $doc = $parser->parse("- if x\n  > 5 then");
 
@@ -159,8 +159,12 @@ class NestedListsWithoutBlankLineOptionTest extends TestCase
         $this->assertInstanceOf(ListBlock::class, $list);
 
         $item = $list->getChildren()[0];
+        $hasQuote = false;
         foreach ($item->getChildren() as $child) {
-            $this->assertNotInstanceOf(BlockQuote::class, $child);
+            if ($child instanceof BlockQuote) {
+                $hasQuote = true;
+            }
         }
+        $this->assertTrue($hasQuote);
     }
 }

--- a/tests/TestCase/SignificantNewlinesTest.php
+++ b/tests/TestCase/SignificantNewlinesTest.php
@@ -74,15 +74,19 @@ class SignificantNewlinesTest extends TestCase
         $this->assertInstanceOf(BlockQuote::class, $children[1]);
     }
 
-    public function testLoneBlockquoteMarkerDoesNotInterruptParagraph(): void
+    public function testLoneBlockquoteMarkerInterruptsInSignificantMode(): void
     {
-        // "if x\n> 5 then ..." — the ">" is greater-than, not a blockquote.
+        // significantNewlines/blocksInterruptParagraphs is an opt-in markdown/
+        // chat-like mode: a line-leading ">" interrupts the paragraph as a quote,
+        // so genuine single-line and lazily-wrapped quotes are preserved. The
+        // trade-off is that an ambiguous "Wenn x\n> 5 ..." is read as a quote too.
         $parser = new BlockParser(significantNewlines: true);
         $doc = $parser->parse("Wenn x\n> 5 dann ist die Bedingung wahr.");
 
         $children = $doc->getChildren();
-        $this->assertCount(1, $children);
+        $this->assertCount(2, $children);
         $this->assertInstanceOf(Paragraph::class, $children[0]);
+        $this->assertInstanceOf(BlockQuote::class, $children[1]);
     }
 
     public function testOrderedListInterruptsParagraph(): void
@@ -451,45 +455,62 @@ DJOT;
         $this->assertInstanceOf(ListBlock::class, $children[1]);
     }
 
-    public function testMultiplicationStarDoesNotBecomeList(): void
+    public function testWrappedStarMarkerInterruptsInSignificantMode(): void
     {
+        // Opt-in markdown/chat-like mode: a line-leading "* " interrupts as a
+        // list. The cost is that a wrapped multiplication ("x = 5\n* 3 + 17")
+        // is read as a list; the benefit is genuine single/wrapped lists survive.
         $parser = new BlockParser(significantNewlines: true);
-        $doc = $parser->parse("Die Frage ist, wann ist x = 5\n* 3 + 17 wahr. Leider eine Liste\nim Text.");
+        $doc = $parser->parse("Die Frage ist, wann ist x = 5\n* 3 + 17 wahr.");
 
         $children = $doc->getChildren();
-        $this->assertCount(1, $children);
+        $this->assertCount(2, $children);
         $this->assertInstanceOf(Paragraph::class, $children[0]);
+        $this->assertInstanceOf(ListBlock::class, $children[1]);
     }
 
-    public function testMinusOperatorDoesNotBecomeList(): void
+    public function testWrappedMinusMarkerInterruptsInSignificantMode(): void
     {
         $parser = new BlockParser(significantNewlines: true);
-        $doc = $parser->parse("Das Ergebnis von 10\n- 3 ist 7. Kein Listenpunkt.");
+        $doc = $parser->parse("Das Ergebnis von 10\n- 3 ist 7.");
 
         $children = $doc->getChildren();
-        $this->assertCount(1, $children);
+        $this->assertCount(2, $children);
         $this->assertInstanceOf(Paragraph::class, $children[0]);
+        $this->assertInstanceOf(ListBlock::class, $children[1]);
     }
 
-    public function testPlusOperatorDoesNotBecomeList(): void
+    public function testWrappedPlusMarkerInterruptsInSignificantMode(): void
     {
         $parser = new BlockParser(significantNewlines: true);
-        $doc = $parser->parse("Die Summe ist 5\n+ 3 ergibt 8. Keine Liste.");
+        $doc = $parser->parse("Die Summe ist 5\n+ 3 ergibt 8.");
 
         $children = $doc->getChildren();
-        $this->assertCount(1, $children);
+        $this->assertCount(2, $children);
         $this->assertInstanceOf(Paragraph::class, $children[0]);
+        $this->assertInstanceOf(ListBlock::class, $children[1]);
     }
 
-    public function testLonePipeLineDoesNotSplitParagraph(): void
+    public function testNonTablePipeLineStaysProse(): void
     {
-        // Regression: a single "| ..." line is not a valid table, yet it used
-        // to sever the paragraph into two stray <p> blocks.
+        // A pipe in prose ("a\n| b als Oder.") is not a valid table row, so it
+        // does not interrupt: only a real "| a | b |" row would (see below).
         $parser = new BlockParser(significantNewlines: true);
         $doc = $parser->parse("Das berechnet a\n| b als bitweises Oder.");
 
         $children = $doc->getChildren();
         $this->assertCount(1, $children);
+        $this->assertInstanceOf(Paragraph::class, $children[0]);
+    }
+
+    public function testTableRowInterruptsInSignificantMode(): void
+    {
+        // A valid one-row table interrupts the paragraph.
+        $parser = new BlockParser(significantNewlines: true);
+        $doc = $parser->parse("Intro\n| a | b |");
+
+        $children = $doc->getChildren();
+        $this->assertCount(2, $children);
         $this->assertInstanceOf(Paragraph::class, $children[0]);
     }
 


### PR DESCRIPTION
Drop lone-marker guard under blocksInterruptParagraphs

blocksInterruptParagraphs (and its significantNewlines alias) is an opt-in
markdown/chat-like mode. The lone-marker lookahead added to it suppressed
genuine blocks, not just ambiguous prose: because a quote or list with
lazy continuation is byte-for-byte identical to a wrapped comparison, the
guard silently dropped legitimate content with no blank line before it.

    foo
    > a real quote
    that wraps onto the next line

became one paragraph instead of a blockquote; single-line and lazily
wrapped lists were lost the same way.

A user enabling this mode is asking for aggressive interruption, so a
line-leading marker now interrupts the paragraph again, with no lookahead:

- `-`/`*`/`+` and `>` interrupt unconditionally (at top level and inside
  list items, so a sublist nests there too).
- `|` interrupts only when the line is a real table row
  (tableParser->isTableRow()), so a pipe in prose does not split a
  paragraph into stray blocks.
- `#` headings, fences and divs are unchanged; ordered lists keep the
  CommonMark 1./1)-only rule.

The cost is that an ambiguous `x = 5\n- 3` or `if a\n> b` is read as a
block in this mode, which is the expected bargain of an opt-in
markdown-like mode. The default (non-blocksInterruptParagraphs) behavior,
where no block interrupts a paragraph, is unchanged.

nestedListsWithoutBlankLine remains the smaller subset: it nests sublists
in list items but does not let other block types interrupt. Tests that
encoded the old lone-marker guard are updated to the new contract.
