### PR TITLE
List continuation marker: attach a block to a list item with `+`

### DIFF
--- a/docs/guide/syntax.md
+++ b/docs/guide/syntax.md
@@ -586,8 +586,11 @@ to other djot implementations.
 A lone `+` on its own line, at the list marker's column, attaches the following
 block to the current list item **without a blank line and without making the
 list loose**. It lets you keep a tight item that carries a code block, table,
-admonition or quote, without indenting the block's body — useful for deeply
+div/admonition or quote, without indenting the block's body. Useful for deeply
 nested or wide-marker lists, and for pasting code (no re-indenting every line).
+
+The marker is recognized **only** in the tight form `x` / `+` / `y`: content,
+then a lone `+`, then the block, with **no blank line before or after** the `+`.
 
 ````djot
 - Build the image
@@ -613,6 +616,13 @@ Push it
 </ul>
 ```
 
+Only **container and verbatim** blocks attach. A leaf block, or a `+` with a
+blank line around it, is left as ordinary text:
+
+| `+` attaches | `+` stays literal text |
+|---|---|
+| blockquote `>`, fenced code / raw ` ``` ` or `~~~`, table `\|`, div / admonition `:::` | paragraph, heading `##`, thematic break `---`, a sibling list item, or any blank line around the `+` |
+
 A blockquote, table or `:::` admonition attaches the same way:
 
 ```djot
@@ -630,6 +640,22 @@ A blockquote, table or `:::` admonition attaches the same way:
 - Outside a list, a lone `+` is ordinary paragraph text.
 - This is sugar, not new structure: the same result is also reachable by
   indenting the block under the item (which djot already supports).
+:::
+
+::: info Portable alternative
+`+` is a djot-php extension and is not portable. The canonical djot way to attach
+a block to a list item is to **indent it under the item** after a blank line,
+which every djot implementation accepts. For callouts specifically, use a
+canonical [`:::` div](#divs) inside the indented item rather than relying on `+`:
+
+```djot
+- item
+
+  ::: note
+  a note attached to the item
+  :::
+- next
+```
 :::
 
 ### Definition Lists

--- a/docs/guide/syntax.md
+++ b/docs/guide/syntax.md
@@ -575,6 +575,63 @@ With `nestedListsWithoutBlankLine` mode enabled, nested lists can appear immedia
 
 See the [Parser Options guide](/guide/parser-options#nested-lists-without-blank-line-mode) for more on `nestedListsWithoutBlankLine` mode.
 
+#### List Continuation Marker
+
+::: warning djot-php addition
+The `+` continuation marker is a djot-php extension, **not** part of canonical
+djot — djot.js does not recognize it. Documents that rely on it are not portable
+to other djot implementations.
+:::
+
+A lone `+` on its own line, at the list marker's column, attaches the following
+block to the current list item **without a blank line and without making the
+list loose**. It lets you keep a tight item that carries a code block, table,
+admonition or quote, without indenting the block's body — useful for deeply
+nested or wide-marker lists, and for pasting code (no re-indenting every line).
+
+````djot
+- Build the image
++
+```sh
+docker build -t app .
+```
+- Push it
+````
+
+renders a **tight** list whose first item carries the code block flush-left:
+
+```html
+<ul>
+<li>
+Build the image
+<pre><code class="language-sh">docker build -t app .
+</code></pre>
+</li>
+<li>
+Push it
+</li>
+</ul>
+```
+
+A blockquote, table or `:::` admonition attaches the same way:
+
+```djot
+- item
++
+> a note attached to the item
+- next
+```
+
+::: tip Notes
+- A bare `+` is **never** a bullet (a bullet needs `+ ` plus content), so this
+  does not collide with `+`-bulleted lists.
+- The marker attaches one block, up to the next blank line, sibling item, or a
+  further `+`.
+- Outside a list, a lone `+` is ordinary paragraph text.
+- This is sugar, not new structure: the same result is also reachable by
+  indenting the block under the item (which djot already supports).
+:::
+
 ### Definition Lists
 
 Terms are prefixed with `: ` and definitions are indented below.

--- a/docs/guide/syntax.md
+++ b/docs/guide/syntax.md
@@ -645,6 +645,34 @@ A blockquote, table or `:::` admonition attaches the same way:
 - next
 ```
 
