### PR TITLE
Preserve tabs in code output by default; add TabNormalizationExtension

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,24 @@
 # Upgrade Guide
 
+## Upgrading to 0.1.30
+
+### Behavior change: tabs in code are preserved by default
+
+Tabs in code blocks and inline code are now **preserved literally** instead of being converted to 4 spaces. This is spec-conformant (djot keeps tabs).
+
+If you relied on the previous 4-space conversion, restore it explicitly:
+
+```php
+// Per renderer
+$converter->getHtmlRenderer()->setCodeBlockTabWidth(4);
+
+// Or via the opt-in extension
+use Djot\Extension\TabNormalizationExtension;
+$converter->addExtension(new TabNormalizationExtension()); // 4 spaces (configurable)
+```
+
+Note: a literal tab in `<pre>` renders at the browser's default tab width (usually 8), so enabling one of the above is recommended if you want a fixed width.
+
 ## Upgrading to 0.1.23
 
 ### Breaking Change: `significantNewlines` No Longer Sets `SoftBreakMode::Break`

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,6 @@
 # Upgrade Guide
 
-## Upgrading to 0.1.30
+## Upgrading to 0.1.29
 
 ### Behavior change: tabs in code are preserved by default
 

--- a/docs/extensions/index.md
+++ b/docs/extensions/index.md
@@ -20,6 +20,7 @@ Extensions provide a clean way to bundle related customizations together. Each e
 | [MermaidExtension](#mermaidextension) | Transforms mermaid code blocks into diagrams |
 | [SemanticSpanExtension](#semanticspanextension) | Converts span attributes to semantic HTML elements (`<kbd>`, `<dfn>`, `<abbr>`) |
 | [SmartQuotesExtension](#smartquotesextension) | Configures locale-specific smart quote characters |
+| [TabNormalizationExtension](#tabnormalizationextension) | Converts tabs in code blocks and inline code to spaces (default 4) for consistent display |
 | [TableOfContentsExtension](#tableofcontentsextension) | Generates a table of contents from headings |
 | [TabsExtension](#tabsextension) | Transforms divs into accessible tabbed content interfaces |
 | [WikilinksExtension](#wikilinksextension) | Converts `[[Page Name]]` patterns to wiki-style links |
@@ -1268,6 +1269,24 @@ $converter->addExtension(new DefaultAttributesExtension([
     'block_quote' => ['class' => 'border-l-4 pl-4 italic'],
 ]));
 ```
+
+## TabNormalizationExtension
+
+Converts tabs in code blocks and inline code to a fixed number of spaces (default 4). djot preserves literal tabs by default (spec-conformant), but a literal tab in `<pre>` renders at the browser's default tab width (usually 8). Enable this extension for consistent display without relying on CSS `tab-size`.
+
+```php
+use Djot\Extension\TabNormalizationExtension;
+
+$converter = new DjotConverter();
+
+// Tabs in code -> 4 spaces
+$converter->addExtension(new TabNormalizationExtension());
+
+// Tabs in code -> 2 spaces
+$converter->addExtension(new TabNormalizationExtension(2));
+```
+
+Only HTML output is affected; with other renderers the extension is a no-op. A width below 1 throws `InvalidArgumentException`.
 
 ## TabsExtension
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -683,8 +683,8 @@ $html = $renderer->render($document);
 **Configuration:**
 
 ```php
-// Tabs in code blocks default to 4 spaces; use null to preserve tabs
-$renderer->setCodeBlockTabWidth(null);
+// Convert tabs in code to 4 spaces (default preserves them)
+$renderer->setCodeBlockTabWidth(4);
 
 // Customize soft break rendering
 $renderer->setSoftBreakMode(SoftBreakMode::Space);
@@ -695,15 +695,20 @@ $renderer->setSafeMode(SafeMode::defaults());
 
 #### Tab Width in Code Blocks
 
-By default, tabs in code blocks are converted to 4 spaces. This ensures consistent display across all contexts, since browsers default to 8-space tabs and CSS `tab-size` isn't supported everywhere (email clients, RSS readers, etc.).
+By default, tabs in code blocks and inline code are **preserved literally**, which is spec-conformant (djot keeps tabs). A literal tab in `<pre>` renders at the browser's default tab width (usually 8), so if you want a fixed width, convert tabs to spaces:
 
 ```php
-// Preserve tabs instead of converting
-$renderer->setCodeBlockTabWidth(null);
+// Convert tabs to 4 spaces
+$renderer->setCodeBlockTabWidth(4);
 
-// Use different width (e.g., 2 spaces)
+// Use a different width (e.g., 2 spaces)
 $renderer->setCodeBlockTabWidth(2);
+
+// Preserve tabs (default)
+$renderer->setCodeBlockTabWidth(null);
 ```
+
+The opt-in [`TabNormalizationExtension`](/extensions/#tabnormalizationextension) wraps this for the common case (`new TabNormalizationExtension()` converts tabs to 4 spaces).
 
 This affects both fenced code blocks (`<pre><code>`) and inline code (`<code>`).
 

--- a/src/Extension/TabNormalizationExtension.php
+++ b/src/Extension/TabNormalizationExtension.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Extension;
+
+use Djot\DjotConverter;
+use Djot\Renderer\HtmlRenderer;
+use InvalidArgumentException;
+
+/**
+ * Normalizes tabs in code output to a fixed number of spaces.
+ *
+ * djot preserves literal tabs (the spec-conformant default). A literal tab in
+ * `<pre>` renders at the browser's default tab width (usually 8), which authors
+ * rarely want. Enable this extension to convert tabs in code blocks and inline
+ * code to a fixed number of spaces (default 4) for consistent display, without
+ * relying on CSS `tab-size`.
+ *
+ * Only HTML output is affected; with other renderers the extension is a no-op.
+ *
+ * Example:
+ * ```php
+ * $converter = new DjotConverter();
+ * $converter->addExtension(new TabNormalizationExtension()); // tabs -> 4 spaces
+ * $converter->addExtension(new TabNormalizationExtension(2)); // tabs -> 2 spaces
+ * ```
+ */
+class TabNormalizationExtension implements ExtensionInterface
+{
+    /**
+     * @param int $width Spaces per tab in code output (must be >= 1)
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(protected int $width = 4)
+    {
+        if ($this->width < 1) {
+            throw new InvalidArgumentException('Tab width must be >= 1, got ' . $this->width);
+        }
+    }
+
+    public function register(DjotConverter $converter): void
+    {
+        $renderer = $converter->getRenderer();
+        if ($renderer instanceof HtmlRenderer) {
+            $renderer->setCodeBlockTabWidth($this->width);
+        }
+    }
+}

--- a/src/Renderer/HtmlRenderer.php
+++ b/src/Renderer/HtmlRenderer.php
@@ -67,9 +67,14 @@ class HtmlRenderer implements RendererInterface
     protected ?SafeMode $safeMode = null;
 
     /**
-     * Tab width for code blocks (null = preserve tabs, integer = convert to spaces)
+     * Tab width for code blocks and inline code (null = preserve tabs literally,
+     * integer = convert each tab to that many spaces).
+     *
+     * Defaults to null to stay spec-conformant: djot preserves literal tabs. Use
+     * TabNormalizationExtension or setCodeBlockTabWidth() to convert them for
+     * display (a literal tab in <pre> renders at the browser default tab width).
      */
-    protected ?int $codeBlockTabWidth = 4;
+    protected ?int $codeBlockTabWidth = null;
 
     /**
      * Round-trip mode adds data attributes to preserve Djot-specific information
@@ -213,11 +218,12 @@ class HtmlRenderer implements RendererInterface
     }
 
     /**
-     * Set tab width for code blocks
+     * Set tab width for code blocks and inline code.
      *
-     * When set, tabs in code blocks and inline code are converted to spaces.
-     * This ensures consistent display across all browsers and contexts
-     * (email clients, RSS readers, etc.) without relying on CSS tab-size.
+     * When set to an integer, tabs are converted to that many spaces, for
+     * consistent display across browsers and contexts (email clients, RSS
+     * readers, etc.) without relying on CSS tab-size. The default is null
+     * (preserve literal tabs), which is spec-conformant.
      *
      * @param int|null $width Number of spaces per tab (null to preserve tabs)
      */

--- a/tests/TestCase/Extension/TabNormalizationExtensionTest.php
+++ b/tests/TestCase/Extension/TabNormalizationExtensionTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Test\TestCase\Extension;
+
+use Djot\DjotConverter;
+use Djot\Extension\TabNormalizationExtension;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class TabNormalizationExtensionTest extends TestCase
+{
+    public function testTabsPreservedWithoutExtension(): void
+    {
+        $html = (new DjotConverter())->convert("```\n\tcode\n```");
+        $this->assertStringContainsString("<pre><code>\tcode\n", $html);
+    }
+
+    public function testConvertsCodeBlockTabsToFourSpacesByDefault(): void
+    {
+        $converter = new DjotConverter();
+        $converter->addExtension(new TabNormalizationExtension());
+
+        $html = $converter->convert("```\n\tcode\n```");
+        $this->assertStringContainsString("<pre><code>    code\n", $html);
+        $this->assertStringNotContainsString("\t", $html);
+    }
+
+    public function testConvertsInlineCodeTabs(): void
+    {
+        $converter = new DjotConverter();
+        $converter->addExtension(new TabNormalizationExtension());
+
+        $html = $converter->convert("`a\tb`");
+        $this->assertStringContainsString('<code>a    b</code>', $html);
+    }
+
+    public function testCustomWidth(): void
+    {
+        $converter = new DjotConverter();
+        $converter->addExtension(new TabNormalizationExtension(2));
+
+        $html = $converter->convert("```\n\tcode\n```");
+        $this->assertStringContainsString("<pre><code>  code\n", $html);
+    }
+
+    public function testRejectsWidthBelowOne(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new TabNormalizationExtension(0);
+    }
+}

--- a/tests/TestCase/Renderer/HtmlRendererTest.php
+++ b/tests/TestCase/Renderer/HtmlRendererTest.php
@@ -504,9 +504,9 @@ class HtmlRendererTest extends TestCase
 
         $result = $this->renderer->render($doc);
 
-        // Default: tabs are converted to 4 spaces
-        $this->assertStringNotContainsString("\t", $result);
-        $this->assertStringContainsString('    return;', $result);
+        // Default: tabs are preserved literally (spec-conformant)
+        $this->assertStringContainsString("\treturn;", $result);
+        $this->assertStringNotContainsString('    return;', $result);
     }
 
     public function testCodeBlockTabWidthConvertsToSpaces(): void
@@ -557,8 +557,8 @@ class HtmlRendererTest extends TestCase
 
     public function testGetCodeBlockTabWidth(): void
     {
-        // Default is 4 spaces
-        $this->assertSame(4, $this->renderer->getCodeBlockTabWidth());
+        // Default preserves tabs (null)
+        $this->assertNull($this->renderer->getCodeBlockTabWidth());
 
         $this->renderer->setCodeBlockTabWidth(2);
         $this->assertSame(2, $this->renderer->getCodeBlockTabWidth());

--- a/tests/TestCase/TabIndentationTest.php
+++ b/tests/TestCase/TabIndentationTest.php
@@ -24,15 +24,15 @@ class TabIndentationTest extends TestCase
     }
 
     /**
-     * Tabs inside code blocks are converted to 4 spaces by default.
+     * Tabs inside code blocks are preserved literally by default (spec-conformant).
      */
-    public function testTabsInCodeBlockConvertedToSpaces(): void
+    public function testTabsInCodeBlockPreservedByDefault(): void
     {
         $input = "```\n\tindented with tab\n\t\tdouble tab\n```";
         $result = $this->converter->convert($input);
 
-        $this->assertStringContainsString('    indented with tab', $result);
-        $this->assertStringContainsString('        double tab', $result);
+        $this->assertStringContainsString("\tindented with tab", $result);
+        $this->assertStringContainsString("\t\tdouble tab", $result);
     }
 
     /**
@@ -219,7 +219,7 @@ class TabIndentationTest extends TestCase
     }
 
     /**
-     * Tab in inline verbatim/code span - converted to spaces by default.
+     * Tab in inline verbatim/code span - preserved literally by default.
      */
     public function testTabInInlineCode(): void
     {
@@ -227,9 +227,8 @@ class TabIndentationTest extends TestCase
         $result = $this->converter->convert($input);
 
         $this->assertStringContainsString('<code>code', $result);
-        // Tabs are converted to 4 spaces in inline code by default
-        $this->assertStringContainsString('    ', $result);
-        $this->assertStringNotContainsString("\t", $result);
+        // Tabs are preserved literally in inline code by default (spec-conformant)
+        $this->assertStringContainsString("\t", $result);
     }
 
     /**


### PR DESCRIPTION
## What

Aligns djot-php with reference djot on tabs in code, and adds an opt-in extension to normalize them for display.

### Part 1 - preserve tabs by default (spec-conformant)
`HtmlRenderer` expanded tabs to 4 spaces in code blocks and inline code (`codeBlockTabWidth = 4`). Reference djot preserves the literal tab. Default flipped to `null` (preserve), so code output now matches upstream:

```
```
<TAB>code
```
```
→ `<pre><code>\tcode\n</code></pre>` (was `<pre><code>    code`).

`setCodeBlockTabWidth()` still works as the manual override.

### Part 2 - `TabNormalizationExtension` (opt-in)
A literal tab in `<pre>` renders at the browser default tab width (usually 8), which authors often don't want. The extension converts tabs in code to a fixed number of spaces (default 4):

```php
$converter->addExtension(new TabNormalizationExtension());  // tabs -> 4 spaces
$converter->addExtension(new TabNormalizationExtension(2)); // tabs -> 2 spaces
```

Only HTML output is affected (no-op for other renderers); width below 1 throws.

## Behavior change

Code output that previously had 4 spaces now has literal tabs by default. Restore the old behavior with `setCodeBlockTabWidth(4)` or the extension. Documented in `UPGRADE.md`.

## Docs

API reference (tab section), extensions list (new entry + section), and `UPGRADE.md` updated.

## Out of scope

Parser-side tab gaps found while testing (separate follow-up): `>` + tab not recognized as a blockquote, leading tab before a list marker not recognized, and `IndentationHelper::TAB_WIDTH = 2` vs djot.js's 4-column tab stops.
