### PR TITLE
Fix blockquote lazy continuation swallowing non-marker lines into open fence/div

### DIFF
--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -1571,11 +1571,21 @@ class BlockParser
         $this->pendingAttributeSourceLines = [];
 
         $innerLines = [];
+        $lazyState = [
+            'inFence' => false,
+            'fenceChar' => '',
+            'fenceLength' => 0,
+            'inComment' => false,
+            'commentLength' => 0,
+            'paragraphOpen' => false,
+        ];
 
         if (preg_match('/^> (.*)$/', $line, $matches)) {
             $innerLines[] = $matches[1];
+            $this->trackBlockQuoteLazyState($matches[1], $lazyState);
         } elseif (preg_match('/^>$/', $line)) {
             $innerLines[] = '';
+            $this->trackBlockQuoteLazyState('', $lazyState);
         }
 
         $i = $start + 1;
@@ -1591,15 +1601,20 @@ class BlockParser
             // Continue with "> " prefix (space required per spec)
             if (preg_match('/^> (.*)$/', $currentLine, $matches)) {
                 $innerLines[] = $matches[1];
+                $this->trackBlockQuoteLazyState($matches[1], $lazyState);
                 $i++;
             } elseif (preg_match('/^>$/', $currentLine)) {
                 // Empty block quote line (just >)
                 $innerLines[] = '';
+                $this->trackBlockQuoteLazyState('', $lazyState);
                 $i++;
-            } elseif (!$this->startsNewBlock($currentLine)) {
-                // Lazy continuation - includes lines starting with ">" but no space
-                // These become literal ">text" in the paragraph
+            } elseif ($lazyState['paragraphOpen'] && !$this->startsNewBlock($currentLine)) {
+                // Lazy continuation only extends an OPEN paragraph (djot rule).
+                // A non-">" line inside an open code fence/comment, or after a
+                // block that left no open paragraph (a just-opened div, a closed
+                // fence), terminates the quote instead of being swallowed.
                 $innerLines[] = $currentLine;
+                $this->trackBlockQuoteLazyState($currentLine, $lazyState);
                 $i++;
             } else {
                 break;
@@ -1615,6 +1630,84 @@ class BlockParser
         $parent->appendChild($blockQuote);
 
         return $i - $start;
+    }
+
+    /**
+     * Track verbatim/paragraph state across a blockquote's collected inner lines.
+     *
+     * A non-">" line lazily continues a blockquote only when an open paragraph is
+     * available to extend (the djot/CommonMark lazy-continuation rule). Inside an
+     * open code fence or fenced comment, or after a structural line that leaves no
+     * open paragraph (a just-opened div, a closed fence), such a line must instead
+     * terminate the quote - otherwise it is wrongly swallowed into the fence/div.
+     *
+     * @param string $content Inner content line (after the "> " marker is stripped).
+     * @param array{inFence:bool,fenceChar:string,fenceLength:int,inComment:bool,commentLength:int,paragraphOpen:bool} $state
+     *     Running state, mutated in place.
+     */
+    private function trackBlockQuoteLazyState(string $content, array &$state): void
+    {
+        if ($state['inComment']) {
+            if ($this->fencedBlockParser->isFencedCommentCloser($content, $state['commentLength'])) {
+                $state['inComment'] = false;
+            }
+            $state['paragraphOpen'] = false;
+
+            return;
+        }
+
+        if ($state['inFence']) {
+            if ($this->fencedBlockParser->isCodeFenceCloser($content, $state['fenceChar'], $state['fenceLength'])) {
+                $state['inFence'] = false;
+            }
+            $state['paragraphOpen'] = false;
+
+            return;
+        }
+
+        if (IndentationHelper::isBlankLine($content)) {
+            $state['paragraphOpen'] = false;
+
+            return;
+        }
+
+        // A fence/comment/div opener starts a new block only when it is allowed to:
+        // djot paragraphs are not interrupted by block elements without a blank line,
+        // so a fence-looking line mid-paragraph is just paragraph text. With
+        // blocksInterruptParagraphs enabled, openers DO interrupt an open paragraph.
+        if (!$state['paragraphOpen'] || $this->blocksInterruptParagraphs) {
+            $fenceInfo = $this->fencedBlockParser->parseCodeFenceOpener($content);
+            if ($fenceInfo !== null) {
+                $state['inFence'] = true;
+                $state['fenceChar'] = $fenceInfo['char'];
+                $state['fenceLength'] = $fenceInfo['length'];
+                $state['paragraphOpen'] = false;
+
+                return;
+            }
+
+            $commentInfo = $this->fencedBlockParser->parseFencedCommentOpener($content);
+            if ($commentInfo !== null) {
+                $state['inComment'] = true;
+                $state['commentLength'] = $commentInfo['length'];
+                $state['paragraphOpen'] = false;
+
+                return;
+            }
+
+            if ($this->fencedBlockParser->parseDivFenceOpener($content) !== null) {
+                // Div opener/closer line is structural; it opens no paragraph itself.
+                $state['paragraphOpen'] = false;
+
+                return;
+            }
+        }
+
+        // Any other non-blank line is paragraph-ish content (plain text, an open
+        // paragraph's continuation, or a block that opens with text on the same line:
+        // list item, heading, nested quote) - all leave an open paragraph a lazy line
+        // may continue.
+        $state['paragraphOpen'] = true;
     }
 
     /**

--- a/tests/TestCase/Parser/BlockQuoteLazyContinuationTest.php
+++ b/tests/TestCase/Parser/BlockQuoteLazyContinuationTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Test\TestCase\Parser;
+
+use Djot\DjotConverter;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A blockquote's lazy continuation (a line without the ">" marker) may only extend
+ * an OPEN paragraph, per the djot/CommonMark rule. Previously a non-">" line was
+ * swallowed into an open fenced code block or just-opened div inside the quote,
+ * corrupting content and stripping ">" markers off following lines. These cases
+ * are verified against the canonical djot.js reference output.
+ */
+class BlockQuoteLazyContinuationTest extends TestCase
+{
+    protected DjotConverter $converter;
+
+    protected function setUp(): void
+    {
+        $this->converter = new DjotConverter();
+    }
+
+    public function testNonMarkerLineInsideOpenFenceTerminatesQuote(): void
+    {
+        // The non-">" lines must NOT be swallowed into the code block; the quote
+        // ends and they become a separate paragraph (">" rendered literally).
+        $djot = "> ```\n> a\nb\n> c";
+        $expected = "<blockquote>\n<pre><code>a\n</code></pre>\n</blockquote>\n"
+            . "<p>b\n&gt; c</p>\n";
+
+        $this->assertSame($expected, $this->converter->convert($djot));
+    }
+
+    public function testNonMarkerLineAfterClosedFenceTerminatesQuote(): void
+    {
+        // Fence is closed; a following non-">" line has no open paragraph to
+        // continue, so it leaves the quote.
+        $djot = "> ```\n> code\n> ```\ntail";
+        $expected = "<blockquote>\n<pre><code>code\n</code></pre>\n</blockquote>\n"
+            . "<p>tail</p>\n";
+
+        $this->assertSame($expected, $this->converter->convert($djot));
+    }
+
+    public function testNonMarkerLineAfterDivOpenerTerminatesQuote(): void
+    {
+        // The div just opened (no paragraph yet), so a non-">" line ends the quote
+        // and is not pulled inside the div.
+        $djot = "> :::note\nbody\n> :::";
+        $expected = "<blockquote>\n<div class=\"note\">\n</div>\n</blockquote>\n"
+            . "<p>body\n&gt; :::</p>\n";
+
+        $this->assertSame($expected, $this->converter->convert($djot));
+    }
+
+    public function testNonMarkerLineWhileFenceOpenTerminatesQuote(): void
+    {
+        $djot = "> ```\n> code\nlazy";
+        $expected = "<blockquote>\n<pre><code>code\n</code></pre>\n</blockquote>\n"
+            . "<p>lazy</p>\n";
+
+        $this->assertSame($expected, $this->converter->convert($djot));
+    }
+
+    public function testLazyContinuationOfParagraphStillFolds(): void
+    {
+        // Regression guard: a non-">" line continuing an OPEN paragraph still folds
+        // into the blockquote (unchanged correct behavior).
+        $djot = "> p\nlazy\n> more";
+        $expected = "<blockquote>\n<p>p\nlazy\nmore</p>\n</blockquote>\n";
+
+        $this->assertSame($expected, $this->converter->convert($djot));
+    }
+
+    public function testLazyContinuationOfParagraphInsideDivStillFolds(): void
+    {
+        // Regression guard: a paragraph IS open inside the div, so the lazy line
+        // folds into it (must not be broken by the fix).
+        $djot = "> :::note\n> para\nlazy\n> :::";
+        $expected = "<blockquote>\n<div class=\"note\">\n<p>para\nlazy</p>\n</div>\n</blockquote>\n";
+
+        $this->assertSame($expected, $this->converter->convert($djot));
+    }
+
+    public function testLazyContinuationOfListItemParagraphStillFolds(): void
+    {
+        // Regression guard: lazy line continues the list item's paragraph.
+        $djot = "> - a\nlazy\n> - b";
+        $expected = "<blockquote>\n<ul>\n<li>\na\nlazy\n</li>\n<li>\nb\n</li>\n</ul>\n</blockquote>\n";
+
+        $this->assertSame($expected, $this->converter->convert($djot));
+    }
+
+    public function testFenceLikeLineInsideOpenParagraphStaysParagraphText(): void
+    {
+        // Regression guard: a code fence does NOT interrupt an open paragraph in
+        // strict djot, so the fence-looking line is paragraph text and the next
+        // unquoted line keeps lazily continuing the paragraph.
+        $djot = "> text\n> ```\nlazy";
+        $expected = "<blockquote>\n<p>text\n<code>\nlazy</code></p>\n</blockquote>\n";
+
+        $this->assertSame($expected, $this->converter->convert($djot));
+    }
+}