+When the block is the **first content** of the item (no text before it), put the
+`+` right after the marker as `- +` (a space between marker and `+`, never a
+trailing space). This is the lint-safe way to start an item with a block:
+
+```djot
+- +
+| a | b |
+- next
+```
+
+renders the table as the first item's only content:
+
+```html
+<ul>
+<li>
+<table>
+<tr>
+<td>a</td>
+<td>b</td>
+</tr>
+</table>
+</li>
+<li>
+next
+</li>
+</ul>
+```
+
 ::: tip Notes
 - A bare `+` is **never** a bullet (a bullet needs `+ ` plus content), so this
   does not collide with `+`-bulleted lists.

--- a/docs/guide/syntax.md
+++ b/docs/guide/syntax.md
@@ -586,8 +586,21 @@ to other djot implementations.
 A lone `+` on its own line, at the list marker's column, attaches the following
 block to the current list item **without a blank line and without making the
 list loose**. It lets you keep a tight item that carries a code block, table,
-div/admonition or quote, without indenting the block's body. Useful for deeply
-nested or wide-marker lists, and for pasting code (no re-indenting every line).
+div/admonition or quote, without indenting the block's body.
+
+::: tip Why, where it beats plain indentation
+The canonical way to attach a block is to indent its body under the item. `+`
+adds the **flush-left** case, which matters when that indentation is painful:
+
+- **Pasting code** keeps its own indentation; you do not have to re-indent every
+  line by the marker width.
+- **Deep or wide markers** make the required indent large: under `10. ` or three
+  levels deep the body would need 4 to 8 leading spaces on every line. `+` keeps
+  the block flush at column 0.
+
+It adds no new structure (the same tree is reachable by indenting); it is
+authoring sugar for the flush-left case.
+:::
 
 The marker is recognized **only** in the tight form `x` / `+` / `y`: content,
 then a lone `+`, then the block, with **no blank line before or after** the `+`.

--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -1898,6 +1898,51 @@ class BlockParser
                 break;
             }
 
