### PR TITLE
perf: bulk-skip plain inline text and guard single-quote cache

### DIFF
--- a/src/Parser/InlineParser.php
+++ b/src/Parser/InlineParser.php
@@ -35,6 +35,19 @@ use Djot\Parser\Utility\AttributeParser;
 class InlineParser
 {
     /**
+     * Characters that can begin a non-plain-text inline construct (escape, code
+     * span, emphasis, link, autolink, math, smart quote/dash, attributes, ...).
+     *
+     * Any run of bytes containing none of these is plain text and is bulk-copied
+     * in a single strcspn() scan instead of going through the per-character
+     * dispatch in parseInlines(). Keep this in sync with the `$char === ...`
+     * branches in that method.
+     *
+     * @var string
+     */
+    private const INLINE_SPECIAL_CHARS = "\\\n\$`:![<_*^~{\"'-.";
+
+    /**
      * @var array<array{type: string, char: string, pos: int, node: \Djot\Node\Node}>
      */
     protected array $delimiterStack = [];
@@ -211,6 +224,20 @@ class InlineParser
         $this->singleQuoteMatchCache = $this->buildSingleQuoteMatchCache($text);
 
         while ($pos < $length) {
+            // Fast path: bulk-copy a run of plain text in a single C-level scan,
+            // bypassing the per-character dispatch below. Skipped when custom
+            // inline patterns are registered, since those may match anywhere.
+            if ($this->customPatterns === []) {
+                $plain = strcspn($text, self::INLINE_SPECIAL_CHARS, $pos);
+                if ($plain > 0) {
+                    $textBuffer .= substr($text, $pos, $plain);
+                    $pos += $plain;
+                    if ($pos >= $length) {
+                        break;
+                    }
+                }
+            }
+
             $char = $text[$pos];
             $nextChar = $text[$pos + 1] ?? '';
 
@@ -1409,6 +1436,11 @@ class InlineParser
      */
     protected function buildSingleQuoteMatchCache(string $text): array
     {
+        // No single quotes means nothing to match; skip the full byte scan.
+        if (!str_contains($text, "'")) {
+            return [];
+        }
+
         $length = strlen($text);
         $openers = [];
         $closers = [];


### PR DESCRIPTION
## What

Two hot-path optimizations in `InlineParser`, the dominant cost in `convert()` (~82% of parse time, of which inline is ~60%).

### 1. Bulk-skip plain text runs
The inline loop examined every byte through a ~15-branch `if ($char === ...)` dispatch before falling through to append a single plain character. On typical prose 80-90% of bytes are plain text, so almost all of that work was pure overhead.

Now a single `strcspn()` over a set of inline-significant characters jumps across the next run of plain text and copies it in one C-level operation. The fast path is skipped when custom inline patterns are registered, since those can match at any position.

### 2. Guard the single-quote match cache
`buildSingleQuoteMatchCache()` ran a full byte scan on every inline call even when the text contained no `'`. Added an early `str_contains($text, "'")` short-circuit.

## Impact

A/B on a prose-heavy 28 KB fixture (60 iterations, median, pcov off, PHP 8.4):

| | median |
|---|--:|
| before (current master) | 13.1 ms |
| after | 10.0 ms |

Roughly 20-25% faster end-to-end `convert()`; the inline phase alone is about halved. Gain scales with the plain-text ratio of the input.

## Correctness

Output is byte-identical. The `strcspn` character set is kept in sync with the `$char === ...` branches (a comment on the constant flags this). Full unit suite and the official djot spec corpus pass unchanged.

## Notes

Complements the block-parser first-char dispatch from #223; this is the inline-side equivalent.