### PR TITLE
Accept a tab after > as a block quote marker delimiter

### DIFF
--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -1661,9 +1661,9 @@ class BlockParser
             return null;
         }
 
-        // Match block quote: > followed by space or end of line (NOT >text or >>)
-        // The > must be followed by a space or be at end of line
-        if (!preg_match('/^> (.*)$/', $line, $matches) && !preg_match('/^>$/', $line)) {
+        // Match block quote: > followed by a space or tab, or end of line
+        // (NOT >text or >>). The space/tab is the marker delimiter.
+        if (!preg_match('/^>[ \t](.*)$/', $line, $matches) && !preg_match('/^>$/', $line)) {
             return null;
         }
 
@@ -1684,7 +1684,7 @@ class BlockParser
             'paragraphOpen' => false,
         ];
 
-        if (preg_match('/^> (.*)$/', $line, $matches)) {
+        if (preg_match('/^>[ \t](.*)$/', $line, $matches)) {
             $innerLines[] = $matches[1];
             $this->trackBlockQuoteLazyState($matches[1], $lazyState);
         } elseif (preg_match('/^>$/', $line)) {
@@ -1702,8 +1702,8 @@ class BlockParser
                 break;
             }
 
-            // Continue with "> " prefix (space required per spec)
-            if (preg_match('/^> (.*)$/', $currentLine, $matches)) {
+            // Continue with a "> " or ">\t" prefix (space or tab delimiter)
+            if (preg_match('/^>[ \t](.*)$/', $currentLine, $matches)) {
                 $innerLines[] = $matches[1];
                 $this->trackBlockQuoteLazyState($matches[1], $lazyState);
                 $i++;

--- a/tests/TestCase/TabIndentationTest.php
+++ b/tests/TestCase/TabIndentationTest.php
@@ -71,20 +71,16 @@ class TabIndentationTest extends TestCase
     }
 
     /**
-     * Block quote requires space after > (not tab) per djot spec.
-     *
-     * The space after > is a syntax delimiter, not indentation.
-     * Tab indentation rules apply to nested structures, not syntax delimiters.
+     * A tab after > is a valid block quote marker delimiter (matches the
+     * reference djot implementation), just like a space.
      */
-    public function testBlockQuoteWithTabNotBlockquote(): void
+    public function testBlockQuoteWithTabIsBlockquote(): void
     {
         $input = ">\tQuoted with tab";
         $result = $this->converter->convert($input);
 
-        // Per spec, > must be followed by space, not tab
-        // So this becomes a paragraph with > as text
-        $this->assertStringNotContainsString('<blockquote>', $result);
-        $this->assertStringContainsString('<p>', $result);
+        $this->assertStringContainsString('<blockquote>', $result);
+        $this->assertStringContainsString('Quoted with tab', $result);
     }
 
     /**
@@ -192,18 +188,16 @@ class TabIndentationTest extends TestCase
     }
 
     /**
-     * Block quote continuation requires space after > (not tab).
-     *
-     * Since >\t is not a blockquote marker, both lines become paragraphs.
+     * Block quote continuation lines also accept a tab after > as the delimiter.
      */
-    public function testBlockQuoteContinuationWithTabNotBlockquote(): void
+    public function testBlockQuoteContinuationWithTab(): void
     {
         $input = ">\tLine 1\n>\tLine 2";
         $result = $this->converter->convert($input);
 
-        // Per spec, > must be followed by space
-        $this->assertStringNotContainsString('<blockquote>', $result);
-        $this->assertStringContainsString('<p>', $result);
+        $this->assertStringContainsString('<blockquote>', $result);
+        $this->assertStringContainsString('Line 1', $result);
+        $this->assertStringContainsString('Line 2', $result);
     }
 
     /**


### PR DESCRIPTION
## What

Reference djot accepts a **tab** after `>` as the block quote marker delimiter, just like a space. djot-php required a literal space (`^> (.*)$`), so `>\tquoted` fell through to a paragraph (`<p>&gt;\tquoted</p>`).

Now a space **or** a tab delimits the marker (`^>[ \t](.*)$`), on the opening line and on continuation lines.

```
>\tquoted   ->  <blockquote><p>quoted</p></blockquote>   (was <p>&gt;\tquoted</p>)
```

`>text` (no delimiter) is still rejected.

## Verification

Full suite + official djot corpus green (2498 tests). The two `TabIndentationTest` cases that asserted the old behavior (they encoded the misconception that `>` requires a space) are flipped to assert the block quote is formed.

## Scope

This is the first of the parser-side tab gaps flagged in #230. The other two are intentionally **not** included (broader / riskier, separate follow-ups):

- **Indented top-level list marker** not recognized. `  - item` / `\t- item` render as a paragraph in djot-php; reference parses a list at any leading indent. This is not tab-specific (spaces fail too), so it is a general list-indentation conformance fix, not a tab fix.
- **`IndentationHelper::TAB_WIDTH = 2`** vs djot.js's 4-column tab-stop model. Changing it ripples through all indentation math; needs corpus validation on its own.