+            // List-continuation marker (AsciiDoc-style `+`): a lone `+` at the
+            // marker column attaches the FOLLOWING flush-left block(s) to the
+            // current item, with no blank line, keeping the list tight. A bare
+            // `+` is never a bullet (a bullet needs `+ ` + content), so this does
+            // not collide with `+`-bulleted lists. Lets you attach a code block,
+            // table or quote to an item without indenting its body.
+            if ($currentIndent === $baseIndent && trim($currentLine) === '+') {
+                $lastItem = $this->listParser->getLastListItem($list);
+                if ($lastItem !== null) {
+                    $i++; // consume the `+` marker line
+                    /** @var array<string> $attached */
+                    $attached = [];
+                    while ($i < $count) {
+                        $line = $lines[$i];
+                        if (IndentationHelper::isBlankLine($line)) {
+                            break; // a blank ends the attachment (single-block demo scope)
+                        }
+                        $lineIndent = IndentationHelper::getLeadingSpaces($line);
+                        if ($lineIndent < $baseIndent) {
+                            break;
+                        }
+                        $trimmed = ltrim($line);
+                        if ($lineIndent === $baseIndent) {
+                            // Stop at a sibling item marker or a further `+` marker.
+                            $marker = $this->listParser->parseListItemMarker($trimmed);
+                            if ($marker !== null && $this->listParser->itemMatchesList($listInfo, $marker)) {
+                                break;
+                            }
+                            if ($trimmed === '+') {
+                                break;
+                            }
+                        }
+                        $attached[] = IndentationHelper::stripLeadingIndent($line, $baseIndent);
+                        $i++;
+                    }
+                    if ($attached !== []) {
+                        $this->parseBlocks($lastItem, $attached, 0);
+                    }
+                    // The continuation attaches content but does not loosen the list.
+                    $lastItemHadBlankAfter = false;
+
+                    continue;
+                }
+            }
+
             // Check for indented continuation (after blank line = nested content)
             if ($lastItemHadBlankAfter && $currentIndent > $baseIndent) {
                 // Content after blank line with indentation belongs to previous item
@@ -2074,6 +2119,12 @@ class BlockParser
                 if ($nextIndent === $baseIndent) {
                     $nextInfo = $this->listParser->parseListItemMarker($nextTrimmed);
                     if ($nextInfo !== null) {
+                        break;
+                    }
+                    // List-continuation marker: stop collecting lead text so the
+                    // main loop's `+` handler attaches the following block to this
+                    // item (instead of swallowing `+` as lazy continuation text).
+                    if ($nextTrimmed === '+') {
                         break;
                     }
                     // Non-list content at base indent - check if it starts another block

--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -3578,12 +3578,10 @@ class BlockParser
      */
     private function opensAttachableContinuationBlock(string $trimmed): bool
     {
-        if ($trimmed === '') {
-            return false;
-        }
+        $first = $trimmed[0] ?? '';
 
-        return $trimmed[0] === '>'
-            || $trimmed[0] === '|'
+        return $first === '>'
+            || $first === '|'
             || preg_match('/^(`{3,}|~{3,}|:{3,})/', $trimmed) === 1;
     }
 

--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -1899,12 +1899,15 @@ class BlockParser
             }
 
             // List-continuation marker (AsciiDoc-style `+`): a lone `+` at the
-            // marker column attaches the FOLLOWING flush-left block(s) to the
-            // current item, with no blank line, keeping the list tight. A bare
-            // `+` is never a bullet (a bullet needs `+ ` + content), so this does
-            // not collide with `+`-bulleted lists. Lets you attach a code block,
-            // table or quote to an item without indenting its body.
-            if ($currentIndent === $baseIndent && trim($currentLine) === '+') {
+            // marker column, in the tight form `x` / `+` / `y` (no blank line
+            // before or after it), attaches the FOLLOWING flush-left block to the
+            // current item and keeps the list tight. Only container/verbatim
+            // blocks attach (see isTightListContinuation()); any other shape
+            // leaves the `+` as ordinary text. A bare `+` is never a bullet
+            // (a bullet needs `+ ` + content), so it does not collide with
+            // `+`-bulleted lists. Lets you attach a code block, table or quote to
+            // an item without indenting its body.
+            if ($this->isTightListContinuation($lines, $i, $baseIndent)) {
                 $lastItem = $this->listParser->getLastListItem($list);
                 if ($lastItem !== null) {
                     $i++; // consume the `+` marker line
@@ -2123,8 +2126,9 @@ class BlockParser
                     }
                     // List-continuation marker: stop collecting lead text so the
                     // main loop's `+` handler attaches the following block to this
-                    // item (instead of swallowing `+` as lazy continuation text).
-                    if ($nextTrimmed === '+') {
+                    // item. Only the tight `x` / `+` / `y` form qualifies; an
+                    // otherwise-shaped `+` stays lazy continuation text.
+                    if ($nextTrimmed === '+' && $this->isTightListContinuation($lines, $i, $baseIndent)) {
                         break;
                     }
                     // Non-list content at base indent - check if it starts another block
@@ -3521,6 +3525,66 @@ class BlockParser
         if ($lastChild instanceof Paragraph) {
             $this->inlineParser->parse($lastChild, ' ' . $content, $line);
         }
+    }
+
+    /**
+     * Whether the line at $i is a list-continuation marker in the only valid form:
+     *
+     *     x
+     *     +
+     *     y
+     *
+     * A lone `+` at the marker column with content (no blank line) immediately
+     * before and after it, where `y` opens a container or verbatim block. Any
+     * other shape (blank line around the `+`, a leaf block such as a paragraph,
+     * heading or thematic break, or a sibling list item) leaves the `+` as
+     * ordinary text.
+     *
+     * @param array<string> $lines
+     * @param int $baseIndent
+     * @param int $i
+     */
+    private function isTightListContinuation(array $lines, int $i, int $baseIndent): bool
+    {
+        $line = $lines[$i] ?? '';
+        if (trim($line) !== '+' || IndentationHelper::getLeadingSpaces($line) !== $baseIndent) {
+            return false;
+        }
+
+        // No blank line (and not the very first line) immediately before the marker.
+        if (!isset($lines[$i - 1]) || IndentationHelper::isBlankLine($lines[$i - 1])) {
+            return false;
+        }
+
+        // A non-blank block must follow immediately at the marker column.
+        $next = $lines[$i + 1] ?? null;
+        if ($next === null || IndentationHelper::isBlankLine($next)) {
+            return false;
+        }
+        if (IndentationHelper::getLeadingSpaces($next) !== $baseIndent) {
+            return false;
+        }
+
+        return $this->opensAttachableContinuationBlock(ltrim($next));
+    }
+
+    /**
+     * Whether a line opens a block that a `+` continuation may attach to a list
+     * item: a container block (blockquote `>`, div/admonition `:::`, table `|`)
+     * or a verbatim block (fenced code/raw ``` or ~~~).
+     *
+     * Leaf blocks (paragraph, heading, thematic break) and lists (a `-`/`1.` at
+     * the marker column is a sibling item, not nested content) are excluded.
+     */
+    private function opensAttachableContinuationBlock(string $trimmed): bool
+    {
+        if ($trimmed === '') {
+            return false;
+        }
+
+        return $trimmed[0] === '>'
+            || $trimmed[0] === '|'
+            || preg_match('/^(`{3,}|~{3,}|:{3,})/', $trimmed) === 1;
     }
 
     /**

--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -1910,35 +1910,8 @@ class BlockParser
             if ($this->isTightListContinuation($lines, $i, $baseIndent)) {
                 $lastItem = $this->listParser->getLastListItem($list);
                 if ($lastItem !== null) {
-                    $i++; // consume the `+` marker line
-                    /** @var array<string> $attached */
-                    $attached = [];
-                    while ($i < $count) {
-                        $line = $lines[$i];
-                        if (IndentationHelper::isBlankLine($line)) {
-                            break; // a blank ends the attachment (single-block demo scope)
-                        }
-                        $lineIndent = IndentationHelper::getLeadingSpaces($line);
-                        if ($lineIndent < $baseIndent) {
-                            break;
-                        }
-                        $trimmed = ltrim($line);
-                        if ($lineIndent === $baseIndent) {
-                            // Stop at a sibling item marker or a further `+` marker.
-                            $marker = $this->listParser->parseListItemMarker($trimmed);
-                            if ($marker !== null && $this->listParser->itemMatchesList($listInfo, $marker)) {
-                                break;
-                            }
-                            if ($trimmed === '+') {
-                                break;
-                            }
-                        }
-                        $attached[] = IndentationHelper::stripLeadingIndent($line, $baseIndent);
-                        $i++;
-                    }
-                    if ($attached !== []) {
-                        $this->parseBlocks($lastItem, $attached, 0);
-                    }
+                    // Attach the following block to the current item; skip the `+`.
+                    $i = $this->attachContinuationBlock($lastItem, $lines, $i + 1, $count, $baseIndent, $listInfo);
                     // The continuation attaches content but does not loosen the list.
                     $lastItemHadBlankAfter = false;
 
@@ -2086,6 +2059,19 @@ class BlockParser
             $listItem = new ListItem($taskMarker);
             /** @var string $itemContent */
             $itemContent = $itemInfo['content'];
+
+            // Empty-item continuation: a marker whose only content is a bare `+`
+            // (e.g. `- +`) with an attachable container/verbatim block on the next
+            // flush-left line attaches that block as the item's sole content. This
+            // is the trailing-whitespace-free form of `x` / `+` / `y` for the case
+            // where the block is the first thing in the item.
+            if ($itemContent === '+' && $this->nextLineOpensAttachableBlock($lines, $i, $baseIndent)) {
+                $list->appendChild($listItem);
+                $i = $this->attachContinuationBlock($listItem, $lines, $i + 1, $count, $baseIndent, $listInfo);
+                $lastItemHadBlankAfter = false;
+
+                continue;
+            }
 
             // Collect item content lines (without blank line = tight continuation)
             /** @var array<string> $itemLines */
@@ -3556,7 +3542,20 @@ class BlockParser
             return false;
         }
 
-        // A non-blank block must follow immediately at the marker column.
+        return $this->nextLineOpensAttachableBlock($lines, $i, $baseIndent);
+    }
+
+    /**
+     * Whether the line after index $i is a non-blank attachable block, flush at
+     * the marker column. Shared by the lone-`+` marker (`x` / `+` / `y`) and the
+     * empty-item marker (`- +` / `y`).
+     *
+     * @param array<string> $lines
+     * @param int $baseIndent
+     * @param int $i
+     */
+    private function nextLineOpensAttachableBlock(array $lines, int $i, int $baseIndent): bool
+    {
         $next = $lines[$i + 1] ?? null;
         if ($next === null || IndentationHelper::isBlankLine($next)) {
             return false;
@@ -3566,6 +3565,50 @@ class BlockParser
         }
 
         return $this->opensAttachableContinuationBlock(ltrim($next));
+    }
+
+    /**
+     * Collect and attach a single flush-left block to $item, starting at line
+     * index $i (the first line of the block). The block runs to the next blank
+     * line, sibling item marker, or further `+`. Returns the index just past the
+     * attached block.
+     *
+     * @param \Djot\Node\Block\ListItem $item
+     * @param array<string> $lines
+     * @param int $baseIndent
+     * @param int $count
+     * @param int $i
+     * @param array<string, mixed> $listInfo
+     */
+    private function attachContinuationBlock(ListItem $item, array $lines, int $i, int $count, int $baseIndent, array $listInfo): int
+    {
+        /** @var array<string> $attached */
+        $attached = [];
+        while ($i < $count) {
+            $line = $lines[$i];
+            if (IndentationHelper::isBlankLine($line)) {
+                break; // a blank ends the attachment (single block)
+            }
+            $lineIndent = IndentationHelper::getLeadingSpaces($line);
+            $trimmed = ltrim($line);
+            if ($lineIndent === $baseIndent) {
+                // Stop at a sibling item marker or a further `+` marker.
+                $marker = $this->listParser->parseListItemMarker($trimmed);
+                if ($marker !== null && $this->listParser->itemMatchesList($listInfo, $marker)) {
+                    break;
+                }
+                if ($trimmed === '+') {
+                    break;
+                }
+            }
+            $attached[] = IndentationHelper::stripLeadingIndent($line, $baseIndent);
+            $i++;
+        }
+        if ($attached !== []) {
+            $this->parseBlocks($item, $attached, 0);
+        }
+
+        return $i;
     }
 
     /**

--- a/tests/TestCase/ListContinuationMarkerTest.php
+++ b/tests/TestCase/ListContinuationMarkerTest.php
@@ -112,4 +112,24 @@ class ListContinuationMarkerTest extends TestCase
         $this->assertStringContainsString("item\n+\n", $html);
         $this->assertStringNotContainsString('<blockquote>', $html);
     }
+
+    /**
+     * The marker is list-item-scoped, not quote-scoped: it works for a list
+     * nested inside a blockquote (attaching to the list item, inside the quote),
+     * but a `+` in a quote with no list stays literal text.
+     */
+    public function testWorksForListNestedInsideBlockquote(): void
+    {
+        $attached = $this->converter->convert("> - item\n> +\n> > note\n> - next");
+        // The quote-in-item is attached to the first list item, inside the outer quote.
+        $this->assertStringContainsString(
+            "<blockquote>\n<ul>\n<li>\nitem\n<blockquote>\n<p>note</p>",
+            $attached,
+        );
+        $this->assertStringContainsString("<li>\nnext\n</li>", $attached);
+
+        // No list to attach to: the `+` is ordinary text.
+        $noList = $this->converter->convert("> para\n> +\n> > note");
+        $this->assertStringContainsString("para\n+\n", $noList);
+    }
 }

