### PR TITLE
Add BlockQuoteDivExtension (`::: >` fenced blockquote)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@
 /docs/.vitepress/cache/
 /docs/.vitepress/dist/
 /docs/.vitepress/grammars/
+
+# Superpowers working docs (never tracked)
+docs/superpowers/
+_*.md

--- a/docs/extensions/index.md
+++ b/docs/extensions/index.md
@@ -697,6 +697,15 @@ item two
 </blockquote>
 ```
 
+The verbose `>`-prefix form below produces the **identical** output, but needs the marker on every line:
+
+```djot
+> - item one
+> - item two
+```
+
+The two are interchangeable; the fenced form simply drops the per-line `>`, which is what makes longer or more deeply nested quoted content practical to edit. The gap grows with the content - a quote wrapping a fenced code block or a table needs a `>` on every one of those lines too.
+
 A `^ attribution` line right after the closing `:::` wraps the quote in a figure, exactly as the `>`-prefix form does:
 
 ```djot

--- a/docs/extensions/index.md
+++ b/docs/extensions/index.md
@@ -675,10 +675,12 @@ use Djot\Extension\BlockQuoteDivExtension;
 $converter->addExtension(new BlockQuoteDivExtension());
 ```
 
-A list inside a quote, with no per-line marker:
+A quote with a lead paragraph and a list, with no per-line marker:
 
 ```djot
 ::: >
+Notes from the meeting:
+
 - item one
 - item two
 :::
@@ -686,6 +688,7 @@ A list inside a quote, with no per-line marker:
 
 ```html
 <blockquote>
+<p>Notes from the meeting:</p>
 <ul>
 <li>
 item one
@@ -697,9 +700,11 @@ item two
 </blockquote>
 ```
 
-The verbose `>`-prefix form below produces the **identical** output, but needs the marker on every line:
+The verbose `>`-prefix form below produces the **identical** output, but needs the marker on every line - the prose line, the blank separator, and each list item:
 
 ```djot
+> Notes from the meeting:
+>
 > - item one
 > - item two
 ```

