### PR TITLE
security: always-on attribute + URL hardening; cap inline nesting

### DIFF
--- a/src/Parser/InlineParser.php
+++ b/src/Parser/InlineParser.php
@@ -48,6 +48,19 @@ class InlineParser
     private const INLINE_SPECIAL_CHARS = "\\\n\$`:![<_*^~{\"'-.";
 
     /**
+     * Maximum inline-recursion depth before remaining text is emitted literally
+     * (DoS guard, see parseInlines()). Far deeper than any real document.
+     *
+     * @var int
+     */
+    protected const MAX_INLINE_DEPTH = 100;
+
+    /**
+     * Current inline-recursion depth (see self::MAX_INLINE_DEPTH).
+     */
+    protected int $inlineDepth = 0;
+
+    /**
      * @var array<array{type: string, char: string, pos: int, node: \Djot\Node\Node}>
      */
     protected array $delimiterStack = [];
@@ -215,6 +228,29 @@ class InlineParser
     }
 
     protected function parseInlines(Node $parent, string $text): void
+    {
+        // Inline-nesting DoS guard: deeply nested inline constructs (e.g. a bomb
+        // of nested links `[[[...](#)](#)...`) recurse through parseInlines and
+        // rescan balanced brackets at each level, which is ~O(n^2). Beyond this
+        // depth the remaining text is emitted literally instead of recursing
+        // further. Far deeper than any real document.
+        if ($this->inlineDepth >= self::MAX_INLINE_DEPTH) {
+            if ($text !== '') {
+                $parent->appendChild(new Text($text));
+            }
+
+            return;
+        }
+
+        $this->inlineDepth++;
+        try {
+            $this->parseInlinesImpl($parent, $text);
+        } finally {
+            $this->inlineDepth--;
+        }
+    }
+
+    protected function parseInlinesImpl(Node $parent, string $text): void
     {
         $length = strlen($text);
         $pos = 0;

--- a/src/Renderer/HtmlRenderer.php
+++ b/src/Renderer/HtmlRenderer.php
@@ -927,9 +927,13 @@ class HtmlRenderer implements RendererInterface
         $href = $node->getDestination();
         $title = $node->getTitle();
 
-        // Sanitize URL in safe mode
-        if ($this->safeMode !== null && $href !== null) {
-            $href = $this->safeMode->sanitizeUrl($href);
+        // Always-on URL hardening (dangerous scheme denylist), then safe mode
+        // may apply a stricter allowlist on top.
+        if ($href !== null) {
+            $href = $this->sanitizeUrlBaseline($href);
+            if ($this->safeMode !== null) {
+                $href = $this->safeMode->sanitizeUrl($href);
+            }
         }
 
         $html = '<a';
@@ -963,7 +967,9 @@ class HtmlRenderer implements RendererInterface
         $src = $node->getSource();
         $title = $node->getTitle();
 
-        // Sanitize URL in safe mode
+        // Always-on URL hardening (dangerous scheme denylist), then safe mode
+        // may apply a stricter allowlist on top.
+        $src = $this->sanitizeUrlBaseline($src);
         if ($this->safeMode !== null) {
             $src = $this->safeMode->sanitizeUrl($src);
         }
@@ -1083,12 +1089,128 @@ class HtmlRenderer implements RendererInterface
             $attrs = array_diff_key($attrs, array_flip($exclude));
         }
 
-        // Filter dangerous attributes in safe mode
+        // Always-on hardening: strip event handlers / injection sinks and
+        // neutralize dangerous attribute values regardless of safe mode.
+        $attrs = $this->sanitizeAttributes($attrs);
+
+        // Safe mode may strip additional names (e.g. style under strict) on top.
         if ($this->safeMode !== null) {
             $attrs = $this->safeMode->filterAttributes($attrs);
         }
 
         return $attrs;
+    }
+
+    /**
+     * URL schemes that are always neutralized in attribute values and in
+     * `href` / `src`, regardless of safe mode.
+     *
+     * @var array<string>
+     */
+    private const DANGEROUS_VALUE_SCHEMES = ['javascript', 'vbscript', 'data', 'file'];
+
+    /**
+     * Always-on attribute hardening, applied regardless of safe mode.
+     *
+     * Drops event-handler names (`on*`) and the injection sinks `srcdoc` /
+     * `formaction`, and blanks a value carrying a dangerous URL scheme or a CSS
+     * `expression(...)`. Safe mode (when set) filters further on top. Attribute
+     * names are otherwise left as-is (their well-formedness is the parser's job).
+     *
+     * @param array<string, string> $attrs
+     *
+     * @return array<string, string>
+     */
+    protected function sanitizeAttributes(array $attrs): array
+    {
+        $out = [];
+        foreach ($attrs as $key => $value) {
+            $name = strtolower((string)$key);
+            if (str_starts_with($name, 'on') || $name === 'srcdoc' || $name === 'formaction') {
+                continue;
+            }
+            $out[$key] = $this->sanitizeAttributeValue($name, (string)$value);
+        }
+
+        return $out;
+    }
+
+    /**
+     * Blank an attribute value that carries a dangerous URL scheme or a CSS
+     * `expression(...)`. The scheme is normalized (C0 controls + spaces removed)
+     * before comparison to defeat `java\tscript:` style evasion.
+     */
+    protected function sanitizeAttributeValue(string $name, string $value): string
+    {
+        $colon = strpos($value, ':');
+        if ($colon !== false) {
+            $scheme = strtolower((string)preg_replace('/[\x00-\x20]+/', '', substr($value, 0, $colon)));
+            if (in_array($scheme, self::DANGEROUS_VALUE_SCHEMES, true)) {
+                return '';
+            }
+        }
+        if ($name === 'style' && $this->hasDangerousCss($value)) {
+            return '';
+        }
+
+        return $value;
+    }
+
+    /**
+     * Detect script-bearing / fetching constructs in a CSS `style` value:
+     * `expression()` (legacy IE script), `url(...)` (can fetch or carry
+     * `javascript:`), `@import`, and the legacy `behavior` / `-moz-binding`
+     * script bindings. CSS escapes are decoded and whitespace collapsed first so
+     * `expr\65 ssion(` / `expr ession (` cannot evade.
+     */
+    protected function hasDangerousCss(string $value): bool
+    {
+        $withoutComments = preg_replace('/\/\*.*?\*\//s', '', $value) ?? $value;
+        $decoded = preg_replace_callback(
+            '/\\\\([0-9A-Fa-f]{1,6}\s?|.)/s',
+            static function (array $m): string {
+                $escape = $m[1];
+                if (preg_match('/^([0-9A-Fa-f]{1,6})\s?$/', $escape, $hex) === 1) {
+                    $codepoint = (int)hexdec($hex[1]);
+                    if ($codepoint <= 0 || $codepoint > 0x10FFFF) {
+                        return '';
+                    }
+
+                    return mb_chr($codepoint, 'UTF-8');
+                }
+
+                return $escape;
+            },
+            $withoutComments,
+        ) ?? $withoutComments;
+        $compact = strtolower((string)preg_replace('/\s+/', '', $decoded));
+
+        return str_contains($compact, 'expression(')
+            || str_contains($compact, 'url(')
+            || str_contains($compact, '@import')
+            || str_contains($compact, 'behavior:')
+            || str_contains($compact, '-moz-binding');
+    }
+
+    /**
+     * Always-on URL hardening for `href` / `src`, independent of safe mode.
+     *
+     * Blanks a URL whose (normalized) scheme is one of the dangerous denylist
+     * schemes (`javascript`, `vbscript`, `data`, `file`); every other scheme and
+     * any scheme-less URL passes. Safe mode may apply a stricter allowlist on
+     * top. Scheme detection strips C0 controls + spaces to defeat `java\tscript:`
+     * evasion.
+     */
+    protected function sanitizeUrlBaseline(string $url): string
+    {
+        $probe = (string)preg_replace('/[\x00-\x20]+/', '', $url);
+        if (preg_match('/^([a-zA-Z][a-zA-Z0-9+.\-]*):/', $probe, $m) === 1) {
+            if (in_array(strtolower($m[1]), self::DANGEROUS_VALUE_SCHEMES, true)) {
+                return '';
+            }
+        }
+
+        return $url;
     }
 
     /**

--- a/tests/TestCase/Renderer/AlwaysOnHardeningTest.php
+++ b/tests/TestCase/Renderer/AlwaysOnHardeningTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Test\TestCase\Renderer;
+
+use Djot\DjotConverter;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Security hardening that applies to the DEFAULT renderer (no safe mode set).
+ *
+ * Dangerous URL schemes, event-handler / injection-sink attributes, CSS
+ * `expression()` and unbounded inline nesting must be neutralized even when the
+ * caller never opts into safe mode. Safe mode (tested in {@see \Djot\Test\SafeModeTest})
+ * layers stricter filtering on top.
+ */
+class AlwaysOnHardeningTest extends TestCase
+{
+    protected DjotConverter $converter;
+
+    protected function setUp(): void
+    {
+        // No safe mode configured: this is the default converter.
+        $this->converter = new DjotConverter();
+    }
+
+    public function testDangerousLinkSchemeBlankedWithoutSafeMode(): void
+    {
+        $result = $this->converter->convert('[x](javascript:alert(1))');
+        $this->assertStringNotContainsString('javascript:', $result);
+        $this->assertStringContainsString('<a href="">x</a>', $result);
+    }
+
+    public function testDangerousImageSchemeBlankedWithoutSafeMode(): void
+    {
+        $result = $this->converter->convert('![a](vbscript:msgbox(1))');
+        $this->assertStringNotContainsString('vbscript:', $result);
+    }
+
+    public function testSchemeEvasionWithControlCharIsBlanked(): void
+    {
+        // `java\tscript:` must not slip past the denylist.
+        $result = $this->converter->convert("[x](java\tscript:alert(1))");
+        $this->assertStringNotContainsString('script:', $result);
+    }
+
+    public function testSafeSchemeAndRelativeUrlPreserved(): void
+    {
+        $this->assertStringContainsString(
+            'href="https://ok.example"',
+            $this->converter->convert('[x](https://ok.example)'),
+        );
+        $this->assertStringContainsString(
+            'href="/local/page"',
+            $this->converter->convert('[x](/local/page)'),
+        );
+    }
+
+    public function testEventHandlerAttributeStrippedWithoutSafeMode(): void
+    {
+        $result = $this->converter->convert('[x](https://a){onclick="alert(1)"}');
+        $this->assertStringNotContainsString('onclick', $result);
+    }
+
+    public function testInjectionSinkAttributesStrippedWithoutSafeMode(): void
+    {
+        $result = $this->converter->convert('text{srcdoc="x" formaction="y"}');
+        $this->assertStringNotContainsString('srcdoc', $result);
+        $this->assertStringNotContainsString('formaction', $result);
+    }
+
+    public function testCssExpressionBlankedWithoutSafeMode(): void
+    {
+        $result = $this->converter->convert('text{style="x:expression(alert(1))"}');
+        $this->assertStringNotContainsString('expression(', $result);
+    }
+
+    public function testDangerousAttributeValueSchemeBlanked(): void
+    {
+        // A non-href attribute may still carry a javascript: payload.
+        $result = $this->converter->convert('text{data-x="javascript:alert(1)"}');
+        $this->assertStringNotContainsString('javascript:', $result);
+    }
+
+    public function testDeeplyNestedInlineDoesNotBlowUp(): void
+    {
+        $depth = 4000;
+        $bomb = str_repeat('[', $depth) . 'x' . str_repeat('](u)', $depth);
+
+        $start = microtime(true);
+        $result = $this->converter->convert($bomb);
+        $elapsed = microtime(true) - $start;
+
+        // Without the cap this is ~O(n^2) (seconds); the guard keeps it fast.
+        $this->assertLessThan(2.0, $elapsed, 'inline nesting DoS guard did not bound parse time');
+        $this->assertNotSame('', $result);
+    }
+}