--- a/tests/TestCase/ListContinuationMarkerTest.php
+++ b/tests/TestCase/ListContinuationMarkerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Test\TestCase;
+
+use Djot\DjotConverter;
+use Djot\Renderer\SoftBreakMode;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * List continuation marker (AsciiDoc-style `+`).
+ *
+ * A lone `+` at the list marker column attaches the following block to the
+ * current item with no blank line, keeping the list tight, without indenting the
+ * block body. A bare `+` is never a bullet (a bullet needs `+ ` + content), so
+ * it does not collide with `+`-bulleted lists; outside a list it stays literal.
+ *
+ * djot-php addition (not canonical djot).
+ */
+class ListContinuationMarkerTest extends TestCase
+{
+    protected DjotConverter $converter;
+
+    protected function setUp(): void
+    {
+        $this->converter = new DjotConverter();
+        $this->converter->getHtmlRenderer()->setSoftBreakMode(SoftBreakMode::Newline);
+    }
+
+    public function testAttachesCodeBlockFlushLeftAndTight(): void
+    {
+        $html = $this->converter->convert("- Build\n+\n```sh\ndocker build .\n```\n- Push");
+        $this->assertStringContainsString("<li>\nBuild\n<pre><code class=\"language-sh\">docker build .\n</code></pre>", $html);
+        $this->assertStringNotContainsString('<p>Build</p>', $html);
+        $this->assertStringContainsString("<li>\nPush\n</li>", $html);
+    }
+
+    public function testAttachesBlockquoteTight(): void
+    {
+        $html = $this->converter->convert("- item\n+\n> note\n- next");
+        $this->assertStringContainsString("<li>\nitem\n<blockquote>", $html);
+        $this->assertStringNotContainsString('<p>item</p>', $html);
+    }
+
+    public function testBareMarkerIsNotABulletInsideOrOutsideList(): void
+    {
+        // Outside a list: a lone `+` is ordinary paragraph text.
+        $this->assertStringContainsString('<p>+</p>', $this->converter->convert("para\n\n+\n\nnext"));
+        // Real `+` bullets (marker + space + content) are unaffected.
+        $bullets = $this->converter->convert("+ one\n+ two");
+        $this->assertStringContainsString("<li>\none\n</li>", $bullets);
+        $this->assertStringContainsString("<li>\ntwo\n</li>", $bullets);
+    }
+
+    public function testContinuationDoesNotLoosenList(): void
+    {
+        $html = $this->converter->convert("- a\n+\n> q\n- b");
+        // No item is <p>-wrapped: the list stayed tight.
+        $this->assertStringNotContainsString("<li>\n<p>", $html);
+    }
+}

