### PR TITLE
Compact list blocks: a sub-block no longer loosens a tight list

### DIFF
--- a/docs/guide/syntax.md
+++ b/docs/guide/syntax.md
@@ -575,6 +575,57 @@ With `nestedListsWithoutBlankLine` mode enabled, nested lists can appear immedia
 
 See the [Parser Options guide](/guide/parser-options#nested-lists-without-blank-line-mode) for more on `nestedListsWithoutBlankLine` mode.
 
+#### Compact List Blocks
+
+::: warning djot-php divergence
+By default djot-php keeps a list **tight** when an item carries a sub-block.
+Canonical djot renders such a list **loose**. This changes only the tight/loose
+rendering, never the block structure, so it does not affect the uniformity
+principle — but the HTML differs from djot.js for these inputs.
+:::
+
+In standard djot, a block inside a list item needs a blank line before it, and
+that blank line makes the whole list **loose** (every item gets `<p>` wrappers).
+So any list whose items carry a sub-block is forced loose. djot-php avoids this:
+the blank line still **starts** the block, but no longer **loosens** the list
+when the indented content opens a block (sub-list, block quote, fenced code,
+fenced div, heading, table). The item stays tight, with its lead text inline.
+
+```djot
+- Deploy the service
+
+  > Needs the new env vars set first
+- Run migrations
+```
+
+renders a **tight** list (lead text inline, the quote attached to its item):
+
+```html
+<ul>
+<li>
+Deploy the service
+<blockquote>
+<p>Needs the new env vars set first</p>
+</blockquote>
+</li>
+<li>
+Run migrations
+</li>
+</ul>
+```
+
+::: tip Still loose, correctly
+Only blank-then-*block* is affected. A genuine **second prose paragraph** in an
+item, and a **blank line between items**, still make the list loose:
+
+```djot
+- First point.
+
+  A full second paragraph of explanation.
+- Second point.
+```
+:::
+
 ### Definition Lists
 
 Terms are prefixed with `: ` and definitions are indented below.

--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -1903,13 +1903,21 @@ class BlockParser
                 // Content after blank line with indentation belongs to previous item
                 $lastItem = $this->listParser->getLastListItem($list);
                 if ($lastItem !== null) {
-                    // Check if the first indented content is a list marker or regular text
-                    // Blank line followed by indented TEXT = loose list (multiple paragraphs)
-                    // Blank line followed by indented LIST MARKER = tight nesting
+                    // A blank line before indented content does not loosen the list
+                    // when that content OPENS A BLOCK (sub-list, block quote, fenced
+                    // code, fenced div, heading, table, thematic break). Only a
+                    // genuine second prose paragraph (blank + indented plain text)
+                    // makes the list loose. This keeps items tight while still
+                    // requiring the blank line djot needs to start the block, so
+                    // block recognition and uniformity are unchanged -- only the
+                    // tight/loose RENDERING differs from canonical djot.
                     $trimmedCurrent = ltrim($currentLine);
-                    $firstContentIsListMarker = $this->listParser->parseListItemMarker($trimmedCurrent) !== null;
-                    if (!$firstContentIsListMarker) {
-                        // Indented text after blank = loose list
+                    $firstContentOpensBlock =
+                        $this->listParser->parseListItemMarker($trimmedCurrent) !== null
+                        || $this->startsNewBlockSignificant($trimmedCurrent);
+                    if (!$firstContentOpensBlock) {
+                        // Indented plain text after a blank line = a second
+                        // paragraph in the item => loose list.
                         $list->setTight(false);
                     }
 

--- a/tests/TestCase/CompactListBlocksTest.php
+++ b/tests/TestCase/CompactListBlocksTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Test\TestCase;
+
+use Djot\DjotConverter;
+use Djot\Renderer\SoftBreakMode;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Compact list blocks (always on).
+ *
+ * A blank line is still required to START a block inside a list item (djot's
+ * block-recognition and the uniformity principle are unchanged). But that blank
+ * line no longer forces the list LOOSE when the indented content opens a block
+ * (sub-list, block quote, fenced code, fenced div, heading, table). Only a
+ * genuine second prose paragraph, or a blank line between items, makes the list
+ * loose. Result: an item can carry a sub-block while staying tight (lead text
+ * inline, no <p> ceremony).
+ *
+ * This is a deliberate divergence from canonical djot, which renders such lists
+ * loose; it changes only the tight/loose RENDERING, never the block structure.
+ */
+class CompactListBlocksTest extends TestCase
+{
+    protected DjotConverter $converter;
+
+    protected function setUp(): void
+    {
+        $this->converter = new DjotConverter();
+        $this->converter->getHtmlRenderer()->setSoftBreakMode(SoftBreakMode::Newline);
+    }
+
+    public function testBlockquoteAfterBlankStaysTight(): void
+    {
+        $html = $this->converter->convert("- item\n\n  > note\n- next");
+        // Lead text inline (tight), not wrapped in <p>.
+        $this->assertStringContainsString("<li>\nitem\n<blockquote>", $html);
+        $this->assertStringNotContainsString('<p>item</p>', $html);
+    }
+
+    public function testFencedCodeAfterBlankStaysTight(): void
+    {
+        $html = $this->converter->convert("- run\n\n  ```\n  make\n  ```\n- next");
+        $this->assertStringContainsString("<li>\nrun\n<pre>", $html);
+        $this->assertStringNotContainsString('<p>run</p>', $html);
+    }
+
+    public function testHeadingAfterBlankStaysTight(): void
+    {
+        $html = $this->converter->convert("- section\n\n  # Title\n- next");
+        $this->assertStringContainsString("<li>\nsection\n", $html);
+        $this->assertStringNotContainsString('<p>section</p>', $html);
+    }
+
+    public function testSublistAfterBlankStaysTight(): void
+    {
+        $html = $this->converter->convert("- parent\n\n  - child\n- next");
+        $this->assertStringNotContainsString('<p>parent</p>', $html);
+    }
+
+    public function testSecondProseParagraphStillLoosens(): void
+    {
+        // A real second paragraph in the item is still a loose list.
+        $html = $this->converter->convert("- item\n\n  second paragraph\n- next");
+        $this->assertStringContainsString('<p>item</p>', $html);
+        $this->assertStringContainsString('<p>second paragraph</p>', $html);
+    }
+
+    public function testBlankLineBetweenItemsStillLoosens(): void
+    {
+        $html = $this->converter->convert("- a\n\n- b");
+        $this->assertStringContainsString('<p>a</p>', $html);
+        $this->assertStringContainsString('<p>b</p>', $html);
+    }
+}

--- a/tests/TestCase/Converter/HtmlToDjotTest.php
+++ b/tests/TestCase/Converter/HtmlToDjotTest.php
@@ -722,7 +722,9 @@ HTML;
 
         $this->assertSame("- One\n\n  > Quote\n", $result);
         $htmlBack = (new DjotConverter())->convert($result);
-        $this->assertStringContainsString("<li>\n<p>One</p>\n<blockquote>", $htmlBack);
+        // Compact-list-blocks: a blank line before a sub-block no longer loosens
+        // the item, so the lead text renders inline (tight), not wrapped in <p>.
+        $this->assertStringContainsString("<li>\nOne\n<blockquote>", $htmlBack);
         $this->assertStringContainsString('<p>Quote</p>', $htmlBack);
     }
 


### PR DESCRIPTION
> **Draft / proposal.** Always-on. This is a deliberate **divergence from canonical djot** for discussion — see "Divergence" at the end. The official djot test suite stays green (it doesn't pin these cases), but djot.js would render the lists below *loose*.

## The problem: you can't have a tight list item that contains a block

djot has two rules that collide:
1. a block (quote, code, div, heading, sub-list) inside a list item needs a **blank line** before it, and
2. a blank line inside an item makes the whole list **loose** (every item gets `<p>` wrappers + vertical spacing).

So **any** list whose items carry a sub-block is forced loose. There is no way to write a *compact* checklist-with-notes or steps-with-code. That's the itch this scratches.

## The change

A blank line is still required to **start** the block (block recognition and the uniformity principle are unchanged). It just no longer **loosens** the list when the indented content opens a block. Loose is still triggered by a genuine second prose paragraph, or a blank line between items.

Net effect, on one example:
```html
- One

  > Quote
```
```diff
  <li>
- <p>One</p>
+ One
  <blockquote>
  <p>Quote</p>
  </blockquote>
  </li>
```
Only the lead `<p>` placement changes — the block structure is identical.

## Showcase — where it comes in handy

**Checklist with a note per task** (deploy runbook, review checklist):
```djot
- [ ] Deploy the service

  > Needs the new env vars set first
- [x] Run migrations
```
→ a **tight** task list; the note sits with its item instead of the whole list blowing out to loose/spaced.
```html
<ul class="task-list">
<li>
<input disabled="" type="checkbox"/>
Deploy the service
<blockquote>
<p>Needs the new env vars set first</p>
</blockquote>
</li>
<li>
<input disabled="" type="checkbox" checked=""/>
Run migrations
</li>
</ul>
```

**Steps with a code block** (install / build instructions):
```djot
- Build the image

  ```sh
  docker build -t app .
  ```
- Push it
```
```html
<ul>
<li>
Build the image
<pre><code class="language-sh">docker build -t app .
</code></pre>
</li>
<li>
Push it
</li>
</ul>
```
The code attaches to its step, list stays tight. Same for a `:::note` admonition, a sub-table, or a quote under each item.

## What is deliberately **not** changed (still loose, correctly)

A real second paragraph in an item:
```djot
- First point.

  A full second paragraph of explanation.
- Second point.
```
→ stays **loose** (`<p>First point.</p>` + `<p>…explanation.</p>`). And a blank line **between items** still loosens. Only blank-then-*block* is affected.

## Why this respects uniformity (the djot principle)

Uniformity is about block *structure* — "a single paragraph stays a single paragraph when embedded." This change touches only tight-vs-loose **rendering** (whether the lead paragraph prints its `<p>` tag), which djot already varies by tight/loose. No block is recognized differently; embedding is unchanged. So it does not violate the principle that motivated djot.

## Divergence (honest)

Canonical djot renders the showcase lists **loose**; this renders them tight. The official test suite passes because it does not pin these specific loose-list-with-sub-block cases, but this **is** a behavioral difference from djot.js on those inputs. Hence: draft, for discussion on whether this belongs in djot-php (always-on), behind a flag, or proposed upstream.

## Implementation

One guard broadened in `BlockParser`: the "blank line + indented content" loosening check goes from *"is a list marker"* to *"opens any structured block"* (reusing `startsNewBlockSignificant`). Between-items loosening untouched; the renderer already strips the lead `<p>` for tight items, so no renderer change. New `CompactListBlocksTest`; one round-trip test updated to the tight output.