--- a/tests/TestCase/SafeModeTest.php
+++ b/tests/TestCase/SafeModeTest.php
@@ -243,11 +243,14 @@ class SafeModeTest extends TestCase
     public function testSafeModeDisabledByDefault(): void
     {
         $converter = new DjotConverter();
-        $djot = '[click](javascript:alert(1))';
-        $result = $converter->convert($djot);
 
-        // Without safe mode, dangerous URLs are allowed
-        $this->assertStringContainsString('javascript:alert(1)', $result);
+        // Safe-mode-only filtering is not applied by default: raw HTML passes
+        // through instead of being escaped.
+        $this->assertStringContainsString('<b>bold</b>', $converter->convert('`<b>bold</b>`{=html}'));
+
+        // Always-on hardening still neutralizes dangerous URL schemes even with
+        // safe mode off (there is no legitimate reason to emit javascript:).
+        $this->assertStringNotContainsString('javascript:', $converter->convert('[click](javascript:alert(1))'));
     }
 
     public function testSafeModeCanBeEnabledAfterConstruction(): void
@@ -266,10 +269,12 @@ class SafeModeTest extends TestCase
         $converter = new DjotConverter(safeMode: true);
         $converter->setSafeMode(false);
 
-        $djot = '[click](javascript:alert(1))';
-        $result = $converter->convert($djot);
+        // Disabling safe mode restores the safe-mode-gated behavior (raw HTML
+        // passes through again)...
+        $this->assertStringContainsString('<b>bold</b>', $converter->convert('`<b>bold</b>`{=html}'));
 