--- a/tests/TestCase/ListContinuationMarkerTest.php
+++ b/tests/TestCase/ListContinuationMarkerTest.php
@@ -103,4 +103,13 @@ class ListContinuationMarkerTest extends TestCase
         $this->assertStringNotContainsString('<blockquote>', $html);
         $this->assertStringContainsString('+', $html);
     }
+
+    public function testIndentedBlockAfterMarkerIsNotFlushAttachment(): void
+    {
+        // The attached block must sit flush at the marker column; an indented
+        // block after `+` is not a tight continuation, so the `+` stays literal.
+        $html = $this->converter->convert("- item\n+\n  > note\n- next");
+        $this->assertStringContainsString("item\n+\n", $html);
+        $this->assertStringNotContainsString('<blockquote>', $html);
+    }
 }

--- a/tests/TestCase/ListContinuationMarkerTest.php
+++ b/tests/TestCase/ListContinuationMarkerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Djot\Test\TestCase;
 
 use Djot\DjotConverter;
+use Djot\Parser\BlockParser;
 use Djot\Renderer\SoftBreakMode;
 use PHPUnit\Framework\TestCase;
 
@@ -131,5 +132,65 @@ class ListContinuationMarkerTest extends TestCase
         // No list to attach to: the `+` is ordinary text.
         $noList = $this->converter->convert("> para\n> +\n> > note");
         $this->assertStringContainsString("para\n+\n", $noList);
