### PR TITLE
Fix: bare list marker is a valid empty list item (djot.js conformance)

### DIFF
--- a/docs/guide/syntax.md
+++ b/docs/guide/syntax.md
@@ -349,6 +349,40 @@ Lists can start at any number:
 </template>
 </OutputTabs>
 
+#### Empty List Items
+
+A list marker may be followed by a space *or by the end of the line*, so a bare
+marker on its own line is a valid empty item. This works for every marker type
+(`-`, `*`, `+`, `1.`, `(1)`, `a.`, `i.`).
+
+**Input:**
+```djot
+- One
+-
+- Three
+```
+
+<OutputTabs>
+<template #output>
+
+```html
+<ul>
+<li>One</li>
+<li></li>
+<li>Three</li>
+</ul>
+```
+
+</template>
+<template #result>
+<ul>
+<li>One</li>
+<li></li>
+<li>Three</li>
+</ul>
+</template>
+</OutputTabs>
+
 #### Nested Lists
 
 Indent with 2+ spaces for nested lists.

--- a/src/Parser/Block/ListParser.php
+++ b/src/Parser/Block/ListParser.php
@@ -66,9 +66,11 @@ class ListParser
         }
 
         // Bullet list: -, +, or *
-        if (preg_match('/^([-*+]) +(.*)$/', $line, $matches)) {
+        // A marker followed by a space (or end of line) is a valid item; a bare
+        // marker alone on its line is an empty item (djot allows marker + newline).
+        if (preg_match('/^([-*+])(?: +(.*))?$/', $line, $matches)) {
             $marker = $matches[1];
-            $content = $matches[2];
+            $content = $matches[2] ?? '';
 
             // Don't treat as list if content ends with same marker (likely emphasis)
             if ($marker === '*' || $marker === '-') {
@@ -88,27 +90,27 @@ class ListParser
             ];
         }
 
-        // Ordered list: 1. or 1) or (1)
-        if (preg_match('/^(\d+)([.)]) +(.*)$/', $line, $matches)) {
+        // Ordered list: 1. or 1) or (1) - bare marker (no content) is an empty item.
+        if (preg_match('/^(\d+)([.)])(?: +(.*))?$/', $line, $matches)) {
             return [
                 'type' => ListBlock::TYPE_ORDERED,
                 'marker' => $matches[2],
-                'content' => $matches[3],
+                'content' => $matches[3] ?? '',
                 'start' => (int)$matches[1],
             ];
         }
 
-        if (preg_match('/^\((\d+)\) +(.*)$/', $line, $matches)) {
+        if (preg_match('/^\((\d+)\)(?: +(.*))?$/', $line, $matches)) {
             return [
                 'type' => ListBlock::TYPE_ORDERED,
                 'marker' => '()',
-                'content' => $matches[2],
+                'content' => $matches[2] ?? '',
                 'start' => (int)$matches[1],
             ];
         }
 
         // Roman numeral ordered list
-        if (preg_match('/^([ivxlcdmIVXLCDM]+)([.)]) +(.*)$/', $line, $matches)) {
+        if (preg_match('/^([ivxlcdmIVXLCDM]+)([.)])(?: +(.*))?$/', $line, $matches)) {
             $roman = $matches[1];
             $isLower = ctype_lower($roman[0]);
             $start = $this->romanToInt(strtoupper($roman));
@@ -116,7 +118,7 @@ class ListParser
                 $result = [
                     'type' => ListBlock::TYPE_ORDERED,
                     'marker' => $matches[2],
-                    'content' => $matches[3],
+                    'content' => $matches[3] ?? '',
                     'start' => $start,
                     'style' => $isLower ? 'i' : 'I',
                 ];
@@ -131,7 +133,7 @@ class ListParser
             }
         }
 
-        if (preg_match('/^\(([ivxlcdmIVXLCDM]+)\) +(.*)$/', $line, $matches)) {
+        if (preg_match('/^\(([ivxlcdmIVXLCDM]+)\)(?: +(.*))?$/', $line, $matches)) {
             $roman = $matches[1];
             $isLower = ctype_lower($roman[0]);
             $start = $this->romanToInt(strtoupper($roman));
@@ -139,7 +141,7 @@ class ListParser
                 $result = [
                     'type' => ListBlock::TYPE_ORDERED,
                     'marker' => '()',
-                    'content' => $matches[2],
+                    'content' => $matches[2] ?? '',
                     'start' => $start,
                     'style' => $isLower ? 'i' : 'I',
                 ];
@@ -155,7 +157,7 @@ class ListParser
         }
 
         // Alpha ordered list: a. or A. or a) or A) or (a) or (A)
-        if (preg_match('/^([a-zA-Z])([.)]) +(.*)$/', $line, $matches)) {
+        if (preg_match('/^([a-zA-Z])([.)])(?: +(.*))?$/', $line, $matches)) {
             $letter = $matches[1];
             $isLower = ctype_lower($letter);
             $start = ord(strtolower($letter)) - ord('a') + 1;
@@ -163,13 +165,13 @@ class ListParser
             return [
                 'type' => ListBlock::TYPE_ORDERED,
                 'marker' => $matches[2],
-                'content' => $matches[3],
+                'content' => $matches[3] ?? '',
                 'start' => $start,
                 'style' => $isLower ? 'a' : 'A',
             ];
         }
 
-        if (preg_match('/^\(([a-zA-Z])\) +(.*)$/', $line, $matches)) {
+        if (preg_match('/^\(([a-zA-Z])\)(?: +(.*))?$/', $line, $matches)) {
             $letter = $matches[1];
             $isLower = ctype_lower($letter);
             $start = ord(strtolower($letter)) - ord('a') + 1;
@@ -177,7 +179,7 @@ class ListParser
             return [
                 'type' => ListBlock::TYPE_ORDERED,
                 'marker' => '()',
-                'content' => $matches[2],
+                'content' => $matches[2] ?? '',
                 'start' => $start,
                 'style' => $isLower ? 'a' : 'A',
             ];

--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -983,7 +983,7 @@ class BlockParser
             if (
                 $marker !== ''
                 && !str_contains(self::BLOCK_MARKER_CHARS, $marker)
-                && !($marker >= 'A' && preg_match('/^[ \t]*[A-Za-z]+[.)][ \t]/', $line) === 1)
+                && !($marker >= 'A' && preg_match('/^[ \t]*[A-Za-z]+[.)]([ \t]|$)/', $line) === 1)
             ) {
                 $i += $this->tryParseParagraph($parent, $lines, $i);
 
@@ -2080,6 +2080,12 @@ class BlockParser
                     if ($this->startsNewBlock($nextTrimmed)) {
                         break;
                     }
+                    // An empty item (bare marker, no content yet) has no open
+                    // paragraph, so a following base-indent line cannot be lazy
+                    // continuation - it starts a new block outside the list.
+                    if ($itemContent === '' && $itemLines === ['']) {
+                        break;
+                    }
                 }
 
                 // Check for list item attributes (must be at content indent, be a standalone attribute block)
@@ -2233,6 +2239,15 @@ class BlockParser
                 }
             }
 
+            // A bare marker (no same-line content) that is followed by indented
+            // continuation lines owns that content directly: the empty lead line
+            // is just the absent marker text, so drop it. This keeps the item from
+            // rendering a stray blank line and lets a following indented block
+            // (blockquote, code fence, ...) be recognized instead of escaped.
+            if ($itemContent === '' && count($itemLines) > 1 && $itemLines[0] === '') {
+                array_shift($itemLines);
+            }
+
             // For tight lists with continuation lines, check if content starts with
             // a block element. If so, parse as blocks; otherwise parse as plain text.
             // This prevents "-like" lines from being parsed as nested lists while
@@ -2249,7 +2264,9 @@ class BlockParser
                     $this->inlineParser->parse($paragraph, implode("\n", $itemLines), $start);
                     $listItem->appendChild($paragraph);
                 }
-            } else {
+            } elseif ($itemLines !== ['']) {
+                // A bare marker with no content is an empty item: leave it childless
+                // so it renders as `<li>\n</li>` rather than wrapping a blank line.
                 $this->parseBlocks($listItem, $itemLines, 0);
             }
 

--- a/src/Renderer/HtmlRenderer.php
+++ b/src/Renderer/HtmlRenderer.php
@@ -771,6 +771,11 @@ class HtmlRenderer implements RendererInterface
             $content = rtrim($content);
         }
 
+        // An empty item (bare marker, no content) renders without a blank line.
+        if ($content === '') {
+            return '<li' . $attrs . ">\n</li>\n";
+        }
+
         // In djot, list item content is always on its own line
         return '<li' . $attrs . ">\n" . $content . "\n</li>\n";
     }

--- a/tests/TestCase/EmptyListItemsTest.php
+++ b/tests/TestCase/EmptyListItemsTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Test\TestCase;
+
+use Djot\DjotConverter;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for empty list items produced by a bare list marker.
+ *
+ * In canonical djot a list marker may be followed by a space *or a newline*,
+ * so a marker alone on its own line (no content after it) is a valid empty
+ * list item. This is confirmed by the reference implementation (djot.js):
+ * `-`, `*`, `+`, `1.`, `(1)`, `a.`, `i.` each render as a single empty `<li>`.
+ *
+ * Before this fix djot-php required at least one space plus content, so a bare
+ * marker fell through to a paragraph (`<p>-</p>`) or was swallowed as lazy
+ * continuation text inside the previous item - a divergence from the reference.
+ *
+ * Definition lists (`:` marker) are deliberately out of scope here; they are
+ * parsed by a separate path (tryParseDjotDefinitionList) and tracked separately.
+ *
+ * Expected HTML in each case mirrors djot.js output verbatim.
+ */
+class EmptyListItemsTest extends TestCase
+{
+    protected DjotConverter $converter;
+
+    protected function setUp(): void
+    {
+        $this->converter = new DjotConverter();
+    }
+
+    // ==================== Lone bullet markers ====================
+
+    public function testLoneHyphenIsEmptyBulletItem(): void
+    {
+        $result = $this->converter->convert("-\n");
+
+        $this->assertSame("<ul>\n<li>\n</li>\n</ul>\n", $result);
+    }
+
+    public function testLoneAsteriskIsEmptyBulletItem(): void
+    {
+        $result = $this->converter->convert("*\n");
+
+        $this->assertSame("<ul>\n<li>\n</li>\n</ul>\n", $result);
+    }
+
+    public function testLonePlusIsEmptyBulletItem(): void
+    {
+        $result = $this->converter->convert("+\n");
+
+        $this->assertSame("<ul>\n<li>\n</li>\n</ul>\n", $result);
+    }
+
+    public function testTwoLoneMarkersAreTwoEmptyItems(): void
+    {
+        $result = $this->converter->convert("-\n-\n");
+
+        $this->assertSame("<ul>\n<li>\n</li>\n<li>\n</li>\n</ul>\n", $result);
+    }
+
+    // ==================== Empty item between filled items ====================
+
+    public function testEmptyBulletItemBetweenItems(): void
+    {
+        $result = $this->converter->convert("- a\n-\n- c\n");
+
+        $this->assertSame(
+            "<ul>\n<li>\na\n</li>\n<li>\n</li>\n<li>\nc\n</li>\n</ul>\n",
+            $result,
+        );
+    }
+
+    public function testMarkerWithTrailingSpaceIsEmptyItem(): void
+    {
+        $result = $this->converter->convert("- a\n- \n- c\n");
+
+        $this->assertSame(
+            "<ul>\n<li>\na\n</li>\n<li>\n</li>\n<li>\nc\n</li>\n</ul>\n",
+            $result,
+        );
+    }
+
+    // ==================== Ordered markers ====================
+
+    public function testLoneOrderedMarkerIsEmptyItem(): void
+    {
+        $result = $this->converter->convert("1.\n");
+
+        $this->assertSame("<ol>\n<li>\n</li>\n</ol>\n", $result);
+    }
+
+    public function testEmptyOrderedItemBetweenItems(): void
+    {
+        $result = $this->converter->convert("1. a\n2.\n3. c\n");
+
+        $this->assertSame(
+            "<ol>\n<li>\na\n</li>\n<li>\n</li>\n<li>\nc\n</li>\n</ol>\n",
+            $result,
+        );
+    }
+
+    public function testLoneParenthesizedOrderedMarkerIsEmptyItem(): void
+    {
+        $result = $this->converter->convert("(1)\n");
+
+        $this->assertSame("<ol>\n<li>\n</li>\n</ol>\n", $result);
+    }
+
+    public function testLoneAlphaMarkerIsEmptyItem(): void
+    {
+        $result = $this->converter->convert("a.\n");
+
+        $this->assertSame("<ol type=\"a\">\n<li>\n</li>\n</ol>\n", $result);
+    }
+
+    public function testLoneRomanMarkerIsEmptyItem(): void
+    {
+        $result = $this->converter->convert("i.\n");
+
+        $this->assertSame("<ol type=\"i\">\n<li>\n</li>\n</ol>\n", $result);
+    }
+
+    // ==================== Non-collisions (unchanged behavior) ====================
+
+    public function testThematicBreakIsNotAnEmptyItem(): void
+    {
+        $result = $this->converter->convert("---\n");
+
+        $this->assertStringNotContainsString('<ul>', $result);
+        $this->assertStringContainsString('<hr', $result);
+    }
+
+    public function testMarkerWithoutSpaceAndContentIsNotAList(): void
+    {
+        // No space between marker and content: stays a paragraph (matches djot.js).
+        $result = $this->converter->convert("-x\n");
+
+        $this->assertSame("<p>-x</p>\n", $result);
+    }
+
+    public function testLoneMarkerThenParagraph(): void
+    {
+        $result = $this->converter->convert("-\n\nfoo\n");
+
+        $this->assertSame("<ul>\n<li>\n</li>\n</ul>\n<p>foo</p>\n", $result);
+    }
+
+    public function testBareMarkerAdoptsIndentedContinuation(): void
+    {
+        // A marker with no same-line content but an indented next line owns that
+        // line as its content (matches djot.js): no stray blank line in the item.
+        $result = $this->converter->convert("-\n  x\n");
+
+        $this->assertSame("<ul>\n<li>\nx\n</li>\n</ul>\n", $result);
+    }
+
+    public function testEmptyItemDoesNotSwallowFollowingParagraph(): void
+    {
+        // An empty item has no open paragraph, so a non-indented following line
+        // starts a new paragraph outside the list (matches djot.js); it must not
+        // be pulled in as lazy continuation.
+        $result = $this->converter->convert("-\nfoo\n");
+
+        $this->assertSame("<ul>\n<li>\n</li>\n</ul>\n<p>foo</p>\n", $result);
+    }
+
+    public function testEmptyOrderedItemDoesNotSwallowFollowingParagraph(): void
+    {
+        $result = $this->converter->convert("1.\nfoo\n");
+
+        $this->assertSame("<ol>\n<li>\n</li>\n</ol>\n<p>foo</p>\n", $result);
+    }
+}


### PR DESCRIPTION
## Problem

In canonical djot a list marker may be followed by a space **or by the end of the line**, so a bare marker on its own line is a valid empty list item. The reference implementation (djot.js) confirms this: `-`, `*`, `+`, `1.`, `(1)`, `a.`, `i.` each render as a single empty `<li>`, and a bare marker between two filled items produces an empty item in the middle.

djot-php diverged: every marker regex required a space plus content, so a bare marker fell through to a paragraph (`<p>-</p>`) or was swallowed as lazy-continuation text inside the previous item. The official conformance suite did not pin these cases, so the divergence went unnoticed (250/250 stayed green).

Reference vs. previous djot-php:

| Input | djot.js (reference) | djot-php (before) |
|---|---|---|
| `-` (lone) | `<ul><li></li></ul>` | `<p>-</p>` |
| `i.` (lone) | `<ol type="i"><li></li></ol>` | `<p>i.</p>` |
| `- a` / `-` / `- c` | three items, middle empty | `-` swallowed as text |

## Change

- Marker regexes in `ListParser` accept a marker with **optional** trailing space + content (bullet, ordered numeric, parenthesized, roman, alpha), so a bare marker yields empty content.
- The letter-marker fast-path probe in `BlockParser` accepts a bare alpha/roman marker (previously required a space after the marker, shunting `a.`/`i.` straight to paragraph).
- An empty item renders `<li>\n</li>` rather than wrapping a stray blank line.
- An empty item no longer lazy-swallows a following base-indent line: it has no open paragraph, so `-\nfoo` becomes an empty item plus a separate `<p>foo</p>` (matches djot.js).
- A bare marker directly followed by indented content adopts that content (`-\n  x` becomes an item containing `x`).

## Scope

Definition lists (`:` marker) are intentionally **out of scope** here. They are parsed by a separate path (`tryParseDjotDefinitionList`); empty definition terms can follow as a separate change.

## Notes

New `EmptyListItemsTest` covers lone markers (all types), empty items between items, trailing-space markers, the empty-item-then-paragraph case, and the indented-continuation case. All outputs are asserted verbatim against djot.js. Full suite stays green and the official djot conformance suite remains 250/250.
