### PR TITLE
Recognize an indented list marker at a block boundary

### DIFF
--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -1832,8 +1832,13 @@ class BlockParser
     {
         $line = $lines[$start];
 
-        // Try to match list item marker
-        $listInfo = $this->listParser->parseListItemMarker($line);
+        // Try to match the list item marker. The marker may carry leading
+        // indentation: at the top level (or any block boundary) djot treats a
+        // leading-indented marker as a list, since indentation is only
+        // significant for nesting. The leading indent becomes the list's base
+        // indentation below. Lazy-continuation lines never reach here (they are
+        // collected by the open paragraph or the enclosing list item first).
+        $listInfo = $this->listParser->parseListItemMarker(ltrim($line, " \t"));
         if ($listInfo === null) {
             return null;
         }

--- a/tests/TestCase/IndentedListTest.php
+++ b/tests/TestCase/IndentedListTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Test\TestCase;
+
+use Djot\DjotConverter;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A list marker carrying leading indentation at a block boundary starts a list.
+ *
+ * djot treats indentation as significant only for nesting, so at the top level
+ * (or after a blank line) a leading-indented marker is just a list. This matches
+ * the reference djot implementation.
+ */
+class IndentedListTest extends TestCase
+{
+    protected DjotConverter $converter;
+
+    protected function setUp(): void
+    {
+        $this->converter = new DjotConverter();
+    }
+
+    public function testSpaceIndentedMarkerStartsList(): void
+    {
+        foreach (['  - item', '    - item', ' - item'] as $input) {
+            $html = $this->converter->convert($input);
+            $this->assertStringContainsString("<ul>\n<li>\nitem\n</li>\n</ul>", $html, $input);
+        }
+    }
+
+    public function testTabIndentedMarkerStartsList(): void
+    {
+        $html = $this->converter->convert("\t- item");
+        $this->assertStringContainsString("<ul>\n<li>\nitem\n</li>\n</ul>", $html);
+    }
+
+    public function testOrderedIndentedMarkerStartsList(): void
+    {
+        $html = $this->converter->convert('  1. item');
+        $this->assertStringContainsString("<ol>\n<li>\nitem\n</li>\n</ol>", $html);
+    }
+
+    public function testIndentedSiblingsFormOneList(): void
+    {
+        $html = $this->converter->convert("  - a\n  - b");
+        $this->assertStringContainsString("<li>\na\n</li>\n<li>\nb\n</li>", $html);
+    }
+
+    public function testBlankThenIndentedMarkerStartsList(): void
+    {
+        $html = $this->converter->convert("text\n\n  - item");
+        $this->assertStringContainsString('<p>text</p>', $html);
+        $this->assertStringContainsString("<ul>\n<li>\nitem", $html);
+    }
+
+    /**
+     * An indented marker that lazily continues an open paragraph stays text
+     * (no blank line), unchanged by this fix.
+     */
+    public function testIndentedMarkerDoesNotInterruptParagraph(): void
+    {
+        $html = $this->converter->convert("text\n  - item");
+        $this->assertStringNotContainsString('<ul>', $html);
+        $this->assertStringContainsString('text', $html);
+    }
+
+    /**
+     * An indented marker collected as a list item's continuation stays lazy text
+     * in default mode (no blank line), unchanged by this fix.
+     */
+    public function testNestedMarkerWithoutBlankStaysLazyText(): void
+    {
+        $html = $this->converter->convert("- a\n  - b");
+        $this->assertStringNotContainsString("<ul>\n<li>\na\n<ul>", $html);
+    }
+}


### PR DESCRIPTION
## What

djot treats indentation as significant only for nesting (`doc/syntax.md`: "Indentation is only significant for list item or footnote nesting"). So a leading-indented list marker at the top level, or after a blank line, is simply a list. Reference djot parses these as lists:

| input | reference | djot-php (before) |
|---|---|---|
| `  - item` | `<ul><li>item` | `<p>- item</p>` |
| `\t- item` | `<ul><li>item` | `<p>- item</p>` |
| `  1. item` | `<ol><li>item` | `<p>1. item</p>` |

djot-php matched the marker against the raw line, so leading whitespace made `parseListItemMarker` fail and the line became a paragraph.

## Fix

Match the marker on the de-indented line in `tryParseList()`. The leading indent still becomes the list's base indentation (nested lists already run with a non-zero base, so the existing machinery handles it).

Lazy-continuation lines are unaffected, because they never reach `tryParseList()`:
- an indented marker continuing an open paragraph (`text` / `  - item`, no blank) is collected by the paragraph;
- an indented marker after a list item without a blank line (`- a` / `  - b`) is collected as that item's continuation.

Both verified to still render as text.

## Scope / known edge

This is the parser-side tab gap B from #230/#231. Covers the common case (uniform leading indent). One rare divergence remains: a first item indented with a *less*-indented sibling (`  - a` / `- b`) ends the list early in djot-php, where reference keeps one list. Vanishingly rare; left for the tab-stop work (gap C) if it matters.

## Verification

Full unit suite + official djot corpus pass (2498 tests).