+    }
+
+    /**
+     * `- +` (marker + bare `+`, no trailing whitespace) attaches the following
+     * block as the item's first and only content.
+     */
+    public function testEmptyItemMarkerAttachesFirstBlock(): void
+    {
+        $table = $this->converter->convert("- +\n| a | b |\n- next");
+        $this->assertStringContainsString("<li>\n<table>", $table);
+        $this->assertStringContainsString("<li>\nnext\n</li>", $table);
+
+        $ordered = $this->converter->convert("1. +\n> note\n2. next");
+        $this->assertStringContainsString("<li>\n<blockquote>", $ordered);
+    }
+
+    public function testEmptyItemMarkerRejectsLeafBlocks(): void
+    {
+        // `- +` only attaches container/verbatim blocks; a leaf block leaves the
+        // `+` as literal item text.
+        $html = $this->converter->convert("- +\n## H\n- next");
+        $this->assertStringContainsString("+\n## H", $html);
+        $this->assertStringNotContainsString('<table>', $html);
+    }
+
+    public function testChainedMarkersAttachMultipleBlocks(): void
+    {
+        $html = $this->converter->convert("- item\n+\n> a\n+\n> b\n- next");
+        // Two blockquotes attached to the first item, then the sibling.
+        $this->assertSame(2, substr_count($html, '<blockquote>'));
+        $this->assertStringContainsString("<li>\nnext\n</li>", $html);
+    }
+
+    public function testBlankLineEndsAttachedBlock(): void
+    {
+        // The attachment is a single block: a blank line after it ends it, and
+        // following content is a normal top-level block.
+        $html = $this->converter->convert("- item\n+\n> note\n\nafter");
+        $this->assertStringContainsString('<blockquote>', $html);
+        $this->assertStringContainsString('<p>after</p>', $html);
+    }
+
+    public function testContinuationInsideNestedListDedents(): void
+    {
+        // Inside a nested list, the attached block ends when a line dedents below
+        // the nested list's marker column.
+        $html = $this->converter->convert("- outer\n\n  - inner\n  +\n  > note\n- after");
+        $this->assertStringContainsString("inner\n<blockquote>", $html);
+        $this->assertStringContainsString("<li>\nafter\n</li>", $html);
+    }
+
+    public function testContinuationInInlineNestedListDedents(): void
+    {
+        // With inline nesting, the nested list and the dedent to the parent share
+        // one line array, so the attachment must stop at the dedented line.
+        $converter = new DjotConverter(parser: new BlockParser(nestedListsWithoutBlankLine: true));
+        $converter->getHtmlRenderer()->setSoftBreakMode(SoftBreakMode::Newline);
+        $html = $converter->convert("- outer\n  - inner\n  +\n  > note\n- after");
+        $this->assertStringContainsString("inner\n<blockquote>", $html);
+        $this->assertStringContainsString("<li>\nafter\n</li>", $html);
     }
 }