-        $this->assertStringContainsString('javascript:alert(1)', $result);
+        // ...but the always-on URL hardening still applies regardless.
+        $this->assertStringNotContainsString('javascript:', $converter->convert('[click](javascript:alert(1))'));
     }
 
     public function testCustomSafeModeConfiguration(): void


### PR DESCRIPTION
Ports the confirmed default-output security hardening from the downstream carve-php fork.

## Problem

All dangerous-content sanitization is gated on safe mode (`if ($this->safeMode !== null)` in `HtmlRenderer`), and safe mode is **off by default**. So a plain `new DjotConverter()` / `new HtmlRenderer()` emits, unfiltered:

- `javascript:` / `vbscript:` / `data:` URLs in link `href` and image `src`
- event-handler attributes (`onclick`, ...) and the injection sinks `srcdoc` / `formaction`
- CSS `expression()` in `style`

Separately, deeply nested inline constructs (a bomb of nested links / emphasis) rescan balanced brackets at each recursion level - roughly O(n^2). A few thousand levels of nesting took ~10s of CPU, a parse-time DoS.

## Change

- **`HtmlRenderer` - always-on baseline, independent of safe mode.** Strip `on*` / `srcdoc` / `formaction` attribute names; blank a value carrying a dangerous URL scheme or a script-bearing CSS construct (`expression()` / `url()` / `@import` / `behavior` / `-moz-binding`). `href` / `src` run the dangerous-scheme denylist before the safe-mode allowlist. Scheme detection strips C0 controls + spaces first, so `java\tscript:` cannot evade. Safe mode still layers its stricter filtering (raw-HTML policy, `style`, allowlists) on top - this only changes the *default* (no-safe-mode) output, which previously did nothing.
- **`InlineParser` - cap inline recursion depth** (100, far deeper than any real document). Beyond the cap the remaining text is emitted literally instead of recursing, bounding the O(n^2) blowup.
- New `AlwaysOnHardeningTest`; two `SafeModeTest` cases that asserted dangerous URLs pass through with safe mode off were updated to the new baseline (the off-by-default distinction is now shown via raw-HTML passthrough).

## Compatibility

This shifts the **default** rendering output: dangerous schemes / handlers that previously passed through are now neutralized even without safe mode. There is no legitimate reason to emit `javascript:` or `onclick` from untrusted markup, so the baseline is unconditional; callers who genuinely need a permissive renderer still control the rest via safe-mode configuration.

## Scope notes

Confirmed-not-applicable and excluded: djot-php already drops a colliding `{href=...}` attribute-block override on links/images (no change needed). The HTML importer (`HtmlToDjot`) carrying `javascript:` through on *import* is a separate surface, left for a follow-up.