### PR TITLE
Fix empty list marker interrupting a paragraph under blocksInterruptParagraphs

### DIFF
--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -3476,10 +3476,18 @@ class BlockParser
                 // interrupts without a blank line (it would otherwise drop a
                 // genuine single-line or lazily-wrapped list).
                 if (isset($line[1]) && $line[1] === ' ') {
-                    return true; // Unordered list
+                    // An empty list item (marker followed by only whitespace)
+                    // cannot interrupt an OPEN PARAGRAPH (CommonMark/djot rule) -
+                    // it folds into the paragraph instead of opening a stray empty
+                    // <li>. Paragraph interruption is the only caller that passes
+                    // $lines for lookahead; in every other context (heading
+                    // termination, etc.) an empty marker still starts a new block.
+                    if ($lines === null || trim(substr($line, 2)) !== '') {
+                        return true; // Unordered list
+                    }
                 }
 
-                // Thematic breaks: *\s*\*\s*\* or -\s*-\s*-
+                // Thematic breaks still interrupt: *\s*\*\s*\* or -\s*-\s*-
                 return preg_match('/^(\*\s*\*\s*\*|-\s*-\s*-)/', $line) === 1;
             case '|':
                 // Tables: a single "| a | b |" row is already a valid table, but
@@ -3500,9 +3508,15 @@ class BlockParser
                 return isset($line[1], $line[2]) && $line[1] === '%' && $line[2] === '%';
             default:
                 // Only 1. or 1) can interrupt paragraphs (CommonMark rule)
-                // Prevents "1985. That year..." from becoming a list
+                // Prevents "1985. That year..." from becoming a list. When
+                // interrupting an open paragraph (lookahead via $lines), an empty
+                // item ("1. " with no content) cannot interrupt either, so require
+                // a non-space char after the marker; other contexts keep starting
+                // a block on a bare empty marker.
                 if ($first === '1') {
-                    return preg_match('/^1[.)]\s/', $line) === 1;
+                    $pattern = $lines === null ? '/^1[.)]\s/' : '/^1[.)]\s+\S/';
+
+                    return preg_match($pattern, $line) === 1;
                 }
 
                 return false;

--- a/tests/TestCase/BlocksInterruptParagraphsOptionTest.php
+++ b/tests/TestCase/BlocksInterruptParagraphsOptionTest.php
@@ -10,6 +10,7 @@ use Djot\Node\Block\Heading;
 use Djot\Node\Block\ListBlock;
 use Djot\Node\Block\Paragraph;
 use Djot\Parser\BlockParser;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class BlocksInterruptParagraphsOptionTest extends TestCase
@@ -260,5 +261,74 @@ class BlocksInterruptParagraphsOptionTest extends TestCase
         }
         $this->assertTrue($hasSublist);
         $this->assertFalse($hasQuote);
+    }
+
+    /**
+     * An empty list item (a marker followed only by whitespace) cannot interrupt
+     * a paragraph; it folds into the paragraph instead of opening a stray empty
+     * <li> (matches the canonical djot.js reference).
+     */
+    #[DataProvider('emptyMarkerProvider')]
+    public function testEmptyMarkerDoesNotInterruptParagraph(string $djot, string $expected): void
+    {
+        $converter = DjotConverter::withBlocksInterruptParagraphs();
+
+        $this->assertSame($expected, $converter->convert($djot));
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function emptyMarkerProvider(): array
+    {
+        return [
+            'dash + space' => ["intro\n- ", "<p>intro\n-</p>\n"],
+            'dash + many spaces' => ["intro\n-   ", "<p>intro\n-</p>\n"],
+            'plus + space' => ["intro\n+ ", "<p>intro\n+</p>\n"],
+            'star + space' => ["intro\n* ", "<p>intro\n*</p>\n"],
+            'ordered dot empty' => ["intro\n1. ", "<p>intro\n1.</p>\n"],
+            'ordered paren empty' => ["intro\n1) ", "<p>intro\n1)</p>\n"],
+        ];
+    }
+
+    public function testMarkerWithContentStillInterrupts(): void
+    {
+        $converter = DjotConverter::withBlocksInterruptParagraphs();
+        $result = $converter->convert("intro\n- x");
+
+        $this->assertStringContainsString('<p>intro</p>', $result);
+        $this->assertStringContainsString('<li>', $result);
+    }
+
+    public function testThematicBreakStillInterrupts(): void
+    {
+        $converter = DjotConverter::withBlocksInterruptParagraphs();
+        $result = $converter->convert("intro\n- - -");
+
+        $this->assertStringContainsString('<p>intro</p>', $result);
+        $this->assertStringContainsString('<hr>', $result);
+    }
+
+    public function testStandaloneEmptyMarkerStillParsesAsList(): void
+    {
+        // Not interrupting a paragraph here, so a bare empty marker is still a
+        // (empty) list, exactly as the reference renders it.
+        $converter = DjotConverter::withBlocksInterruptParagraphs();
+        $result = $converter->convert('- ');
+
+        $this->assertStringContainsString('<ul>', $result);
+        $this->assertStringContainsString('<li>', $result);
+    }
+
+    public function testEmptyMarkerStillEndsHeadingAndStartsList(): void
+    {
+        // The "empty item cannot interrupt" rule is paragraph-only. After a
+        // heading (not a paragraph), an empty marker must still end the heading
+        // and open a list, not fold into the heading text.
+        $converter = DjotConverter::withBlocksInterruptParagraphs();
+        $result = $converter->convert("# h\n- ");
+
+        $this->assertStringContainsString('<h1>h</h1>', $result);
+        $this->assertStringContainsString('<ul>', $result);
     }
 }


### PR DESCRIPTION
## Problem

With `blocksInterruptParagraphs` enabled, a line that is **only a list marker
plus whitespace** wrongly interrupted the preceding paragraph and emitted a
stray empty `<li>`:

```text
intro
- 
```

| input (2nd line) | before | canonical djot.js |
|---|---|---|
| `- ` / `+ ` / `* ` | `<p>intro</p>` + empty `<ul><li>` | `<p>intro\n-</p>` (folds in) |
| `1. ` / `1) ` | `<p>intro</p>` + empty `<ol><li>` | `<p>intro\n1.</p>` (folds in) |

Per the CommonMark/djot rule, an **empty list item cannot interrupt a
paragraph**; the reference folds the marker line into the paragraph as literal
text. The bare `-` (no trailing space) was already handled - only the
marker-plus-whitespace forms slipped through.

## Fix

Reject an empty marker **only when interrupting an open paragraph** - the
paragraph parser is the sole caller that passes the line buffer for lookahead.
In every other context an empty marker still starts a new block, matching the
reference:

- `# h\n- ` ends the heading and opens an (empty) list (does **not** absorb the
  marker into the heading text);
- a standalone `- ` is still a (empty) list.

The earlier attempt that changed the shared block-start helper unconditionally
regressed heading termination; scoping the rule to the paragraph-interruption
caller (lookahead present) fixes the original bug without that regression.

Adds data-provider coverage for the empty-marker fold, plus guards for
content-bearing markers, thematic breaks, the standalone empty list, and the
heading-termination case.
