### PR TITLE
Fix unterminated empty backtick code fence rendered as inline span

### DIFF
--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -1124,16 +1124,21 @@ class BlockParser
             $i++;
         }
 
-        // If not closed and using backticks, check if this should be inline code
-        if (!$closed && $fenceChar === '`') {
-            if ($i === $start + 1 && $info !== '') {
-                // Single line unclosed fence with content - treat as inline code in a paragraph
-                return null;
-            }
-            if ($content === '' && $info === '') {
-                // Empty unclosed fence (just ``` with nothing) - treat as inline code
-                return null;
-            }
+        // An unterminated single-line backtick fence whose info string carries
+        // internal whitespace is not a code block but an inline verbatim span
+        // (e.g. "``` not a code block" -> <p><code> not a code block</code></p>,
+        // per the djot.js reference and the official conformance suite). A bare
+        // fence ("```") or a single-token language specifier ("``` php") still
+        // opens an (empty) code block. Fences with content lines use the
+        // enhanced lang+label syntax and are left untouched.
+        if (
+            !$closed
+            && $fenceChar === '`'
+            && $i === $start + 1
+            && $info !== ''
+            && preg_match('/\s/', $info) === 1
+        ) {
+            return null;
         }
 
         if (!$closed) {

--- a/tests/TestCase/DjotConverterTest.php
+++ b/tests/TestCase/DjotConverterTest.php
@@ -3078,6 +3078,24 @@ DJOT;
         $this->assertSame("<p><code> not a code block</code></p>\n", $result);
     }
 
+    public function testUnclosedEmptyBacktickFenceIsCodeBlock(): void
+    {
+        // A bare unterminated ``` with no content and no info string is an
+        // empty code block, not an inline span (matches djot.js + tilde form).
+        $result = $this->converter->convert('```');
+
+        $this->assertSame("<pre><code></code></pre>\n", $result);
+    }
+
+    public function testUnclosedEmptyBacktickFenceWithLanguageIsCodeBlock(): void
+    {
+        // A single-token language specifier on an unterminated empty fence
+        // still opens a code block and keeps the language class.
+        $result = $this->converter->convert('``` php');
+
+        $this->assertSame("<pre><code class=\"language-php\"></code></pre>\n", $result);
+    }
+
     public function testBackticksWithClosingFenceIsCodeBlock(): void
     {
         // Triple backticks with proper closing = code block


### PR DESCRIPTION
Closes #213

## Problem

An **unterminated empty backtick code fence** was parsed as an inline code span
instead of an empty code block:

| input | before | after / canonical djot.js |
|-------|--------|---------------------------|
| `` ``` `` (bare, no content) | `<p><code></code></p>` | `<pre><code></code></pre>` |
| `` ``` php `` (single-token language) | `<p><code> php</code></p>` | `<pre><code class="language-php"></code></pre>` |
| `` ``` not a code block `` (info with spaces) | `<p><code> not a code block</code></p>` | unchanged - inline |
| tilde / closed / with-content forms | already correct | unchanged |

Verified against the canonical djot.js reference and the official conformance
suite (`code_blocks.test`).

## Root cause

`tryParseCodeBlock` had a backtick-only fallback that demoted an unterminated
single-line fence to an inline span. It fired too broadly:

- an empty fence with **no** info (`` ``` ``) was demoted - wrong, it is an empty code block;
- a single-line fence with **any** info string was demoted - wrong for a valid
  single-token language specifier (`` ``` php ``), right only for a multi-word
  info string (`` ``` not a code block ``), which the spec does not accept as a
  code block opener ("a language specifier ... but nothing else").

## Fix

Narrow the demotion: an unterminated single-line backtick fence falls back to an
inline span **only** when its info string carries internal whitespace. A bare
fence or a single-token language specifier opens an (empty) code block; fences
with content lines keep using the enhanced `lang [Label]` syntax untouched.

Regression tests cover the bare and single-token-language cases; the existing
multi-word case (`` ``` not a code block ``) and the full official suite stay
green.