### PR TITLE
fix: drop comments in profile to-text path instead of leaking content

### DIFF
--- a/src/Filter/ProfileFilter.php
+++ b/src/Filter/ProfileFilter.php
@@ -9,6 +9,7 @@ use Djot\LinkPolicy;
 use Djot\Node\Block\BlockNode;
 use Djot\Node\Block\BlockQuote;
 use Djot\Node\Block\CodeBlock;
+use Djot\Node\Block\Comment;
 use Djot\Node\Block\DefinitionDescription;
 use Djot\Node\Block\DefinitionList;
 use Djot\Node\Block\DefinitionTerm;
@@ -194,6 +195,15 @@ class ProfileFilter
 
     protected function convertToText(Node $node, Node $parent): void
     {
+        // A comment is never visible content. Converting it to text would leak
+        // its body into the output (and, being a block node, wrap it in a stray
+        // paragraph), so always drop it instead.
+        if ($node instanceof Comment) {
+            $parent->removeChild($node);
+
+            return;
+        }
+
         $textContent = $this->extractTextContent($node);
 
         if ($textContent === '') {

--- a/tests/TestCase/ProfileTest.php
+++ b/tests/TestCase/ProfileTest.php
@@ -97,6 +97,26 @@ class ProfileTest extends TestCase
         $this->assertStringContainsString('Paragraph text', $html);
     }
 
+    public function testCommentProfileDropsBraceCommentWithoutLeakingContent(): void
+    {
+        $converter = new DjotConverter(profile: Profile::comment());
+        $html = $converter->convert("hello\n\n{% secret note %}\n\nworld");
+
+        $this->assertStringNotContainsString('secret', $html);
+        $this->assertStringContainsString('<p>hello</p>', $html);
+        $this->assertStringContainsString('<p>world</p>', $html);
+    }
+
+    public function testCommentProfileDropsFencedCommentWithoutLeakingContent(): void
+    {
+        $converter = new DjotConverter(profile: Profile::comment());
+        $html = $converter->convert("a\n\n%%%\nsecret\n%%%\n\nb");
+
+        $this->assertStringNotContainsString('secret', $html);
+        $this->assertStringContainsString('<p>a</p>', $html);
+        $this->assertStringContainsString('<p>b</p>', $html);
+    }
+
     public function testParseEnforcesProfileMaxLength(): void
     {
         $converter = new DjotConverter(profile: (new Profile())->setMaxLength(5));


### PR DESCRIPTION
## What

When a profile disallows the `comment` type (for example `Profile::comment()`, whose allowlist omits it) with the to-text action, comments were routed through `convertToText`. That read the comment body and, because a comment is a block node, wrapped it in a paragraph, leaking the comment text into the rendered output.

Repro (before), `Profile::comment()` on `hello\n\n{% secret note %}\n\nworld`:

```html
<p>hello</p>
<p>secret note</p>
<p>world</p>
```

## Fix

A comment is never visible content, so `convertToText` drops it outright instead of converting it. Covers both fenced (`%%%`) and brace (`{% %}`) block comments. `ACTION_STRIP` already removed the node; `ACTION_ERROR` is unaffected.

Backport of markup-carve/carve-php#58 (shared parser lineage), adapted to djot's comment node forms.

## Tests

Added two cases under the comment profile (fenced and brace comments) asserting the body does not appear and surrounding paragraphs render.