--- a/tests/TestCase/ListContinuationMarkerTest.php
+++ b/tests/TestCase/ListContinuationMarkerTest.php
@@ -95,4 +95,12 @@ class ListContinuationMarkerTest extends TestCase
         $blankBefore = $this->converter->convert("- item\n\n+\n> note");
         $this->assertStringNotContainsString("<li>\nitem\n<blockquote>", $blankBefore);
     }
+
+    public function testTrailingMarkerWithNoFollowingBlockIsLiteral(): void
+    {
+        // A `+` with nothing after it is not a continuation marker.
+        $html = $this->converter->convert("- item\n+");
+        $this->assertStringNotContainsString('<blockquote>', $html);
+        $this->assertStringContainsString('+', $html);
+    }
 }

--- a/tests/TestCase/ListContinuationMarkerTest.php
+++ b/tests/TestCase/ListContinuationMarkerTest.php
@@ -59,4 +59,40 @@ class ListContinuationMarkerTest extends TestCase
         // No item is <p>-wrapped: the list stayed tight.
         $this->assertStringNotContainsString("<li>\n<p>", $html);
     }
+
+    public function testAttachesTableAndDiv(): void
+    {
+        $table = $this->converter->convert("- item\n+\n| a | b |\n- next");
+        $this->assertStringContainsString("<li>\nitem\n<table>", $table);
+
+        $div = $this->converter->convert("- item\n+\n::: note\nhi\n:::\n- next");
+        $this->assertStringContainsString("<li>\nitem\n<div class=\"note\">", $div);
+    }
+
+    /**
+     * Strict scope: a `+` only attaches container/verbatim blocks. A leaf block
+     * (heading, thematic break, plain paragraph) is not attached; the `+` stays
+     * literal continuation text on the item.
+     */
+    public function testDoesNotAttachLeafBlocks(): void
+    {
+        foreach (['## Heading', '---', 'plain paragraph'] as $leaf) {
+            $html = $this->converter->convert("- item\n+\n{$leaf}\n- next");
+            $this->assertStringContainsString("item\n+\n", $html, "+ should stay literal before: {$leaf}");
+            $this->assertStringNotContainsString('<blockquote>', $html);
+        }
+    }
+
+    /**
+     * Only the tight `x` / `+` / `y` form is a continuation marker; a blank line
+     * before or after the `+` leaves it as ordinary text.
+     */
+    public function testBlankLineAroundMarkerIsNotContinuation(): void
+    {
+        $blankAfter = $this->converter->convert("- item\n+\n\n> note");
+        $this->assertStringNotContainsString("<li>\nitem\n<blockquote>", $blankAfter);
+
+        $blankBefore = $this->converter->convert("- item\n\n+\n> note");
+        $this->assertStringNotContainsString("<li>\nitem\n<blockquote>", $blankBefore);
+    }
 }


