### PR TITLE
fix: invalid inline-span attribute block stays literal

### DIFF
--- a/src/Parser/InlineParser.php
+++ b/src/Parser/InlineParser.php
@@ -912,19 +912,30 @@ class InlineParser
             }
         }
 
-        // Check for attribute span: [text]{.class} or [text]{.foo}{.bar}
+        // Inline span [text]{attrs}. A bracketed run forms a <span> only when
+        // the directly-abutting block is a valid attribute block: one that
+        // yields an attribute, or an empty/whitespace/comment-only block (kept
+        // so a default-attribute extension can target [x]{} / [x]{ }). A block
+        // carrying unrecognized content ({???}, {=y=}) is not an attribute
+        // block, so the brackets and block render literally - the bracket text
+        // is still inline-parsed, e.g. [*x*]{???} -> [<strong>x</strong>]{???}.
         if ($afterBracket < $length && $text[$afterBracket] === '{') {
             $attrEnd = $this->findAttributeEnd($text, $afterBracket);
             if ($attrEnd !== null) {
-                $span = new Span();
-                // Apply all consecutive attribute blocks
-                $endPos = $this->applyConsecutiveAttributes($span, $text, $afterBracket);
-                $this->parseInlines($span, $linkText);
+                $attrStr = substr($text, $afterBracket + 1, $attrEnd - $afterBracket - 1);
+                if ($this->isValidAttrPayload($attrStr)) {
+                    $span = new Span();
+                    // Apply the gating block, then absorb any further
+                    // consecutive attribute blocks.
+                    $this->applyAttributesToNode($span, $attrStr);
+                    $endPos = $this->applyConsecutiveAttributes($span, $text, $attrEnd + 1);
+                    $this->parseInlines($span, $linkText);
 
-                return [
-                    'node' => $span,
-                    'pos' => $endPos,
-                ];
+                    return [
+                        'node' => $span,
+                        'pos' => $endPos,
+                    ];
+                }
             }
         }
 
@@ -1888,6 +1899,25 @@ class InlineParser
      *
      * @return int The final position after all attribute blocks
      */
+
+    /**
+     * Whether a `{...}` payload is a valid attribute block.
+     *
+     * Valid means it yields at least one attribute under the attribute grammar,
+     * or it is empty/whitespace/comment-only - a valid empty block kept as a
+     * bare <span> so a default-attribute extension can target it. A block
+     * carrying unrecognized content (`{???}`, `{=y=}`) is not an attribute
+     * block, so the surrounding bracketed run stays literal text.
+     */
+    protected function isValidAttrPayload(string $attrStr): bool
+    {
+        if (AttributeParser::parse($attrStr) !== []) {
+            return true;
+        }
+
+        return trim($this->removeAttributeComments($attrStr)) === '';
+    }
+
     protected function applyConsecutiveAttributes(Node $node, string $text, int $startPos): int
     {
         $length = strlen($text);
@@ -1900,6 +1930,13 @@ class InlineParser
             }
 
             $attrStr = substr($text, $pos + 1, $attrEnd - $pos - 1);
+            // Stop at the first block that is not a valid attribute block; it
+            // (and anything after it) stays literal instead of being silently
+            // consumed, e.g. the {???} in [x]{.a}{???}.
+            if (!$this->isValidAttrPayload($attrStr)) {
+                break;
+            }
+
             $this->applyAttributesToNode($node, $attrStr);
             $pos = $attrEnd + 1;
         }

--- a/tests/TestCase/DjotConverterTest.php
+++ b/tests/TestCase/DjotConverterTest.php
@@ -303,6 +303,26 @@ class DjotConverterTest extends TestCase
         $this->assertSame($expected, $this->converter->convert($djot));
     }
 
+    public function testInvalidAttrBlockKeepsBracketsLiteral(): void
+    {
+        // A bracketed run abutting an invalid attribute block ({???}) is not a
+        // span: the brackets and block render literally, but the bracket text
+        // is still inline-parsed.
+        $this->assertSame("<p>[x]{???}</p>\n", $this->converter->convert('[x]{???}'));
+        $this->assertSame(
+            "<p>[<strong>x</strong>]{???}</p>\n",
+            $this->converter->convert('[*x*]{???}'),
+        );
+    }
+
+    public function testEmptyAttrBlockStillFormsSpan(): void
+    {
+        // An empty or whitespace-only block is a valid empty attribute block,
+        // kept as a bare <span> so a default-attribute extension can target it.
+        $this->assertSame("<p><span>x</span></p>\n", $this->converter->convert('[x]{}'));
+        $this->assertSame("<p><span>x</span></p>\n", $this->converter->convert('[x]{ }'));
+    }
+
     public function testTable(): void
     {
         $djot = "| A | B |\n|---|---|\n| 1 | 2 |";


### PR DESCRIPTION
## What

A bracketed run directly abutting an attribute block always materialized a `<span>` and then silently dropped any block that was not valid attribute syntax. The payload vanished:

| input | before | after |
|---|---|---|
| `[x]{???}` | `<span>x</span>` | `[x]{???}` |
| `[*x*]{???}` | `<span><strong>x</strong></span>` | `[<strong>x</strong>]{???}` |
| `[x]{.a}{???}` | `<span class="a">x</span>` | `<span class="a">x</span>{???}` |

## Fix

A new `isValidAttrPayload()` gates both span formation and `applyConsecutiveAttributes()`: a `{...}` block forms or extends attributes only when it yields an attribute, or is empty/whitespace/comment-only. A block carrying unrecognized content is not an attribute block, so the brackets and the block render literally (the bracket text is still inline-parsed). The change applies to spans, links, and code spans through the shared helper.

Empty and whitespace-only blocks (`[x]{}`, `[x]{ }`) still form a bare `<span>`, kept so `DefaultAttributesExtension` can target it. Note djot keeps `{=...=}` highlight, so `[x]{=y=}` now correctly renders `[x]<mark>y</mark>` (the highlight was previously swallowed as a span attribute).

Backport of markup-carve/carve-php#43, adapted to djot (which retains `{=...=}` highlight and the empty-block span).

## Known limitation

An exotic `[x]{.a}{???}{.b}` leaves the trailing `{.b}` to attach to the now-literal `{???}` via djot's standalone-attribute feature (`text{.b}` -> `<span class="b">text</span>`), yielding `<span class="a">x</span><span class="b">{???}</span>` rather than fully-literal `{???}{.b}`. Suppressing that would mean conditionally disabling a separate, legitimate djot feature; out of scope for this fix.

## Tests

Added cases for the invalid-block-literal behavior and the preserved empty-block span. Full suite and official corpus green.
