### PR TITLE
Fix block content leaking out of marker-line nested-list items

### DIFF
--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -2052,6 +2052,18 @@ class BlockParser
             /** @var string $itemContent */
             $itemContent = $itemInfo['content'];
 
+            // A sublist opened on this item's marker line (`- - A`): the content
+            // itself begins with a list marker. Such an inner list must behave like
+            // any other nested container - its item stays open and absorbs blocks
+            // indented to the inner content column, and a following same-indent
+            // marker continues it. We achieve that by collecting the whole nested
+            // region into the item's lines below and parsing it as blocks, so the
+            // recursive list parser builds a persistent inner list (matching the
+            // reference djot.js). Definition lists keep their dedicated handling.
+            $markerLineSublist = $itemContent !== ''
+                && ($subMarker = $this->listParser->parseListItemMarker($itemContent)) !== null
+                && $subMarker['type'] !== ListBlock::TYPE_DEFINITION;
+
             // Collect item content lines (without blank line = tight continuation)
             /** @var array<string> $itemLines */
             $itemLines = [$itemContent];
@@ -2141,6 +2153,73 @@ class BlockParser
                 $i++;
             }
 
+            // Marker-line sublist (`- - A`): pull the whole nested region into
+            // this item's lines so the recursive parse builds a persistent inner
+            // list. A line that belongs to the inner list is either indented past
+            // the inner marker column (`> $contentIndent` - inner item content or
+            // a deeper sublist), or a list marker sitting exactly at the inner
+            // marker column (`== $contentIndent` - a following/sibling item). A
+            // non-marker line at the inner marker column, or anything less
+            // indented, is outer-item (or higher-level) content and ends the
+            // region, left for the outer loop to attach correctly. Without this
+            // the outer "indented continuation" path would steal the inner item's
+            // blocks and attach them beside the inner list, on the outer item.
+            $markerLineSublistParsed = false;
+            if ($markerLineSublist) {
+                $j = $i;
+                $gathered = [];
+                $consumedThrough = $i;
+                while ($j < $count) {
+                    $subLine = $lines[$j];
+                    if (IndentationHelper::isBlankLine($subLine)) {
+                        $gathered[] = '';
+                        $j++;
+
+                        continue;
+                    }
+                    $lineIndent = IndentationHelper::getLeadingSpaces($subLine);
+                    if ($lineIndent < $contentIndent) {
+                        break;
+                    }
+                    if (
+                        $lineIndent === $contentIndent
+                        && $this->listParser->parseListItemMarker(ltrim($subLine)) === null
+                    ) {
+                        // A non-marker line sitting exactly at the inner marker
+                        // column is the inner item's content only when it lazily
+                        // continues an open paragraph (the previously gathered line
+                        // is non-blank). After a blank line, or with nothing open
+                        // before it, it is outer-item content and ends the region.
+                        $previousIsOpenParagraph = $gathered !== []
+                            && $gathered[array_key_last($gathered)] !== '';
+                        if (!$previousIsOpenParagraph) {
+                            break;
+                        }
+                    }
+                    $gathered[] = IndentationHelper::stripLeadingIndent($subLine, $contentIndent);
+                    $j++;
+                    $consumedThrough = $j;
+                }
+                // Drop trailing blank lines collected past the last real content.
+                while ($gathered !== [] && $gathered[array_key_last($gathered)] === '') {
+                    array_pop($gathered);
+                }
+                if ($gathered !== []) {
+                    if ($itemLines !== [] && $itemLines[array_key_last($itemLines)] !== '') {
+                        $itemLines[] = '';
+                    }
+                    foreach ($gathered as $gatheredLine) {
+                        $itemLines[] = $gatheredLine;
+                    }
+                    // Resume after the last consumed content line, not past blank
+                    // lines that precede outer content (the outer loop needs them
+                    // to detect the loose-list boundary).
+                    $i = $consumedThrough;
+                    $hasNonMarkerContinuation = true;
+                    $markerLineSublistParsed = true;
+                }
+            }
+
             // Check for list item attributes on the next line.
             //
             // Rule: a standalone {...} line attaches to the <li> ONLY when it
@@ -2158,8 +2237,8 @@ class BlockParser
                 $markerAttrsRaw = $itemInfo['attrs'];
                 $itemAttributes = AttributeParser::parseOrdered($markerAttrsRaw);
             }
