### PR TITLE
Use stream_isatty for CLI stdin detection

### DIFF
--- a/bin/djot
+++ b/bin/djot
@@ -292,7 +292,7 @@ function runConvert(array $argv): int
         }
     } else {
         // Read from stdin.
-        if (posix_isatty(STDIN)) {
+        if (stream_isatty(STDIN)) {
             fwrite(STDERR, "Reading from stdin... (Ctrl+D to end, Ctrl+C to cancel)\n");
         }
         $input = stream_get_contents(STDIN);
@@ -354,7 +354,7 @@ $command = $args[1] ?? null;
 
 // No arguments: convert piped stdin (legacy `cat file | djot`), else show help.
 if ($command === null) {
-    if (!posix_isatty(STDIN)) {
+    if (!stream_isatty(STDIN)) {
         exit(runConvert([]));
     }
     showHelp();

--- a/tests/TestCase/CliTest.php
+++ b/tests/TestCase/CliTest.php
@@ -20,13 +20,14 @@ class CliTest extends TestCase
      *
      * @param array<int, string> $args
      * @param string $stdin
+     * @param array<int, string> $phpFlags Extra flags passed to the PHP binary itself.
      *
      * @return array{stdout: string, stderr: string, exit: int}
      */
-    protected function runCli(array $args, string $stdin = ''): array
+    protected function runCli(array $args, string $stdin = '', array $phpFlags = []): array
     {
         $bin = dirname(__DIR__, 2) . '/bin/djot';
-        $command = array_merge([PHP_BINARY, $bin], $args);
+        $command = array_merge([PHP_BINARY], $phpFlags, [$bin], $args);
 
         $descriptors = [
             0 => ['pipe', 'r'],
@@ -153,6 +154,28 @@ class CliTest extends TestCase
     {
         $result = $this->runCli([], '*hi*');
         $this->assertSame(0, $result['exit']);
+        $this->assertStringContainsString('<strong>hi</strong>', $result['stdout']);
+    }
+
+    public function testConvertWorksWithoutPosixExtension(): void
+    {
+        // ext-posix is not a hard dependency; stdin detection must not fatal on
+        // PHP builds without posix_isatty(). Simulate by disabling the function.
+        $noPosix = ['-d', 'disable_functions=posix_isatty'];
+
+        $result = $this->runCli(['convert', '-'], '*hi*', $noPosix);
+        $this->assertSame(0, $result['exit']);
+        $this->assertStringNotContainsString('posix_isatty', $result['stderr']);
+        $this->assertStringContainsString('<strong>hi</strong>', $result['stdout']);
+    }
+
+    public function testLegacyStdinWorksWithoutPosixExtension(): void
+    {
+        $noPosix = ['-d', 'disable_functions=posix_isatty'];
+
+        $result = $this->runCli([], '*hi*', $noPosix);
+        $this->assertSame(0, $result['exit']);
+        $this->assertStringNotContainsString('posix_isatty', $result['stderr']);
         $this->assertStringContainsString('<strong>hi</strong>', $result['stdout']);
     }
 


### PR DESCRIPTION
## Problem

`bin/djot` uses `posix_isatty(STDIN)` to detect whether stdin is a terminal (for the interactive hint and the legacy bare-stdin convert path). `ext-posix` is not a hard dependency of the package, so on PHP builds without it - Windows, or minimal/container PHP installs - the CLI fatals:

```
Fatal error: Call to undefined function posix_isatty()
```

instead of converting the input.

## Fix

Replace both `posix_isatty(STDIN)` calls with the built-in `stream_isatty(STDIN)`, which is part of PHP core since 7.2 and requires no extension. Behavior is identical where posix was available, and now works everywhere.

Added two CLI tests that run `bin/djot` with `posix_isatty` disabled (`-d disable_functions=posix_isatty`), covering both the `convert -` subcommand and the legacy bare-stdin form.

## Context

Surfaced while updating the [djot-intellij](https://github.com/php-collective/djot-intellij) plugin to call this CLI: the plugin needs a fallback specifically because of this crash. With this fix the CLI is safe to invoke on any supported PHP build.

## Note

`phpstan` reports one pre-existing error in `Parser/BlockParser.php:589` (`offsetAccess.invalidOffset`) on master, unrelated to this change - left untouched.
