### PR TITLE
perf: skip block probe chain for plain paragraph lines

### DIFF
--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -45,6 +45,22 @@ use Djot\Renderer\HeadingIdTracker;
 class BlockParser
 {
     /**
+     * Non-letter first (post-indent) characters that can begin a built-in block
+     * construct: headings (#), bullet/ordered lists (-*+, digits, parenthesized),
+     * thematic breaks (-*), block quotes (>), fenced code/div/raw/comment (` ~ %),
+     * tables and line blocks (|), captions (^), footnote/reference defs ([),
+     * abbreviations (*), divs/definition lists (:), and block attributes ({).
+     *
+     * Letters are handled separately in parseBlocksImpl() because they only begin a
+     * block when shaped like an alphabetic/roman ordered-list marker. A line whose
+     * first non-blank character is neither in this set nor such a marker can only be
+     * a paragraph. Keep this in sync with the probes in parseBlocksImpl().
+     *
+     * @var string
+     */
+    private const BLOCK_MARKER_CHARS = '#>-*+~`|^[%:({0123456789';
+
+    /**
      * Neutral starting point for incremental brace scanning.
      *
      * @var array{depth: int, inQuote: bool, quoteChar: string, pendingEscape: bool}
@@ -930,6 +946,23 @@ class BlockParser
             $customConsumed = $this->tryCustomBlockPatterns($parent, $lines, $i);
             if ($customConsumed !== null) {
                 $i += $customConsumed;
+
+                continue;
+            }
+
+            // Fast path: every built-in block construct begins with a fixed marker
+            // character (after optional leading whitespace). If the first non-blank
+            // character is none of them, the line can only be a paragraph, so skip
+            // the probe chain below. Letters can begin alphabetic/roman ordered list
+            // markers (a. / iv) / etc.), so a letter only enters the chain when it
+            // matches that marker shape; plain prose words fall straight through.
+            $marker = $line[strspn($line, " \t")] ?? '';
+            if (
+                $marker !== ''
+                && !str_contains(self::BLOCK_MARKER_CHARS, $marker)
+                && !($marker >= 'A' && preg_match('/^[ \t]*[A-Za-z]+[.)][ \t]/', $line) === 1)
+            ) {
+                $i += $this->tryParseParagraph($parent, $lines, $i);
 
                 continue;
             }


### PR DESCRIPTION
## What

`parseBlocksImpl()` ran every non-blank line through up to 15 `tryParse*` probes (several doing a `preg_match` or helper scan) in precedence order before falling through to `tryParseParagraph()`. On prose the large majority of lines are paragraphs, so that whole chain was wasted work on every one.

Every built-in block construct begins with a fixed marker character after optional indentation. The new fast path gates the chain on the first non-blank character:

- punctuation/digit markers enter the chain exactly as before;
- a letter enters the chain only when the line is shaped like an alphabetic/roman ordered-list marker (`a.`, `iv)`, ...), checked with one cheap regex;
- anything else (ordinary prose) goes straight to a paragraph.

The marker set is a superset of every construct's opener, so a real block is never diverted to a paragraph.

## Impact

A/B on a mixed 26 KB fixture (60 iterations, median, pcov off, PHP 8.4):

| | median |
|---|--:|
| before | 8.4 ms |
| after | 7.8 ms |

About 7% on mixed content; larger on prose-heavy input where nearly every line is a paragraph. Independent of, and stacks with, the inline plain-text fast path in #225 (different file).

## Correctness

Output is byte-identical. The block-quote/list/heading probes keep their own exact logic; this only avoids calling them when the first character cannot begin a block. Full unit suite and the official djot spec corpus pass unchanged. The alphabetic-list case (`A. item` etc.) is covered by the letter branch and by existing corpus tests.
