### PR TITLE
Cap block nesting depth to prevent stack/memory exhaustion

### DIFF
--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -51,6 +51,18 @@ class BlockParser
      */
     private const INITIAL_BRACE_STATE = ['depth' => 0, 'inQuote' => false, 'quoteChar' => '', 'pendingEscape' => false];
 
+    /**
+     * Maximum block-container nesting depth. Every level of blockquote / div /
+     * list / footnote recurses through parseBlocks(), so unbounded nesting (e.g.
+     * `> ` repeated thousands of times) exhausts the stack or memory. Past this
+     * depth, container content is emitted as a literal paragraph instead of
+     * recursing. Far above any real document; only adversarial input reaches it.
+     */
+    private const MAX_NESTING_DEPTH = 200;
+
+    /** Current block-container nesting depth, maintained by parseBlocks(). */
+    private int $nestingDepth = 0;
+
     protected InlineParser $inlineParser;
 
     protected ListParser $listParser;
@@ -856,11 +868,41 @@ class BlockParser
     }
 
     /**
+     * Recurse into block content, but cap nesting depth so pathologically
+     * nested input degrades to literal text instead of overflowing the stack
+     * (or exhausting memory). See MAX_NESTING_DEPTH.
+     *
      * @param \Djot\Node\Node $parent
      * @param array<string> $lines
      * @param int $indent
      */
     protected function parseBlocks(Node $parent, array $lines, int $indent): void
+    {
+        if ($this->nestingDepth >= self::MAX_NESTING_DEPTH) {
+            $text = implode("\n", $lines);
+            if (trim($text) !== '') {
+                $paragraph = new Paragraph();
+                $this->inlineParser->parse($paragraph, $text);
+                $parent->appendChild($paragraph);
+            }
+
+            return;
+        }
+
+        $this->nestingDepth++;
+        try {
+            $this->parseBlocksImpl($parent, $lines, $indent);
+        } finally {
+            $this->nestingDepth--;
+        }
+    }
+
+    /**
+     * @param \Djot\Node\Node $parent
+     * @param array<string> $lines
+     * @param int $indent
+     */
+    private function parseBlocksImpl(Node $parent, array $lines, int $indent): void
     {
         $i = 0;
         $count = count($lines);

--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -57,10 +57,11 @@ class BlockParser
      * `> ` repeated thousands of times) exhausts the stack or memory. Past this
      * depth, container content is emitted as a literal paragraph instead of
      * recursing. Far above any real document; only adversarial input reaches it.
+     *
+     * @var int
      */
     private const MAX_NESTING_DEPTH = 200;
 
-    /** Current block-container nesting depth, maintained by parseBlocks(). */
     private int $nestingDepth = 0;
 
     protected InlineParser $inlineParser;

--- a/tests/TestCase/DeepNestingTest.php
+++ b/tests/TestCase/DeepNestingTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Test\TestCase;
+
+use Djot\DjotConverter;
+use Djot\Node\Block\BlockQuote;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Guards MAX_NESTING_DEPTH. Every block-container level recurses through
+ * parseBlocks(), so deeply nested input used to exhaust the stack / memory.
+ * Past the cap, content degrades to a literal paragraph instead of crashing.
+ */
+class DeepNestingTest extends TestCase
+{
+    private DjotConverter $converter;
+
+    protected function setUp(): void
+    {
+        $this->converter = new DjotConverter();
+    }
+
+    public function testDeeplyNestedBlockquotesDoNotCrash(): void
+    {
+        foreach ([1000, 5000, 50000] as $depth) {
+            $html = $this->converter->convert(str_repeat('> ', $depth) . 'x');
+            $this->assertStringContainsString('<blockquote>', $html);
+        }
+    }
+
+    public function testDeeplyNestedDivsDoNotCrash(): void
+    {
+        $source = str_repeat(":::\n", 5000) . "x\n" . str_repeat(":::\n", 5000);
+        $html = $this->converter->convert($source);
+        $this->assertNotSame('', trim($html));
+    }
+
+    public function testModestNestingStillNests(): void
+    {
+        $doc = $this->converter->parse('> > > x');
+        $depth = 0;
+        $children = $doc->getChildren();
+        while ($children !== [] && $children[0] instanceof BlockQuote) {
+            $depth++;
+            $children = $children[0]->getChildren();
+        }
+        $this->assertSame(3, $depth);
+    }
+}


### PR DESCRIPTION
## Problem

Every block container (blockquote / div / list / footnote) is parsed by recursing through `parseBlocks()`. Deeply nested input therefore exhausts the call stack or memory rather than degrading gracefully — e.g. `> ` repeated tens of thousands of times OOMs.

## Fix

Track nesting depth on the parser. Past `MAX_NESTING_DEPTH` (200), `parseBlocks()` emits the remaining lines as a literal paragraph instead of recursing. Real documents never approach 200 levels; only adversarial input reaches it, and it now degrades to text instead of crashing.

## Result

1k / 5k / 50k nested blockquotes and divs all parse without crashing (even at a 256M memory limit); modest nesting still nests correctly. Suite (2516 tests) + phpstan + phpcs green.

Mirrors markup-carve/carve-js#70 (and the carve-php counterpart).
