### PR TITLE
docs: document optional closing fence and single-token language rule

### DIFF
--- a/docs/guide/syntax.md
+++ b/docs/guide/syntax.md
@@ -126,6 +126,38 @@ Plain code block
 </template>
 </OutputTabs>
 
+::: info Closing fence is optional
+The closing fence may be omitted. An unterminated code block is implicitly
+closed at the end of its enclosing block (a list item, a block quote) or the
+end of the document - the same rule the official djot reference uses:
+
+````djot
+> ```
+> code in a block quote
+````
+
+renders the fenced block closed at the end of the quote. A bare `` ``` `` with
+nothing after it is therefore a valid (empty) code block, not an inline code
+span.
+:::
+
+::: info Language specifier must be a single token
+After the opening fence, only a single-token language specifier (optionally
+surrounded by whitespace) is allowed - "nothing else". A would-be info string
+with internal whitespace is **not** a code block opener: the backtick form
+falls through to an inline verbatim span, and the tilde form to a plain
+paragraph.
+
+| Input | Result |
+|-------|--------|
+| `` ``` `` | empty code block |
+| `` ``` php `` | code block, `language-php` |
+| `` ``` not a code block `` | inline `<code>` span (not a code block) |
+
+The enhanced [code group](/extensions/) syntax (`lang [Label]`) is the one
+exception, and only applies to fences that have content lines.
+:::
+
 ### Block Quotes
 
 Block quotes use `>` at the start of each line.
@@ -991,6 +1023,11 @@ More outer
 </div>
 </template>
 </OutputTabs>
+
+::: info Closing fence is optional
+Like code blocks, the closing `:::` may be omitted - an unterminated div is
+implicitly closed at the end of its enclosing block or the document.
+:::
 
 ### Comments
 


### PR DESCRIPTION
## Problem

The syntax reference (`docs/guide/syntax.md`) showed code blocks and divs only
with explicit closing fences and never documented two user-visible rules,
leaving them discoverable only by reading the parser or the upstream spec:

1. **The closing fence is optional.** An unterminated code block or div is
   implicitly closed at the end of its enclosing block (list item, block quote)
   or the document. A bare `` ``` `` is therefore a valid empty code block, not
   an inline code span.
2. **The language specifier must be a single token.** A fence may be followed
   only by a single-token language specifier, "nothing else". An info string
   with internal whitespace is not a code block opener - the backtick form falls
   through to an inline verbatim span and the tilde form to a plain paragraph
   (e.g. `` ``` not a code block ``).

The second rule is exactly the behavior clarified by the unterminated-empty-fence
fix (#215 / closes #213); this documents it for users.

## Change

Add two `::: info` callouts under **Code Blocks** and one under **Divs**,
including a small input/result table for the language-specifier cases. Docs only;
no code changes.