### PR DESCRIPTION
> **Draft / proposal / demo.** Always-on. A djot-php **addition** (not canonical djot — djot.js has no `+` continuation marker). The official djot test suite stays green. Companion to #227 (compact list blocks); this one is the explicit, no-indent variant.

## What it does

A lone `+` on its own line, at the list-marker column, attaches the **following block** to the current list item — no blank line, list stays **tight**, and the block body is **not indented**. (AsciiDoc's list-continuation idiom.)

```djot
- Build the image
+
```sh
docker build -t app .
```
- Push it
```
→
```html
<ul>
<li>
Build the image
<pre><code class="language-sh">docker build -t app .
</code></pre>
</li>
<li>
Push it
</li>
</ul>
```

A quote, table or `:::` admonition attaches the same way:
```djot
- item
+
> a note attached to the item
- next
```
→ `<li>\nitem\n<blockquote><p>a note attached to the item</p></blockquote>\n</li>` + `<li>\nnext\n</li>`.

## Why — where it beats plain indentation

#227 already lets an *indented* block stay tight. `+` adds the **no-indent** case, which matters when indentation is painful:

- **Pasting code** — no re-indenting every line by the marker width.
- **Deep / wide markers** — under `10. ` or three levels deep, the required indent is 4–8 spaces; `+` keeps the block flush-left.

It adds **no new structure** (same result is reachable by indenting under the item); it's authoring sugar for the flush-left case.

## Collision safety

`+` is a bullet marker — but only `+ ` + content is a bullet. A **bare `+`** is not, so:
- inside a `+`-bulleted list it's unambiguous (not an empty sibling item);
- outside any list a lone `+` stays ordinary paragraph text (`<p>+</p>`).

Both pinned in tests.

## Implementation

- The item-content collector stops at a bare `+` (instead of swallowing it as lazy continuation); the list loop then attaches the following flush-left block(s) to the last item and keeps the list tight.
- One block per `+`, up to the next blank line / sibling item / further `+`.

## Tests & docs

- `ListContinuationMarkerTest` — attach code/quote, no-loosen, bullet + outside-list non-collision.
- Full suite **2539 green**, official djot suite **250/250**.
- Docs: new "List Continuation Marker" section in `guide/syntax.md`, flagged as a djot-php addition.

## Status / relationship to #227

Independent branch from `master`. #227 (compact list blocks) is the zero-syntax win for the common case; this PR is the explicit `+` variant for non-indented blocks. They can land independently or together. Draft for discussion on whether the `+` sigil is worth carrying in a djot port vs leaving it to dialects.
