### PR TITLE
perf: keep large table parsing linear (O(n^2) to O(n))

### DIFF
--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -2871,7 +2871,11 @@ class BlockParser
             }
 
             // Process rowspan markers - find cells above that should span down
-            // We need to track column positions considering rowspan markers in previous rows
+            // We need to track column positions considering rowspan markers in previous rows.
+            // getChildren() hands back a copy-on-write alias of the table's internal child
+            // array. Holding it alive across the appendChild() below would force PHP to copy
+            // the entire array on every row (turning a plain table into O(rows^2)), so it is
+            // released with unset() right before the append - see the note there.
             $tableChildren = $table->getChildren();
             $currentRowIndex = count($tableChildren); // Index where current row will be added
 
@@ -2922,6 +2926,9 @@ class BlockParser
                 $this->removeOverlappingCells($table, $row, $rowCellData, $currentRowIndex);
             }
 
+            // Release the copy-on-write alias taken above so appendChild() mutates the
+            // child array in place instead of duplicating it; keeps table parsing linear.
+            unset($tableChildren);
             $table->appendChild($row);
         }
 

--- a/tests/TestCase/LargeTableTest.php
+++ b/tests/TestCase/LargeTableTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Test\TestCase;
+
+use Djot\DjotConverter;
+use Djot\Node\Block\Table;
+use Djot\Node\Block\TableRow;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Guards table parsing against the O(rows^2) regression where holding a
+ * copy-on-write alias of the table's child array across appendChild() forced
+ * PHP to copy the whole array on every row. The fix releases the alias before
+ * the append so building a table stays linear. These tests assert correctness
+ * at scale (no rows or cells dropped); the linearity itself is what keeps them
+ * fast.
+ */
+class LargeTableTest extends TestCase
+{
+    private DjotConverter $converter;
+
+    protected function setUp(): void
+    {
+        $this->converter = new DjotConverter();
+    }
+
+    public function testLargeTableKeepsEveryRowAndCell(): void
+    {
+        $rows = 5000;
+        $source = "| A | B | C |\n|---|---|---|\n";
+        for ($r = 0; $r < $rows; $r++) {
+            $source .= "| r{$r}c0 | r{$r}c1 | r{$r}c2 |\n";
+        }
+
+        $document = $this->converter->parse($source);
+
+        $table = $document->getChildren()[0] ?? null;
+        $this->assertInstanceOf(Table::class, $table);
+
+        $tableRows = $table->getChildren();
+        // Header row + every body row.
+        $this->assertCount($rows + 1, $tableRows);
+
+        foreach ($tableRows as $tableRow) {
+            $this->assertInstanceOf(TableRow::class, $tableRow);
+            $this->assertCount(3, $tableRow->getChildren());
+        }
+    }
+
+    public function testLargeTableRendersAllCells(): void
+    {
+        $rows = 2000;
+        $source = "| A | B |\n|---|---|\n";
+        for ($r = 0; $r < $rows; $r++) {
+            $source .= "| left{$r} | right{$r} |\n";
+        }
+
+        $html = $this->converter->convert($source);
+
+        $this->assertStringContainsString('left0', $html);
+        $this->assertStringContainsString('right' . ($rows - 1), $html);
+        // 1 header + N body rows, each opening a <tr>.
+        $this->assertSame($rows + 1, substr_count($html, '<tr'));
+    }
+}


### PR DESCRIPTION
## What

Building a table held a copy-on-write alias of the table's child array across the per-row `appendChild()`, forcing PHP to copy the whole child array on every appended row. That made parsing a plain table O(rows^2). Releasing the alias before the append restores linear-time parsing.

This is a port of one of the table optimizations from carve-php (markup-carve/carve-php#79); the other optimization from that PR (the prose fast path that skips the block-probe chain for plain paragraph lines) already landed here in #226, so this PR covers only the table fix.

## The bug

In `tryParseTable()`:

```php
$tableChildren = $table->getChildren(); // CoW alias of the internal child array
$currentRowIndex = count($tableChildren);
// ... rowspan lookups read $tableChildren ...
$table->appendChild($row); // alias still alive -> PHP copies the whole array
```

`getChildren()` returns the internal `$children` array by value. While the returned copy is held in `$tableChildren`, the array has a refcount greater than one, so the next `appendChild()` (`$this->children[] = $child`) triggers a full copy-on-write separation. Per row that is an O(rows) copy, so the table as a whole becomes O(rows^2).

## The fix

`unset($tableChildren)` immediately before the append, so the child array has a single reference and `appendChild()` mutates it in place. The alias is only needed for the rowspan-marker lookup above the append, so releasing it there is safe. Output is byte-identical (verified by md5 on plain, rowspan/colspan, and header+attribute tables); only the allocation pattern changes.

## Numbers

Parse-only, best-of-8, 3-column table:

| rows | before | after | speedup |
|---|---|---|---|
| 2000 | 72.0 ms | 48.9 ms | 1.5x |
| 4000 | 151.6 ms | 96.2 ms | 1.6x |
| 8000 | 493.0 ms | 199.0 ms | 2.5x |
| 16000 | 1397.4 ms | 418.2 ms | 3.3x |
| 32000 | 4297.1 ms | 968.4 ms | 4.4x |

Before scales super-linearly (16x the rows, 60x the time); after is linear (16x the rows, ~20x the time).

An isolated micro-benchmark of the copy term alone (32000 appends) confirms the mechanism: held alias 549 ms vs released alias 4.4 ms.

## Tests

`LargeTableTest` builds 5000- and 2000-row tables and asserts no rows or cells are dropped at scale.
