### PR TITLE
perf: dispatch paragraph opener probes on first char

### DIFF
--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -1724,30 +1724,39 @@ class BlockParser
         // so a fence-looking line mid-paragraph is just paragraph text. With
         // blocksInterruptParagraphs enabled, openers DO interrupt an open paragraph.
         if (!$state['paragraphOpen'] || $this->blocksInterruptParagraphs) {
-            $fenceInfo = $this->fencedBlockParser->parseCodeFenceOpener($content);
-            if ($fenceInfo !== null) {
-                $state['inFence'] = true;
-                $state['fenceChar'] = $fenceInfo['char'];
-                $state['fenceLength'] = $fenceInfo['length'];
-                $state['paragraphOpen'] = false;
+            // Each opener below requires a specific first non-space character
+            // (code fence ` or ~, fenced comment %, div :). Dispatch on it so a
+            // plain-text continuation line skips all three probes and their
+            // per-line trim allocations - the common case under
+            // blocksInterruptParagraphs, where this branch runs for every line.
+            $firstChar = $content[strspn($content, " \t\n\r\0\x0B")] ?? '';
 
-                return;
-            }
+            if ($firstChar === '`' || $firstChar === '~') {
+                $fenceInfo = $this->fencedBlockParser->parseCodeFenceOpener($content);
+                if ($fenceInfo !== null) {
+                    $state['inFence'] = true;
+                    $state['fenceChar'] = $fenceInfo['char'];
+                    $state['fenceLength'] = $fenceInfo['length'];
+                    $state['paragraphOpen'] = false;
 
-            $commentInfo = $this->fencedBlockParser->parseFencedCommentOpener($content);
-            if ($commentInfo !== null) {
-                $state['inComment'] = true;
-                $state['commentLength'] = $commentInfo['length'];
-                $state['paragraphOpen'] = false;
+                    return;
+                }
+            } elseif ($firstChar === '%') {
+                $commentInfo = $this->fencedBlockParser->parseFencedCommentOpener($content);
+                if ($commentInfo !== null) {
+                    $state['inComment'] = true;
+                    $state['commentLength'] = $commentInfo['length'];
+                    $state['paragraphOpen'] = false;
 
-                return;
-            }
+                    return;
+                }
+            } elseif ($firstChar === ':') {
+                if ($this->fencedBlockParser->parseDivFenceOpener($content) !== null) {
+                    // Div opener/closer line is structural; it opens no paragraph itself.
+                    $state['paragraphOpen'] = false;
 
-            if ($this->fencedBlockParser->parseDivFenceOpener($content) !== null) {
-                // Div opener/closer line is structural; it opens no paragraph itself.
-                $state['paragraphOpen'] = false;
-
-                return;
+                    return;
+                }
             }
         }
 


### PR DESCRIPTION
## What

Under `blocksInterruptParagraphs`, the paragraph line classifier probed for code-fence, fenced-comment and div openers on **every** continuation line. Two of those probes (`parseCodeFenceOpener`, `parseFencedCommentOpener`) allocate a trimmed copy of the line before their own first-character check, so a plain-text continuation line paid two throwaway string allocations plus three function calls for nothing.

Each opener requires a specific first non-space character (`` ` ``/`~`, `%`, `:`). This dispatches on that character and calls only the matching probe.

## Correctness

Behavior is unchanged: a line whose first non-space character is none of those characters cannot open any of the three blocks. Full suite stays green (2531 tests), phpstan and phpcs clean.

## Performance

No numeric speedup is claimed. The benchmark machine was under concurrent load and the run-to-run noise (±50% on the relevant fixture) swamped the expected effect, so a clean A/B was not possible. The change is a strict reduction in per-line work (fewer probes, no trim allocations on plain lines) and is offered on that basis, not on a measured win.