-            $parseItemLinesAsBlocks = false;
-            if ($i < $count) {
+            $parseItemLinesAsBlocks = $markerLineSublistParsed;
+            if (!$markerLineSublistParsed && $i < $count) {
                 $potentialAttrLine = $lines[$i];
                 $trimmedAttrLine = ltrim($potentialAttrLine);
                 if (

--- a/tests/TestCase/NestedListEdgeCasesTest.php
+++ b/tests/TestCase/NestedListEdgeCasesTest.php
@@ -772,4 +772,89 @@ DJOT;
         $this->assertStringContainsString("a\nc", $result);
         $this->assertStringNotContainsString('  c', $result);
     }
+
+    // ============ Sublist opened on the parent item's marker line ============
+    //
+    // `- - A` opens a nested list on the OUTER item's marker line. That inner
+    // list must behave like any other nested container: its item stays open,
+    // absorbs a block indented to the inner content column, and a following
+    // same-indent marker continues it. Output is pinned to the reference
+    // djot.js 0.3.2. (carve-php inherits this parser, so it was affected too.)
+
+    public function testMarkerLineSublistItemAbsorbsBlockAndKeepsFollowingMarker(): void
+    {
+        // Case 1: the inner item A keeps the block indented to its content
+        // column, and a following same-indent marker stays in the same list.
+        $result = $this->converter->convert("- - A\n\n    block for A\n  - B");
+
+        $expected = <<<'HTML'
+            <ul>
+            <li>
+            <ul>
+            <li>
+            <p>A</p>
+            <p>block for A</p>
+            </li>
+            <li>
+            <p>B</p>
+            </li>
+            </ul>
+            </li>
+            </ul>
+
+            HTML;
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function testMarkerLineSublistItemAbsorbsBlockWithoutLeak(): void
+    {
+        // Case 2: the block stays inside inner item A; it must not leak out to
+        // the outer item.
+        $result = $this->converter->convert("- - A\n\n    block under A");
+
+        $expected = <<<'HTML'
+            <ul>
+            <li>
+            <ul>
+            <li>
+            <p>A</p>
+            <p>block under A</p>
+            </li>
+            </ul>
+            </li>
+            </ul>
+
+            HTML;
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function testMarkerLineSublistTightItemsStayOneList(): void
+    {
+        // Case 3 (regression guard): without an interleaved block, the markers
+        // form a single tight inner list [A, B, C].
+        $result = $this->converter->convert("- - A\n  - B\n  - C");
+
+        $expected = <<<'HTML'
+            <ul>
+            <li>
+            <ul>
+            <li>
+            A
+            </li>
+            <li>
+            B
+            </li>
+            <li>
+            C
+            </li>
+            </ul>
+            </li>
+            </ul>
+
+            HTML;
+
+        $this->assertSame($expected, $result);
+    }
 }


### PR DESCRIPTION
## The bug

A nested list opened on its parent item's **marker line** (`- - A`) was treated as line-scoped. The inner list was materialized from an isolated single-line slice, so its item closed immediately at the line break. As a result:

- a block placed in the inner item **leaked out** to the outer item, and
- a following same-indent marker **fragmented** the list into two separate lists.

The reference djot.js 0.3.2 keeps the inner item open: it absorbs blocks indented to its content column and continues the list across following same-indent markers. djot-php now matches that.

(carve-php inherits this parser and was affected by the same bug.)

## The fix

When an item's content itself begins with a list marker (the marker-line sublist case), collect the whole nested region (lines indented past the inner marker column, plus markers sitting at it, across blank lines) into the item's lines and parse them as blocks. The existing recursive list parser then builds a **persistent** inner list - reusing the nested-list handling that already works for a sublist appearing on a following line, rather than adding a parallel path.

Boundary rules (verified against reference djot.js 0.3.2):

- A line indented past the inner marker column is inner-item content or a deeper sublist.
- A list marker exactly at the inner marker column continues / siblings the inner list.
- A non-marker line at the inner marker column is inner-item content only when it lazily continues an open paragraph; after a blank line (or with nothing open before it) it is outer-item content and ends the region.

## Cases now matching the reference

Case 1 - input `- - A\n\n    block for A\n  - B`:

```html
<ul>
<li>
<ul>
<li>
<p>A</p>
<p>block for A</p>
</li>
<li>
<p>B</p>
</li>
</ul>
</li>
</ul>
```

Case 2 - input `- - A\n\n    block under A` (block stays inside inner item A, no leak):

```html
<ul>
<li>
<ul>
<li>
<p>A</p>
<p>block under A</p>
</li>
</ul>
</li>
</ul>
```

Case 3 - input `- - A\n  - B\n  - C` (already worked, kept as a regression guard): single tight inner list `[A, B, C]`.

## Scope

- The paragraph-interrupt rule ("a list needs a blank line to follow a paragraph") is untouched.
- Bare-marker rejection is untouched.
- Single-pass parsing is preserved.
- Diff is confined to the marker-line (loose) sublist path in `BlockParser::tryParseList()`; a corpus diff of 33 non-marker-line list inputs shows zero output changes versus master. New tests pin Cases 1, 2, and 3 to exact HTML.
