### PR TITLE
docs: document line blocks as a beyond-spec enhancement

### DIFF
--- a/docs/guide/syntax.md
+++ b/docs/guide/syntax.md
@@ -1240,9 +1240,10 @@ dolor sit amet
 This produces two separate paragraphs. For comments that should not interrupt
 paragraph flow (keeping text in the same paragraph), use inline comments (`{% ... %}`).
 
-### Line Blocks
+### Line Blocks (Extension)
 
 Preserve line breaks using `|` at the start of each line. Useful for poetry or addresses.
+This is a djot-php addition beyond the core spec; see [Enhancements](/reference/enhancements#line-blocks).
 
 **Input:**
 ```djot

--- a/docs/reference/enhancements.md
+++ b/docs/reference/enhancements.md
@@ -17,6 +17,7 @@ They are either on the way to get incorporated upstream - or may be incorporated
   - [Block Interrupts Paragraphs Mode](#block-interrupts-paragraphs-mode)
   - [Nested Lists Without Blank Line Mode](#nested-lists-without-blank-line-mode)
 - [Language Features Beyond Spec](#language-features-beyond-spec)
+  - [Line Blocks](#line-blocks)
   - [Task List Underscore Notation](#task-list-underscore-notation)
   - [List Item Attributes](#list-item-attributes)
   - [Table Row and Cell Attributes](#table-row-and-cell-attributes)
@@ -392,6 +393,48 @@ container.
 attributes valid only on `<ol>`. djot-php silently drops them from
 `<li>` / `<dd>` output to keep the HTML valid; use a preceding
 block-attribute line on the list itself to set them on `<ol>`.
+
+---
+
+### Line Blocks
+
+**Related:** [Pandoc line blocks](https://pandoc.org/MANUAL.html#line-blocks)
+
+**Status:** djot-php extension
+
+Lines prefixed with `| ` (pipe + space) form a *line block*: a single paragraph
+whose original line breaks are preserved as hard breaks. Useful for poetry,
+addresses, and other content where line layout is significant. This mirrors
+Pandoc's line-block syntax and is **not** part of the djot core spec.
+
+```djot
+| Roses are red,
+| Violets are blue,
+| Sugar is sweet,
+| And so are you.
+```
+
+**Output:**
+```html
+<div class="line-block">
+<p>Roses are red,<br>
+Violets are blue,<br>
+Sugar is sweet,<br>
+And so are you.</p>
+</div>
+```
+
+**Rules:**
+- Each line starts with `| ` (pipe followed by a space); the marker is stripped.
+- A bare `|` on its own line produces an empty line within the block.
+- At least **two** consecutive `|` lines are required: a single `| ...` line
+  stays a normal paragraph, and a `| a | b |` row is parsed as a table, not a
+  line block.
+- Inline markup is parsed per line; the line breaks render as `<br>` hard breaks.
+- A preceding `{...}` attribute block attaches to the wrapping `<div class="line-block">`.
+
+Round-trips through the Markdown, plain-text, and ANSI renderers (the
+`div.line-block` class is detected on the way back in HtmlToDjot).
 
 ---
 
@@ -1003,6 +1046,7 @@ vendor/bin/phpunit
 
 | Feature                           | Upstream PR/Issue                                                   | Status     |
 |-----------------------------------|---------------------------------------------------------------------|------------|
+| Line blocks (`\|` poetry/address) | [Pandoc line blocks](https://pandoc.org/MANUAL.html#line-blocks)    | djot-php   |
 | Task list underscore notation     | [djot:305](https://github.com/jgm/djot/issues/305)                  | Open       |
 | List item attributes              | [djot:262](https://github.com/jgm/djot/pull/262)                    | Open PR    |
 | Table row/cell attributes         | [djot:250](https://github.com/jgm/djot/issues/250)                  | Open       |


### PR DESCRIPTION
## Problem

Line blocks (`|`-prefixed lines, Pandoc-style, for poetry/addresses) are a djot-php feature that is **not** part of the djot core spec, yet they were:

- missing entirely from `docs/reference/enhancements.md` (the canonical beyond-spec tracker), and
- shown in `docs/guide/syntax.md` without the beyond-spec marker that peer features (List Item Attributes, Fenced Comments, etc.) carry.

This made line blocks look like core djot when they aren't.

## Audit

I cross-checked every built-in node against the djot core syntax spec. Among the built-in block/inline nodes, **line blocks are the only beyond-spec construct that was undocumented as such** - everything else is either core djot or already listed in the Enhancements reference (Captions/Figure, Abbreviations, definition-list extras, table rowspan/colspan, etc.).

## Changes (docs only)

- **`docs/reference/enhancements.md`**: add a `Line Blocks` section (TOC entry, body with syntax/output/rules, and a row in the Language Features upstream-tracking table). Rules and round-trip behavior verified against `BlockParser::tryParseLineBlock` and the Markdown/plain-text/ANSI renderers plus `HtmlToDjot`.
- **`docs/guide/syntax.md`**: mark the heading as an Extension and link to the new enhancements entry.

No code or behavior changes.

## Note for reviewer

The image/table/block-quote **caption** sections in `syntax.md` are also beyond-spec but likewise lack the Extension marker. Left untouched here to keep this PR focused - happy to follow up if you want that consistency too.
