### PR TITLE
fix: no endnotes section for unreferenced footnotes

### DIFF
--- a/src/Renderer/HtmlRenderer.php
+++ b/src/Renderer/HtmlRenderer.php
@@ -307,10 +307,10 @@ class HtmlRenderer implements RendererInterface
 
                 $html = $this->renderDocumentWithSections($document);
 
-                if (
-                    $this->sharedRenderContext->collectedFootnotes !== []
-                    || $this->sharedRenderContext->footnoteNumbers !== []
-                ) {
+                // Only emit the endnotes section when at least one footnote was
+                // actually referenced. A footnote defined but never referenced
+                // produces no section; an empty <ol> would otherwise leak.
+                if ($this->sharedRenderContext->footnoteNumbers !== []) {
                     $html .= $this->renderFootnotesSection();
                 }
 

--- a/tests/TestCase/DjotConverterTest.php
+++ b/tests/TestCase/DjotConverterTest.php
@@ -475,6 +475,16 @@ DJOT;
         $this->assertStringContainsString('role="doc-endnotes"', $result);
     }
 
+    public function testUnreferencedFootnoteDefinitionEmitsNoEndnotes(): void
+    {
+        // A footnote defined but never referenced produces no endnotes section;
+        // an empty <ol> would otherwise leak.
+        $result = $this->converter->convert("text\n\n[^f]: note");
+
+        $this->assertStringNotContainsString('role="doc-endnotes"', $result);
+        $this->assertSame('<p>text</p>', trim($result));
+    }
+
     public function testFootnotesUseXhtmlHrInXhtmlMode(): void
     {
         $converter = new DjotConverter(true);


### PR DESCRIPTION
## What

The endnotes section was emitted whenever any footnote definition was collected (`collectedFootnotes`), regardless of whether it was referenced. A footnote defined but never referenced produced a stray, empty section:

Before, `text\n\n[^f]: note`:

```html
<p>text</p>
<section role="doc-endnotes">
<hr>
<ol>
</ol>
</section>
```

## Fix

Gate the section on referenced footnotes only (`footnoteNumbers`, populated when a reference is rendered). An unreferenced definition now produces no output. Referenced footnotes are unchanged.

Backport of the footnote part of markup-carve/carve-php#31 (shared parser lineage).

## Tests

Added a case asserting an unreferenced footnote definition emits no `doc-endnotes` section. Full suite and official corpus green.
