### PR TITLE
Normalize NUL bytes to U+FFFD at parse entry

### DIFF
--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -496,6 +496,14 @@ class BlockParser
         $this->headingReferenceLabels = [];
         $this->lineOffset = 0;
         $document = new Document();
+
+        // Replace any NUL (U+0000) with the U+FFFD replacement character so a
+        // control byte never reaches output (decided cross-impl behavior;
+        // WHATWG-style). A raw NUL must never reach rendered output.
+        if (str_contains($input, "\0")) {
+            $input = str_replace("\0", "\u{FFFD}", $input);
+        }
+
         $lines = $this->splitLines($input);
 
         // First pass: extract reference definitions, footnotes, abbreviations, and heading references
@@ -561,7 +569,7 @@ class BlockParser
             //   `"Title"` makes the line not a reference definition (matches djot.js)
             if (preg_match('/^\[([^\]]+)\]:(?:[ \t]+(\S*))?[ \t]*$/', $line, $matches)) {
                 // Normalize label: collapse whitespace, trim
-                $label = preg_replace('/\s+/', ' ', trim($matches[1]));
+                $label = preg_replace('/\s+/', ' ', trim($matches[1])) ?? '';
                 $url = trim($matches[2] ?? '');
 
                 // Collect continuation lines (URL can start on continuation line)

--- a/src/SafeMode.php
+++ b/src/SafeMode.php
@@ -228,8 +228,11 @@ class SafeMode
             $scheme = substr($url, 0, $colonPos);
 
             // Normalize scheme: strip ASCII whitespace and control characters (0x00-0x20)
-            // This prevents bypass attempts like "java\tscript:", "java\x0bscript:", etc.
-            $scheme = preg_replace('/[\x00-\x20]+/', '', $scheme) ?? $scheme;
+            // plus the U+FFFD replacement character (a NUL becomes U+FFFD at the
+            // parse entry, so a `java\x00script:` evasion arrives as
+            // `java\u{FFFD}script:`). This prevents bypass attempts like
+            // "java\tscript:", "java\x0bscript:", "java\x00script:", etc.
+            $scheme = preg_replace('/[\x00-\x20]+|\x{FFFD}+/u', '', $scheme) ?? $scheme;
             $scheme = strtolower($scheme);
 
             // Check against dangerous schemes

--- a/tests/TestCase/Parser/BlockParserTest.php
+++ b/tests/TestCase/Parser/BlockParserTest.php
@@ -703,4 +703,31 @@ DJOT;
         $this->assertCount(1, $children);
         $this->assertSame('<b>bold</b>', $children[0]->getContent());
     }
+
+    public function testNulByteIsReplacedWithReplacementCharacter(): void
+    {
+        // A raw NUL (U+0000) must never reach rendered output: it is normalized
+        // to the U+FFFD replacement character at the parse entry (WHATWG-style,
+        // decided cross-impl behavior).
+        $converter = new DjotConverter();
+        $html = $converter->convert("a\0b");
+
+        $this->assertStringNotContainsString("\0", $html, 'A raw NUL byte must not reach output');
+        $this->assertStringContainsString("\u{FFFD}", $html, 'NUL must be normalized to U+FFFD');
+        $this->assertStringContainsString("a\u{FFFD}b", $html);
+    }
+
+    public function testNulByteInLinkSchemeDoesNotProduceExecutableHref(): void
+    {
+        // A `java\x00script:` evasion arrives as `java\u{FFFD}script:` after NUL
+        // normalization. SafeMode also strips U+FFFD from a scheme, so the
+        // evasion is still detected and blocked (empty href), and no raw NUL or
+        // executable javascript: scheme may reach output.
+        $converter = new DjotConverter(safeMode: true);
+        $html = $converter->convert("[x](java\0script:alert(1))");
+
+        $this->assertStringNotContainsString("\0", $html, 'A raw NUL byte must not reach output');
+        $this->assertStringNotContainsString('javascript:', $html, 'No executable javascript: scheme');
+        $this->assertStringContainsString('href=""', $html, 'NUL-evasion javascript: scheme is blocked');
+    }
 }


### PR DESCRIPTION
A raw NUL (U+0000) must never reach rendered output. This replaces it with the U+FFFD replacement character at the parse entry (WHATWG-style normalization, for cross-impl conformance), so a control byte cannot survive into the produced HTML.

### What changed

- `BlockParser`: at the parse entry, any NUL in the input is replaced with U+FFFD before line splitting.
- `SafeMode`: the URL-scheme normalization now also strips the U+FFFD replacement character. A NUL-in-scheme evasion such as `java\x00script:` arrives as `java\u{FFFD}script:` after normalization; stripping U+FFFD keeps that evasion detected and blocked (empty href), preserving the existing SafeMode guarantee.

The dangerous-scheme detection regex itself was kept intact; the change only extends the set of stripped characters so the upstream NUL normalization does not open a new bypass.

Ported from carve-php commit ff40264.
