### PR TITLE
Fix: strip surplus indent on over-indented list-item paragraph continuation

### DIFF
--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -2269,7 +2269,13 @@ class BlockParser
                     $this->parseBlocks($listItem, $itemLines, 0);
                 } else {
                     $paragraph = new Paragraph();
-                    $this->inlineParser->parse($paragraph, implode("\n", $itemLines), $start);
+                    // Plain-paragraph item: continuation lines strip ALL leading
+                    // whitespace (djot soft-break rule), matching tryParseParagraph().
+                    // itemLines keep indent relative to the item for the block-parse
+                    // branch above; here that surplus indent would leak into the
+                    // inline text (e.g. an over-indented continuation rendering as
+                    // "  c" instead of "c").
+                    $this->inlineParser->parse($paragraph, implode("\n", array_map('ltrim', $itemLines)), $start);
                     $listItem->appendChild($paragraph);
                 }
             } elseif ($itemLines !== ['']) {

--- a/tests/TestCase/NestedListEdgeCasesTest.php
+++ b/tests/TestCase/NestedListEdgeCasesTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Djot\Test\TestCase;
 
 use Djot\DjotConverter;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -731,5 +732,44 @@ DJOT;
         $headingPos = strpos($result, '<h2>');
         $this->assertNotFalse($headingPos);
         $this->assertGreaterThan($lastUlPos, $headingPos);
+    }
+
+    // ============ Over-indented paragraph continuation in a list item ============
+
+    /**
+     * A tight list-item paragraph continuation line indented MORE than the item
+     * content indent must strip all leading whitespace (djot soft-break rule),
+     * not just the item indent. Matches canonical djot.js, which renders every
+     * variant below identically.
+     *
+     * @return array<string, array{0: string}>
+     */
+    public static function overIndentedContinuationProvider(): array
+    {
+        return [
+            'flush continuation' => ["- a\n  - b\nc\n"],
+            'one-space continuation' => ["- a\n  - b\n c\n"],
+            'content-indent continuation' => ["- a\n  - b\n  c\n"],
+            'over-indented continuation' => ["- a\n  - b\n    c\n"],
+        ];
+    }
+
+    #[DataProvider('overIndentedContinuationProvider')]
+    public function testOverIndentedParagraphContinuationStripsSurplusIndent(string $djot): void
+    {
+        $result = $this->converter->convert($djot);
+
+        // The "- b" line and "c" line are plain paragraph continuation text of
+        // item "a"; surplus indentation must not leak into the inline output.
+        $this->assertStringContainsString("a\n- b\nc", $result);
+        $this->assertStringNotContainsString('  c', $result);
+    }
+
+    public function testListItemOverIndentedContinuationWithoutNestedMarker(): void
+    {
+        $result = $this->converter->convert("- a\n    c\n");
+
+        $this->assertStringContainsString("a\nc", $result);
+        $this->assertStringNotContainsString('  c', $result);
     }
 }


### PR DESCRIPTION
## Problem

A tight list-item paragraph continuation line indented **more** than the item's
content indent kept the surplus whitespace in the rendered inline text.

Input:

```
- a
  - b
    c
```

Before this fix djot-php rendered the continuation as `  c` (two leading
spaces preserved):

```html
<ul>
<li>
a
- b
  c
</li>
</ul>
```

Canonical djot.js (the `djot/djot` npm package) renders every indentation
variant of this case identically, with the continuation stripped to `c`. The
four variants (`c` flush, one-space, content-indent, over-indented) should all
produce the same output.

## Root cause

In `BlockParser`, list-item continuation lines are collected with their indent
kept relative to the item content indent (`stripLeadingIndent($nextLine, $contentIndent)`).
That relative indentation is needed for the branch that parses an item's lines
as nested blocks (code fences, blockquotes, etc.).

The tight single-paragraph branch, however, joined those lines and handed them
straight to the inline parser. The inline parser emits a soft break for each
newline without trimming leading whitespace, so any surplus indent leaked into
the text. The dedicated paragraph collector (`tryParseParagraph`) already trims
leading whitespace on continuation lines per the djot soft-break rule; the list
path did not.

## Fix

In the single-paragraph branch only, strip all leading whitespace on the
collected continuation lines before inline parsing, matching `tryParseParagraph`
and canonical djot.js. The block-parse branch is untouched, so indentation
remains significant where it matters.

## Result

All four indentation variants now match canonical djot.js output, and the
official conformance suite stays green.