--- a/docs/extensions/index.md
+++ b/docs/extensions/index.md
@@ -17,6 +17,7 @@ Extensions provide a clean way to bundle related customizations together. Each e
 | [HeadingPermalinksExtension](#headingpermalinksextension) | Adds clickable anchor links to headings |
 | [InlineFootnotesExtension](#inlinefootnotesextension) | Converts `[content]{.fn}` spans to inline footnotes |
 | [LineBlockDivExtension](#lineblockdivextension) | Adds a fenced `::: |` line block (verse/addresses) without prefixing every line |
+| [BlockQuoteDivExtension](#blockquotedivextension) | Adds a fenced `::: >` blockquote so a quote can own lists/fences/tables without a per-line `>` |
 | [MentionsExtension](#mentionsextension) | Converts `@username` patterns to profile links |
 | [MermaidExtension](#mermaidextension) | Transforms mermaid code blocks into diagrams |
 | [SemanticSpanExtension](#semanticspanextension) | Converts span attributes to semantic HTML elements (`<kbd>`, `<dfn>`, `<abbr>`) |
@@ -663,6 +664,62 @@ The pipe is consumed as the marker, so the output is a `line-block` div, never a
 ### Why This Syntax?
 
 This follows the approach discussed in [djot issue #29](https://github.com/jgm/djot/issues/29). A leading `|` on every line (Pandoc-style line blocks) can be confused with pipe tables and is awkward to edit; an English keyword div class (`::: verse`) was undesirable. A language-neutral `|` marker on the div opener sidesteps both concerns.
+
+## BlockQuoteDivExtension
+
+Adds a fenced blockquote written as a `:::` div whose only token is a greater-than sign: `::: >`. It produces the same semantic `<blockquote>` as the [`>`-prefixed form](/guide/syntax#block-quotes), but without prefixing every line - which matters when the quote contains **block** content, because the `>`-prefix form needs the marker on every line of a list, nested fence, or table (lazy continuation only folds plain paragraph text into a quote, never new block structure).
+
+```php
+use Djot\Extension\BlockQuoteDivExtension;
+
+$converter->addExtension(new BlockQuoteDivExtension());
+```
+
+A list inside a quote, with no per-line marker:
+
+```djot
+::: >
+- item one
+- item two
+:::
+```
+
+```html
+<blockquote>
+<ul>
+<li>
+item one
+</li>
+<li>
+item two
+</li>
+</ul>
+</blockquote>
+```
+
+A `^ attribution` line right after the closing `:::` wraps the quote in a figure, exactly as the `>`-prefix form does:
+
+```djot
+::: >
+Stay hungry, stay foolish.
+:::
+^ Steve Jobs
+```
+
+```html
+<figure>
+<blockquote>
+<p>Stay hungry, stay foolish.</p>
+</blockquote>
+<figcaption>Steve Jobs</figcaption>
+</figure>
+```
+
+The gt is consumed as the marker, so the output is a `<blockquote>`, never a literal `class=">"`. Because `>` is not a meaningful class, intercepting it cannot collide with real usage - which is why this needs no core parser change, the same design as the `::: |` line block. Attributes on the preceding line (`{#id .class}`) attach to the blockquote, and longer colon runs nest (`:::: >` outside, `::: >` inside).
+
+### Why This Syntax?
+
+The `>`-prefix blockquote is fine for prose, but every list item or nested block inside it needs its own `>`. The fenced form mirrors the language-neutral `::: |` line block: a single sigil on the opener, no English keyword, no per-line marker. `::: quote` is deliberately different - it stays an `<aside class="admonition quote">`, not a semantic `<blockquote>`.
 
 ## MentionsExtension
 

--- a/docs/guide/syntax.md
+++ b/docs/guide/syntax.md
@@ -256,6 +256,8 @@ Use `^` after a block quote to add an attribution/caption. The block quote will 
 </template>
 </OutputTabs>
 
+Prefer not to prefix every line? The [`BlockQuoteDivExtension`](/extensions/#blockquotedivextension) adds a fenced form, `::: >`, that produces the same `<blockquote>` without the per-line `>` - useful when the quote contains lists, fences, or tables.
+
 ### Lists
 
 #### Bullet Lists

--- a/docs/reference/enhancements.md
+++ b/docs/reference/enhancements.md
@@ -438,6 +438,52 @@ Round-trips through the Markdown, plain-text, and ANSI renderers (the
 
 ---
 
+### Fenced Block Quote (`::: >`)
+
+**Related:** [`BlockQuoteDivExtension`](/extensions/#blockquotedivextension)
+
+**Status:** djot-php extension (opt-in)
+
+A `:::` div whose only token is `>` produces a semantic `<blockquote>` - the same
+node as the `>`-prefixed form, but without a marker on every line. This matters
+for **block** content inside a quote: the `>`-prefix form needs the marker on
+every line of a list, nested fence, or table, because lazy continuation only
+folds plain paragraph text into a quote, never new block structure.
+
+```djot
+::: >
+- item one
+- item two
+:::
+```
+
+**Output:**
+```html
+<blockquote>
+<ul>
+<li>
+item one
+</li>
+<li>
+item two
+</li>
+</ul>
+</blockquote>
+```
+
+**Rules:**
+- The opener is `:::` (3+ colons) followed by only `>` (optional surrounding spaces); the gt is the marker, so the output is `<blockquote>`, never `class=">"`.
+- The body is parsed as ordinary block content, so any block (lists, fences, tables, nested quotes) is allowed without a per-line `>`.
+- A `^ attribution` line right after the closing `:::` wraps the quote in a `<figure>`/`<figcaption>`, the same as the `>`-prefix caption form.
+- A preceding `{...}` attribute block attaches to the `<blockquote>`.
+- Longer colon runs nest (`:::: >` outside, `::: >` inside), per djot div semantics.
+
+Mirrors the language-neutral design of the `::: |` line block. Distinct from
+`::: quote`, which stays an `<aside class="admonition quote">` rather than a
+semantic blockquote.
+
+---
+
 ### Task List Underscore Notation
 
 **Related:** [jgm/djot#305](https://github.com/jgm/djot/issues/305)
@@ -1047,6 +1093,7 @@ vendor/bin/phpunit
 | Feature                           | Upstream PR/Issue                                                   | Status     |
 |-----------------------------------|---------------------------------------------------------------------|------------|
 | Line blocks (`\|` poetry/address) | [Pandoc line blocks](https://pandoc.org/MANUAL.html#line-blocks)    | djot-php   |
+| Fenced block quote (`::: >`)      | [`BlockQuoteDivExtension`](/extensions/#blockquotedivextension)      | djot-php   |
 | Task list underscore notation     | [djot:305](https://github.com/jgm/djot/issues/305)                  | Open       |
 | List item attributes              | [djot:262](https://github.com/jgm/djot/pull/262)                    | Open PR    |
 | Table row/cell attributes         | [djot:250](https://github.com/jgm/djot/issues/250)                  | Open       |

--- a/src/Extension/BlockQuoteDivExtension.php
+++ b/src/Extension/BlockQuoteDivExtension.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Extension;
+
+use Djot\DjotConverter;
+use Djot\Node\Block\BlockQuote;
+use Djot\Node\Node;
+use Djot\Parser\Block\FencedBlockParser;
+use Djot\Parser\BlockParser;
+
+/**
+ * Adds a fenced blockquote div: `::: >`.
+ *
+ * A `:::` div whose only token is a greater-than sign is treated as a
+ * blockquote - the same `<blockquote>` the `>`-prefixed form produces, but
+ * without prefixing every line. This lets a quote own block content (lists,
+ * nested fences, tables) where the per-line `>` form would need the marker on
+ * every line: lazy continuation only folds plain paragraph text into a quote,
+ * never new block structure.
+ *
+ * Syntax:
+ * ```
+ * ::: >
+ * - item one
+ * - item two
+ * :::
+ * ```
+ *
+ * The gt is consumed as the marker, so the output is a `<blockquote>`, not a
+ * literal `class=">"`. This is why no core change is needed: `>` is not a
+ * meaningful class, so intercepting it cannot collide with real usage - the
+ * same reasoning behind {@see LineBlockDivExtension}'s `|`.
+ *
+ * A `^ attribution` line after the closing `:::` wraps the quote in a
+ * `<figure>`/`<figcaption>` via the core caption handler - no extra code here.
+ *
+ * Example usage:
+ * ```php
+ * $converter = new DjotConverter();
+ * $converter->addExtension(new BlockQuoteDivExtension());
+ * $html = $converter->convert($djot);
+ * ```
+ */
+class BlockQuoteDivExtension implements ExtensionInterface
+{
+    /**
+     * Opener: 3+ colons, then only a gt (optional surrounding spaces/tabs).
+     *
+     * @var string
+     */
+    protected const OPENER = '/^(:{3,})[ \t]*>[ \t]*$/';
+
+    public function register(DjotConverter $converter): void
+    {
+        $converter->getParser()->addBlockPattern(self::OPENER, $this->parseBlockQuoteDiv(...));
+    }
+
+    /**
+     * @param array<string> $lines
+     * @param int $start
+     * @param \Djot\Node\Node $parent
+     * @param \Djot\Parser\BlockParser $blockParser
+     */
+    protected function parseBlockQuoteDiv(array $lines, int $start, Node $parent, BlockParser $blockParser): ?int
+    {
+        if (preg_match(self::OPENER, $lines[$start], $matches) !== 1) {
+            return null; // @codeCoverageIgnore - pattern already matched
+        }
+
+        $fenceLength = strlen($matches[1]);
+        $innerLines = $this->collectInnerLines($lines, $start, $fenceLength, $consumed);
+        if ($innerLines === null) {
+            // Unclosed fence: leave it for the core parser to report.
+            return null;
+        }
+
+        $blockQuote = new BlockQuote();
+
+        // Consume the preceding `{...}` block before parsing the body, otherwise
+        // the still-pending attributes are claimed by the first inner block
+        // instead of the blockquote (and never reach the caption's figure).
+        $attributes = $blockParser->consumePendingAttributes();
+        if ($attributes !== []) {
+            $blockQuote->setAttributes($attributes);
+        }
+
+        $blockParser->parseBlockContent($blockQuote, $innerLines);
+
+        $parent->appendChild($blockQuote);
+
+        return $consumed;
+    }
+
+    /**
+     * Collect the lines between the opener and its matching closing fence.
+     *
+     * Uses the core {@see FencedBlockParser} detectors so code-fence and
+     * div-closer recognition stay identical to the built-in div parser: a `:::`
+     * inside a fenced code block is not treated as the closer. A nested div uses
+     * a longer fence (djot semantics), so the closer is the first bare `:::` run
+     * of at least the opener length. Returns null when no closer is found, so the
+     * caller can decline the match.
+     *
+     * @param array<string> $lines
+     * @param int $start
+     * @param int $fenceLength
+     * @param int|null $consumed Set to the number of lines consumed (opener..closer).
+     *
+     * @return array<string>|null
+     */
+    protected function collectInnerLines(array $lines, int $start, int $fenceLength, ?int &$consumed): ?array
+    {
+        $fences = new FencedBlockParser();
+        $inner = [];
+        $inCode = false;
+        $codeChar = '';
+        $codeLength = 0;
+        $count = count($lines);
+        $i = $start + 1;
+
+        while ($i < $count) {
+            $line = $lines[$i];
+
+            if (!$inCode) {
+                $opener = $fences->parseCodeFenceOpener($line);
+                if ($opener !== null) {
+                    $inCode = true;
+                    $codeChar = $opener['char'];
+                    $codeLength = $opener['length'];
+                    $inner[] = $line;
+                    $i++;
+
+                    continue;
+                }
+            }
+            if ($inCode) {
+                if ($fences->isCodeFenceCloser($line, $codeChar, $codeLength)) {
+                    $inCode = false;
+                }
+                $inner[] = $line;
+                $i++;
+
+                continue;
+            }
+
+            if ($fences->isDivFenceCloser($line, $fenceLength)) {
+                $consumed = $i + 1 - $start;
+
+                return $inner;
+            }
+
+            $inner[] = $line;
+            $i++;
+        }
+
+        return null;
+    }
+}

--- a/tests/TestCase/Extension/BlockQuoteDivExtensionTest.php
+++ b/tests/TestCase/Extension/BlockQuoteDivExtensionTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Test\TestCase\Extension;
+
+use Djot\DjotConverter;
+use Djot\Extension\BlockQuoteDivExtension;
+use PHPUnit\Framework\TestCase;
+
+class BlockQuoteDivExtensionTest extends TestCase
+{
+    private function converter(): DjotConverter
+    {
+        $converter = new DjotConverter();
+        $converter->addExtension(new BlockQuoteDivExtension());
+
+        return $converter;
+    }
+
+    public function testGtMarkerBecomesBlockquote(): void
+    {
+        $djot = "::: >\nA quote.\n:::";
+
+        $html = $this->converter()->convert($djot);
+
+        $this->assertStringContainsString('<blockquote>', $html);
+        $this->assertStringContainsString('<p>A quote.</p>', $html);
+        $this->assertStringNotContainsString('class=">"', $html);
+        $this->assertStringNotContainsString('<div', $html);
+    }
+
+    public function testOwnsBlockContentWithoutPerLineMarker(): void
+    {
+        $djot = "::: >\n- item one\n- item two\n:::";
+
+        $html = $this->converter()->convert($djot);
+
+        $this->assertStringContainsString('<blockquote>', $html);
+        $this->assertStringContainsString('<ul>', $html);
+        $this->assertMatchesRegularExpression('/<li>\s*item one\s*<\/li>/', $html);
+        $this->assertMatchesRegularExpression('/<li>\s*item two\s*<\/li>/', $html);
+    }
+
+    public function testEquivalentToPrefixedBlockquote(): void
+    {
+        $fenced = $this->converter()->convert("::: >\n- a\n- b\n:::");
+        $prefixed = $this->converter()->convert("> - a\n> - b");
+
+        $this->assertSame($prefixed, $fenced);
+    }
+
+    public function testCaptionAfterCloseWrapsInFigure(): void
+    {
+        $djot = "::: >\nStay hungry, stay foolish.\n:::\n^ Steve Jobs";
+
+        $html = $this->converter()->convert($djot);
+
+        $this->assertStringContainsString('<figure>', $html);
+        $this->assertStringContainsString('<blockquote>', $html);
+        $this->assertStringContainsString('Steve Jobs', $html);
+        $this->assertStringContainsString('<figcaption>', $html);
+    }
+
+    public function testAttributesOnPrecedingLineLandOnBlockquote(): void
+    {
+        $djot = "{#epigraph .pull}\n::: >\nText.\n:::";
+
+        $html = $this->converter()->convert($djot);
+
+        // Attributes must land on the blockquote itself, not on the inner block.
+        $this->assertMatchesRegularExpression('/<blockquote[^>]*id="epigraph"/', $html);
+        $this->assertMatchesRegularExpression('/<blockquote[^>]*class="pull"/', $html);
+        $this->assertDoesNotMatchRegularExpression('/<p[^>]*id="epigraph"/', $html);
+    }
+
+    public function testAttributesTransferToFigureWithCaption(): void
+    {
+        $djot = "{#epigraph .pull}\n::: >\nText.\n:::\n^ Author";
+
+        $html = $this->converter()->convert($djot);
+
+        // Caption wrapping moves the blockquote's attributes onto the figure.
+        $this->assertMatchesRegularExpression('/<figure[^>]*id="epigraph"/', $html);
+        $this->assertMatchesRegularExpression('/<figure[^>]*class="pull"/', $html);
+        $this->assertStringContainsString('<figcaption>', $html);
+    }
+
+    public function testNestingWithLongerFence(): void
+    {
+        $djot = ":::: >\nOuter.\n\n::: >\nInner.\n:::\n::::";
+
+        $html = $this->converter()->convert($djot);
+
+        $this->assertSame(2, substr_count($html, '<blockquote>'));
+        $this->assertStringContainsString('Outer.', $html);
+        $this->assertStringContainsString('Inner.', $html);
+    }
+
+    public function testUnclosedFenceDoesNotProduceBlockquote(): void
+    {
+        $djot = "::: >\nNo closer here.";
+
+        $html = $this->converter()->convert($djot);
+
+        $this->assertStringNotContainsString('<blockquote>', $html);
+    }
+
+    public function testWithoutExtensionGtDivHasNoBlockquote(): void
+    {
+        // Sanity: the slot is only claimed when the extension is registered.
+        $plain = (new DjotConverter())->convert("::: >\nText.\n:::");
+
+        $this->assertStringNotContainsString('<blockquote>', $plain);
+    }
+}

--- a/tests/TestCase/Extension/BlockQuoteDivExtensionTest.php
+++ b/tests/TestCase/Extension/BlockQuoteDivExtensionTest.php
@@ -97,6 +97,20 @@ class BlockQuoteDivExtensionTest extends TestCase
         $this->assertStringContainsString('Inner.', $html);
     }
 
+    public function testInnerCodeFenceIsNotMistakenForTheCloser(): void
+    {
+        // The ::: inside the code block must not close the quote; only the
+        // bare ::: after the code fence does.
+        $djot = "::: >\n```\n:::\n```\nAfter.\n:::";
+
+        $html = $this->converter()->convert($djot);
+
+        $this->assertStringContainsString('<blockquote>', $html);
+        // The code block keeps the literal ::: as its content.
+        $this->assertMatchesRegularExpression('/<code[^>]*>[\s\S]*:::[\s\S]*<\/code>/', $html);
+        $this->assertStringContainsString('After.', $html);
+    }
+
     public function testUnclosedFenceDoesNotProduceBlockquote(): void
     {
         $djot = "::: >\nNo closer here.";


### PR DESCRIPTION
## What

Adds an opt-in `BlockQuoteDivExtension`: a `:::` div whose only token is `>` produces a semantic `<blockquote>`, the fenced analog of the existing `::: |` line block.

```djot
::: >
Notes from the meeting:

- item one
- item two
:::
```
```html
<blockquote>
<p>Notes from the meeting:</p>
<ul>
<li>
item one
</li>
<li>
item two
</li>
</ul>
</blockquote>
```

The verbose `>`-prefix form produces the **identical** output, but needs the marker on every line - the prose line, the blank separator, and each list item:

```djot
> Notes from the meeting:
>
> - item one
> - item two
```

The two are interchangeable; the fenced form just drops the per-line `>`. The gap grows with the content - a quote wrapping a fenced code block or a table needs a `>` on every one of those lines too.

## Why

The `>`-prefix block quote is comfortable for prose, where lazy continuation lets you drop the marker on wrapped lines. It is not comfortable when the quote contains **block** structure (a list, a nested fence, a table), because lazy continuation folds only plain paragraph text into a quote, never new block structure. Every list item and nested block then needs its own `>`, which is tedious to write and error-prone to edit.

The fenced form removes the per-line marker while keeping identical semantics. It mirrors the language-neutral design of the `::: |` line block: a single sigil on the opener, no English keyword, no per-line prefix. Distinct from `::: quote`, which stays an `<aside class="admonition quote">` rather than a semantic blockquote.

## Behavior

- **Output** is identical to the `>`-prefix form: `<blockquote>`.
- **Caption:** a `^ attribution` line right after the closing `:::` wraps the quote in `<figure>`/`<figcaption>`, reusing the core caption handler.
- **Attributes:** a preceding `{...}` block attaches to the `<blockquote>` (consumed before the body is parsed, so an inner block cannot claim it; with a caption the attributes transfer onto the `<figure>`).
- **Nesting:** longer colon runs nest, per djot div semantics.

## Design note

No core parser change. Because `>` is not a meaningful class, a block-pattern hook intercepts the `::: >` opener, collects the inner lines with the standard div-closer detection, and parses them as block content into a `BlockQuote` node, exactly the property that let `::: |` ship as an extension.

## Docs

- `docs/extensions/index.md` - availability table row + a `BlockQuoteDivExtension` section.
- `docs/guide/syntax.md` - pointer from the block-quote section.
- `docs/reference/enhancements.md` - enhancement entry + feature-table row beside the line block.