### PR TITLE
Strip all leading whitespace from a list item's text continuation

### DIFF
--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -2107,8 +2107,11 @@ class BlockParser
                     if ($this->allowsImmediateNestedBlock($nextTrimmed, $lines, $i)) {
                         break;
                     }
-                    // Properly indented continuation - include with original indentation relative to content
-                    $itemLines[] = IndentationHelper::stripLeadingIndent($nextLine, $contentIndent);
+                    // Text continuation of the item (not a nested block, which
+                    // breaks out above): strip all leading whitespace. Indentation
+                    // beyond the content column is not significant for plain text,
+                    // matching the reference implementation.
+                    $itemLines[] = $nextTrimmed;
                 } else {
                     // Lazy continuation (not properly indented but not at base level either)
                     $itemLines[] = $nextTrimmed;

--- a/tests/TestCase/ListItemContinuationIndentTest.php
+++ b/tests/TestCase/ListItemContinuationIndentTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Test\TestCase;
+
+use Djot\DjotConverter;
+use Djot\Renderer\SoftBreakMode;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A list item's lazy text continuation strips all leading whitespace, matching
+ * the reference implementation. Indentation beyond the content column is not
+ * significant for plain text, so no residual spaces or tabs leak into the output.
+ *
+ * Properly nested blocks (separated by a blank line) keep their relative
+ * indentation, which is handled by a different code path.
+ */
+class ListItemContinuationIndentTest extends TestCase
+{
+    protected DjotConverter $converter;
+
+    protected function setUp(): void
+    {
+        $this->converter = new DjotConverter();
+        $this->converter->getHtmlRenderer()->setSoftBreakMode(SoftBreakMode::Newline);
+    }
+
+    public function testOverIndentedSpacesAreStripped(): void
+    {
+        $html = $this->converter->convert("- a\n      deep");
+        $this->assertStringContainsString("a\ndeep", $html);
+        $this->assertStringNotContainsString('    deep', $html);
+    }
+
+    public function testOverIndentedTabsAreStripped(): void
+    {
+        $html = $this->converter->convert("- a\n\t\tdeep");
+        $this->assertStringContainsString("a\ndeep", $html);
+        $this->assertStringNotContainsString("\tdeep", $html);
+    }
+
+    public function testContentIndentContinuationStillWorks(): void
+    {
+        $html = $this->converter->convert("- a\n  more");
+        $this->assertStringContainsString("a\nmore", $html);
+    }
+
+    public function testNestedCodeBlockKeepsIndentation(): void
+    {
+        // Properly nested (blank line) code block keeps its internal indentation.
+        $html = $this->converter->convert("- item\n\n  ```\n  def f():\n      return 1\n  ```");
+        $this->assertStringContainsString("def f():\n    return 1", $html);
+    }
+}


### PR DESCRIPTION
## What

A lazy **text continuation** line inside a list item kept its indentation beyond the content column, leaking residual whitespace into the output. The reference implementation strips all of it (indentation is not significant for plain text).

| `- a` + continuation | reference | djot-php (before) |
|---|---|---|
| `␠␠␠␠␠␠deep` (6 sp) | `deep` | `    deep` (4 residual) |
| `⇥⇥deep` (2 tab) | `deep` | `⇥deep` (1 residual) |

This is general (spaces and tabs); it surfaced while checking tab handling but is not tab-specific. Top-level paragraphs and blockquotes already stripped correctly.

## Fix

In the list item content collector, strip the full leading whitespace for the text-continuation case (the line already passed the `allowsImmediateNestedBlock` check, so it is text, not a nested block).

Real nested blocks separated by a blank line go through a different path and keep their relative indentation, verified for an indented fenced code block inside an item:

```
- item

  ```
  def f():
      return 1     <- 4-space code indent preserved
  ```
```

## Verification

Full unit suite + official djot corpus pass (2498 tests).

## Context

Closes out the parser-side tab conformance follow-ups from #230/#231/#232. (The originally-proposed "tab width / tab-stop model" change turned out unnecessary: no width-specific divergence exists; this continuation-stripping difference was the real, width-independent gap.)