### PR TITLE
Reverse smart punctuation in HtmlToDjot for source-stable round-trip

### DIFF
--- a/src/Converter/HtmlToDjot.php
+++ b/src/Converter/HtmlToDjot.php
@@ -2385,6 +2385,12 @@ class HtmlToDjot
      */
     protected function escapeDjotText(string $text, bool $atLineStart): string
     {
+        // Reverse the parser's deterministic smart-punctuation mapping
+        // (`...` -> `…`, `--` -> `–`, `---` -> `—`) so the regenerated source
+        // keeps the ASCII the author wrote. Runs before the escapers because it
+        // only emits `.` and `-`, neither of which they touch.
+        $text = $this->reverseSmartPunctuation($text, $atLineStart);
+
         // `]` is escaped alongside `[` so that a literal bracket in text never
         // closes an enclosing link/span label early on the next parse. Structural
         // `]` emitted by child-element processors is not text and is unaffected.
@@ -2400,6 +2406,32 @@ class HtmlToDjot
         }
 
         return $escaped;
+    }
+
+    /**
+     * Reverse the parser's smart-punctuation transforms back to ASCII so a
+     * Djot -> HTML -> Djot round-trip preserves the author's original source.
+     *
+     * The parser maps `...` -> `…`, `--` -> en dash and `---` -> em dash
+     * deterministically, so reversing stays HTML-stable: re-rendering the ASCII
+     * reproduces the same typographic characters. Ellipsis is never a block
+     * marker, so it is always reversed. A typographic dash at the start of a
+     * line is kept literal: reversing it to `---`/`--` at column zero would
+     * re-parse as a thematic break or interact with the leading-marker escaper.
+     * Keeping it as the typographic character there is still HTML-stable.
+     */
+    protected function reverseSmartPunctuation(string $text, bool $atLineStart): string
+    {
+        $text = str_replace("\u{2026}", '...', $text);
+
+        if ($atLineStart && preg_match('/^[\x{2013}\x{2014}]/u', $text) === 1) {
+            $first = mb_substr($text, 0, 1);
+            $rest = str_replace(["\u{2014}", "\u{2013}"], ['---', '--'], mb_substr($text, 1));
+
+            return $first . $rest;
+        }
+
+        return str_replace(["\u{2014}", "\u{2013}"], ['---', '--'], $text);
     }
 
     /**

--- a/src/Converter/HtmlToDjot.php
+++ b/src/Converter/HtmlToDjot.php
@@ -2424,11 +2424,10 @@ class HtmlToDjot
     {
         $text = str_replace("\u{2026}", '...', $text);
 
-        if ($atLineStart && preg_match('/^[\x{2013}\x{2014}]/u', $text) === 1) {
-            $first = mb_substr($text, 0, 1);
-            $rest = str_replace(["\u{2014}", "\u{2013}"], ['---', '--'], mb_substr($text, 1));
+        if ($atLineStart && preg_match('/^([\x{2013}\x{2014}])(.*)$/su', $text, $matches) === 1) {
+            $rest = str_replace(["\u{2014}", "\u{2013}"], ['---', '--'], $matches[2]);
 
-            return $first . $rest;
+            return $matches[1] . $rest;
         }
 
         return str_replace(["\u{2014}", "\u{2013}"], ['---', '--'], $text);

--- a/tests/TestCase/Converter/HtmlToDjotSmartPunctuationTest.php
+++ b/tests/TestCase/Converter/HtmlToDjotSmartPunctuationTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Test\TestCase\Converter;
+
+use Djot\Converter\HtmlToDjot;
+use Djot\DjotConverter;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Source-stable round-trip for Djot smart punctuation.
+ *
+ * The parser deterministically normalizes ASCII punctuation to typographic
+ * characters: `...` becomes `…`, `--` becomes `–`, `---` becomes `—`. Those
+ * transforms are one-directional in the parser, so a naive HtmlToDjot bakes the
+ * typographic character into the regenerated source and the original ASCII is
+ * lost across a Djot -> HTML -> Djot round-trip.
+ *
+ * HtmlToDjot reverses the dash and ellipsis transforms in prose text so the
+ * regenerated Djot keeps the ASCII the author wrote. Because the parser mapping
+ * is deterministic, the reversal stays HTML-stable: re-rendering the ASCII
+ * reproduces the same typographic HTML.
+ *
+ * Verbatim contexts (inline code, fenced code) are excluded: the parser never
+ * normalizes there, so a typographic character inside code is genuine literal
+ * content and must survive untouched.
+ */
+class HtmlToDjotSmartPunctuationTest extends TestCase
+{
+    protected HtmlToDjot $converter;
+
+    protected DjotConverter $renderer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->converter = new HtmlToDjot();
+        $this->renderer = new DjotConverter();
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function reversibleProvider(): array
+    {
+        return [
+            'ellipsis' => ['<p>a … b</p>', 'a ... b'],
+            'en dash' => ['<p>a – b</p>', 'a -- b'],
+            'em dash' => ['<p>a — b</p>', 'a --- b'],
+            'ellipsis no spaces' => ['<p>wait…done</p>', 'wait...done'],
+            'em dash no spaces' => ['<p>x—y</p>', 'x---y'],
+        ];
+    }
+
+    #[DataProvider('reversibleProvider')]
+    public function testTypographicPunctuationReversedToAscii(string $html, string $expectedFragment): void
+    {
+        $djot = $this->converter->convert($html);
+
+        $this->assertStringContainsString($expectedFragment, $djot);
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function sourceStableProvider(): array
+    {
+        return [
+            'ellipsis' => ['a ... b'],
+            'en dash' => ['a -- b'],
+            'em dash' => ['a --- b'],
+            'mixed' => ['well ... maybe --- or -- so'],
+        ];
+    }
+
+    /**
+     * The original ASCII source survives a full Djot -> HTML -> Djot round-trip.
+     */
+    #[DataProvider('sourceStableProvider')]
+    public function testRoundTripPreservesAsciiSource(string $djotSource): void
+    {
+        $html = $this->renderer->convert($djotSource);
+        $back = trim($this->converter->convert($html));
+
+        $this->assertSame($djotSource, $back);
+    }
+
+    /**
+     * A dash at the start of a line must not be reversed: `---`/`--` there would
+     * re-parse as a thematic break or interact with the leading-marker escaper.
+     * The typographic dash stays literal, which remains HTML-stable.
+     */
+    public function testLeadingEmDashStaysLiteral(): void
+    {
+        $djot = trim($this->converter->convert('<p>— quote</p>'));
+
+        $this->assertSame('— quote', $djot);
+
+        $reRendered = $this->renderer->convert($djot);
+        $this->assertStringNotContainsString('<hr', $reRendered);
+        $this->assertStringContainsString('quote', $reRendered);
+    }
+
+    public function testLeadingEnDashStaysLiteral(): void
+    {
+        $djot = trim($this->converter->convert('<p>– quote</p>'));
+
+        $this->assertSame('– quote', $djot);
+
+        $reRendered = $this->renderer->convert($djot);
+        $this->assertStringNotContainsString('<hr', $reRendered);
+    }
+
+    /**
+     * A leading ellipsis is harmless (not a block marker) and is reversed.
+     */
+    public function testLeadingEllipsisReversed(): void
+    {
+        $djot = trim($this->converter->convert('<p>… and so on</p>'));
+
+        $this->assertSame('... and so on', $djot);
+    }
+
+    /**
+     * Inline code is verbatim: a typographic character there is literal content
+     * and must not be rewritten to ASCII.
+     */
+    public function testTypographicPunctuationInInlineCodePreserved(): void
+    {
+        $djot = trim($this->converter->convert('<p><code>x … y — z</code></p>'));
+
+        $this->assertSame('`x … y — z`', $djot);
+    }
+
+    /**
+     * Fenced code is verbatim for the same reason.
+     */
+    public function testTypographicPunctuationInFencedCodePreserved(): void
+    {
+        $djot = $this->converter->convert('<pre><code>a — b … c</code></pre>');
+
+        $this->assertStringContainsString('a — b … c', $djot);
+    }
+}


### PR DESCRIPTION
## Problem

The parser maps ASCII punctuation to typographic characters deterministically (`...` to ellipsis, `--` to en dash, `---` to em dash). `HtmlToDjot` emitted the typographic character verbatim, so a Djot -> HTML -> Djot round-trip baked the typographic form into the regenerated source. The original ASCII the author wrote was lost:

```
a ... b   ->   <p>a … b</p>   ->   a … b      (source mutated)
```

## Fix

`HtmlToDjot` now reverses the dash and ellipsis transforms in prose text. Because the parser mapping is deterministic, the reversal stays HTML-stable: re-rendering the ASCII reproduces the same typographic output.

- Ellipsis is always reversed (never a block marker).
- A typographic dash at the start of a line is kept literal: reversing it to `---`/`--` at column zero would re-parse as a thematic break or collide with the leading-marker escaper.
- Verbatim contexts (inline and fenced code) are left untouched, so a typographic character inside code stays literal.

## Scope

Smart quotes are intentionally out of scope. Their open/close form is re-derived from context on the next parse and warrants separate handling in a follow-up.