### PR DESCRIPTION
## Problem

Inside a blockquote, a line **without** the `>` marker was always collected as lazy
continuation. When that line landed inside an open fenced code block or a just-opened
div, it was swallowed into the block instead of terminating the quote, and the `>` of
any following quoted line was stripped and merged in too.

Djot (and CommonMark) only allow a lazy continuation line to extend an **open
paragraph**. A code block, a just-opened div, or a closed block leave no open paragraph,
so a non-`>` line there must end the blockquote.

### Before (wrong)

```text
> ```
> a
b
> c
```

rendered as (the `b` and `> c` swallowed into the code block, `>` lost):

```html
<blockquote>
<pre><code>a
b
c
</code></pre>
</blockquote>
```

### After (matches the canonical djot.js reference)

```html
<blockquote>
<pre><code>a
</code></pre>
</blockquote>
<p>b
&gt; c</p>
```

The same applied to a just-opened div (`> :::note` then a non-`>` `body` line) and to a
line following a closed fence.

## Fix

`tryParseBlockQuote` now tracks verbatim/paragraph state across the collected inner
lines (`trackBlockQuoteLazyState`). A non-`>` line is accepted as lazy continuation only
when an open paragraph is available to extend; otherwise it terminates the quote.

A fence/comment/div opener starts a new block only when no paragraph is already open, or
when `blocksInterruptParagraphs` is enabled (where blocks do interrupt paragraphs). This
preserves the rule that a fence-looking line mid-paragraph is plain paragraph text, e.g.
`> text` / `> ` + fence / `lazy` keeps `lazy` folded into the paragraph.

## Notes

- Paragraph, list-item, and div-paragraph lazy continuations are unchanged (regression
  guards included).
- All 250 official djot.js conformance cases still pass; outputs were checked against the
  canonical reference.
- Orthogonal and out of scope: a bare unterminated empty fence (`` ``` `` with no
  content) still renders as `<p><code></code></p>` rather than `<pre><code></code></pre>`
  - that is a pre-existing top-level rendering quirk, not specific to blockquotes.
