### PR TITLE
security: ignore round-trip raw attributes on untrusted HTML import; bound abbreviation expansion

### DIFF
--- a/src/Converter/HtmlToDjot.php
+++ b/src/Converter/HtmlToDjot.php
@@ -23,9 +23,30 @@ use RuntimeException;
  * Key Djot requirements handled:
  * - Blank lines required around block elements (headings, code blocks, lists)
  * - Nested lists require blank line before the nested portion
+ *
+ * SECURITY: this converter is NOT a sanitizer. Its output is Djot markup that
+ * may still contain content derived from the input; render untrusted input with
+ * safe mode enabled on the downstream renderer. By default the converter IGNORES
+ * the `data-djot-src` / `data-djot-raw` round-trip attributes on the input (they
+ * would otherwise be re-emitted verbatim as raw Djot, letting a crafted attribute
+ * smuggle a raw-HTML block -> live <script> into the output). Only enable
+ * round-trip extraction via the constructor flag when the HTML is TRUSTED (e.g.
+ * produced by djot itself for a faithful round-trip).
  */
 class HtmlToDjot
 {
+    /**
+     * When true, trust and re-emit the `data-djot-src` / `data-djot-raw`
+     * round-trip attributes on the input. Default false: untrusted HTML must not
+     * be able to smuggle raw Djot (incl. a raw-HTML block) through them.
+     */
+    protected bool $trustedRoundTrip = false;
+
+    public function __construct(bool $trustedRoundTrip = false)
+    {
+        $this->trustedRoundTrip = $trustedRoundTrip;
+    }
+
     protected int $listDepth = 0;
 
     protected bool $inPre = false;
@@ -948,6 +969,14 @@ class HtmlToDjot
 
     protected function extractRoundTripSource(DOMElement $node, string $tagName): ?string
     {
+        // Untrusted HTML must not be able to smuggle raw Djot through a
+        // `data-djot-src` attribute (it is emitted verbatim, so a crafted value
+        // could inject a raw-HTML block -> live <script>). Only honor it when the
+        // caller explicitly trusts the source.
+        if (!$this->trustedRoundTrip) {
+            return null;
+        }
+
         if (!$node->hasAttribute('data-djot-src')) {
             return null;
         }
@@ -1852,8 +1881,12 @@ class HtmlToDjot
             return '\\' . $node->textContent;
         }
 
-        // Check for raw inline content (round-trip support)
-        if ($node->hasAttribute('data-djot-raw')) {
+        // Check for raw inline content (round-trip support). Only honor it for
+        // trusted input: `data-djot-raw` is re-emitted verbatim as a raw inline
+        // span (`` `...`{=html} ``), so a crafted attribute on untrusted HTML
+        // could smuggle live markup. Untrusted input falls through to ordinary
+        // span processing (getElementAttributes drops the data-djot-* attribute).
+        if ($this->trustedRoundTrip && $node->hasAttribute('data-djot-raw')) {
             return $this->processRawInline($node);
         }
 
@@ -2224,7 +2257,10 @@ class HtmlToDjot
 
     protected function convertInlineFragmentToDjot(string $html): string
     {
-        $converter = new self();
+        // Propagate the trust setting so a trusted round-trip parent keeps
+        // honoring inner round-trip attributes in the recursive sub-conversion
+        // (and an untrusted parent keeps ignoring them).
+        $converter = new self($this->trustedRoundTrip);
         $converter->preserveTextWhitespace = true;
 
         $doc = new DOMDocument();

--- a/src/DjotConverter.php
+++ b/src/DjotConverter.php
@@ -417,6 +417,10 @@ class DjotConverter
 
         $document = $this->parser->parse($djot);
 
+        // Record the source size so render-time DoS budgets (abbreviation
+        // expansion) can scale with the input rather than a fixed cap.
+        $document->setSourceLength(strlen($djot));
+
         foreach ($this->extensions as $extension) {
             if ($extension instanceof ParsedDocumentExtensionInterface) {
                 $extension->afterParse($document);

--- a/src/Extension/TabsExtension.php
+++ b/src/Extension/TabsExtension.php
@@ -582,7 +582,7 @@ class TabsExtension implements ResettableExtensionInterface
             $child instanceof DefinitionList => $this->renderDefinitionListToDjot($child, $renderer),
             $child instanceof Div => $this->renderDivToDjot($child, $renderer),
             $child instanceof Table => $this->renderTableToDjot($child, $renderer),
-            default => rtrim((new HtmlToDjot())->convert($renderer->renderNodeFragment($child)), "\n"),
+            default => rtrim((new HtmlToDjot(trustedRoundTrip: true))->convert($renderer->renderNodeFragment($child)), "\n"),
         };
     }
 
@@ -592,9 +592,9 @@ class TabsExtension implements ResettableExtensionInterface
 
         foreach ($list->getChildren() as $child) {
             if ($child instanceof DefinitionTerm) {
-                $lines[] = rtrim((new HtmlToDjot())->convert($renderer->renderNodeFragment($child)), "\n");
+                $lines[] = rtrim((new HtmlToDjot(trustedRoundTrip: true))->convert($renderer->renderNodeFragment($child)), "\n");
             } elseif ($child instanceof DefinitionDescription) {
-                $content = rtrim((new HtmlToDjot())->convert($renderer->renderNodeFragment($child)), "\n");
+                $content = rtrim((new HtmlToDjot(trustedRoundTrip: true))->convert($renderer->renderNodeFragment($child)), "\n");
                 $lines[] = ': ' . $content;
             }
         }
@@ -655,7 +655,7 @@ class TabsExtension implements ResettableExtensionInterface
                     continue;
                 }
 
-                $cells[] = rtrim((new HtmlToDjot())->convert($renderer->renderNodeFragment($cell)), "\n");
+                $cells[] = rtrim((new HtmlToDjot(trustedRoundTrip: true))->convert($renderer->renderNodeFragment($cell)), "\n");
                 if ($row->isHeader() || !isset($alignments[$cellIndex])) {
                     $alignments[$cellIndex] = $cell->getAlignment();
                 }

--- a/src/Node/Document.php
+++ b/src/Node/Document.php
@@ -16,9 +16,33 @@ class Document extends Node
      */
     protected array $abbreviations = [];
 
+    /**
+     * Byte length of the original source the document was parsed from.
+     *
+     * Used to scale render-time DoS budgets (e.g. abbreviation expansion).
+     * Defaults to 0 for documents built directly rather than parsed.
+     */
+    protected int $sourceLength = 0;
+
     public function getType(): string
     {
         return 'document';
+    }
+
+    /**
+     * Get the byte length of the original parsed source.
+     */
+    public function getSourceLength(): int
+    {
+        return $this->sourceLength;
+    }
+
+    /**
+     * Set the byte length of the original parsed source.
+     */
+    public function setSourceLength(int $sourceLength): void
+    {
+        $this->sourceLength = $sourceLength;
     }
 
     /**

--- a/src/Renderer/AnsiRenderer.php
+++ b/src/Renderer/AnsiRenderer.php
@@ -47,6 +47,7 @@ use Djot\Node\Inline\Superscript;
 use Djot\Node\Inline\Symbol;
 use Djot\Node\Inline\Text;
 use Djot\Node\Node;
+use Djot\Renderer\Utility\AbbreviationBudgetTrait;
 
 /**
  * Renders AST to ANSI-formatted terminal output
@@ -56,6 +57,8 @@ use Djot\Node\Node;
  */
 class AnsiRenderer implements RendererInterface
 {
+    use AbbreviationBudgetTrait;
+
     // ANSI escape codes
     /**
      * @var string
@@ -367,6 +370,8 @@ class AnsiRenderer implements RendererInterface
 
     public function render(Document $document): string
     {
+        $this->resetAbbreviationBudget($document->getSourceLength());
+
         $output = $this->renderChildren($document);
 
         // Normalize multiple blank lines
@@ -921,6 +926,13 @@ class AnsiRenderer implements RendererInterface
     protected function renderAbbreviation(Abbreviation $node): string
     {
         $text = $this->renderChildren($node);
+
+        // DoS guard: once the cumulative expansion bytes would exceed the
+        // budget, degrade to plain key text (no parenthesized definition).
+        if (!$this->chargeAbbreviationExpansion($node->getTitle())) {
+            return $text;
+        }
+
         $title = $node->getTitle();
 
         // Show abbreviation with definition in parentheses

--- a/src/Renderer/HtmlRenderer.php
+++ b/src/Renderer/HtmlRenderer.php
@@ -48,6 +48,7 @@ use Djot\Node\Inline\Superscript;
 use Djot\Node\Inline\Symbol;
 use Djot\Node\Inline\Text;
 use Djot\Node\Node;
+use Djot\Renderer\Utility\AbbreviationBudgetTrait;
 use Djot\Renderer\Utility\EventDispatcherTrait;
 use Djot\SafeMode;
 use Djot\Util\StringUtil;
@@ -57,6 +58,7 @@ use Djot\Util\StringUtil;
  */
 class HtmlRenderer implements RendererInterface
 {
+    use AbbreviationBudgetTrait;
     use EventDispatcherTrait;
 
     protected SoftBreakMode $softBreakMode = SoftBreakMode::Newline;
@@ -304,6 +306,7 @@ class HtmlRenderer implements RendererInterface
             $this->sharedRenderContext,
             function () use ($document): string {
                 $this->sharedRenderContext->reset();
+                $this->resetAbbreviationBudget($document->getSourceLength());
 
                 $html = $this->renderDocumentWithSections($document);
 
@@ -1060,8 +1063,15 @@ class HtmlRenderer implements RendererInterface
 
     protected function renderAbbreviation(Abbreviation $node): string
     {
-        $attrs = $this->renderAttributes($node);
         $title = $node->getTitle();
+
+        // DoS guard: once the cumulative expansion bytes would exceed the
+        // budget, degrade to plain key text (no <abbr> wrapper, no title).
+        if (!$this->chargeAbbreviationExpansion($title)) {
+            return $this->renderChildren($node);
+        }
+
+        $attrs = $this->renderAttributes($node);
 
         return '<abbr title="' . $this->escapeAttribute($title) . '"' . $attrs . '>'
             . $this->renderChildren($node) . '</abbr>';

--- a/src/Renderer/MarkdownRenderer.php
+++ b/src/Renderer/MarkdownRenderer.php
@@ -47,6 +47,7 @@ use Djot\Node\Inline\Superscript;
 use Djot\Node\Inline\Symbol;
 use Djot\Node\Inline\Text;
 use Djot\Node\Node;
+use Djot\Renderer\Utility\AbbreviationBudgetTrait;
 use Djot\Renderer\Utility\EventDispatcherTrait;
 use Djot\Util\StringUtil;
 
@@ -66,6 +67,7 @@ use Djot\Util\StringUtil;
  */
 class MarkdownRenderer implements RendererInterface
 {
+    use AbbreviationBudgetTrait;
     use EventDispatcherTrait;
 
     protected int $listDepth = 0;
@@ -96,6 +98,8 @@ class MarkdownRenderer implements RendererInterface
 
     public function render(Document $document): string
     {
+        $this->resetAbbreviationBudget($document->getSourceLength());
+
         $markdown = $this->renderChildren($document);
 
         // Normalize multiple blank lines
@@ -528,12 +532,21 @@ class MarkdownRenderer implements RendererInterface
      */
     protected function renderAbbreviation(Abbreviation $node): string
     {
+        // DoS guard: once the cumulative expansion bytes would exceed the
+        // budget, degrade to plain key text (no <abbr> wrapper, no title).
+        // Return the children as ordinary Markdown text - NOT the HTML-escaped
+        // form below, which is only correct inside the raw <abbr> element (a
+        // bare `&`/`<` in the key must stay literal in Markdown output).
+        if (!$this->chargeAbbreviationExpansion($node->getTitle())) {
+            return $this->renderChildren($node);
+        }
+
         // The whole element is raw inline HTML, so both the title (attribute)
         // and the text (element content) need HTML escaping, NOT Markdown text
         // escaping: a `"` in the title or a `<` in the text would otherwise
         // break the tag / be misparsed as markup downstream.
-        $title = htmlspecialchars($node->getTitle(), ENT_QUOTES, 'UTF-8');
         $text = htmlspecialchars($this->renderChildren($node), ENT_QUOTES, 'UTF-8');
+        $title = htmlspecialchars($node->getTitle(), ENT_QUOTES, 'UTF-8');
 
         return '<abbr title="' . $title . '">' . $text . '</abbr>';
     }

--- a/src/Renderer/Utility/AbbreviationBudgetTrait.php
+++ b/src/Renderer/Utility/AbbreviationBudgetTrait.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Renderer\Utility;
+
+/**
+ * Bounds the cumulative bytes contributed by abbreviation expansion across a
+ * single render, guarding against an output-amplification (memory) DoS.
+ *
+ * Each occurrence of an abbreviation re-emits its full definition (the `title`
+ * of an `<abbr>` element, the `(definition)` suffix in ANSI, etc.). A tiny
+ * source such as `*[HT]: <50KB of text>` followed by many `HT` occurrences
+ * would otherwise expand to `definition_len * occurrence_count` bytes
+ * (hundreds of MB), which PHP happily allocates - a true RAM-exhaustion DoS.
+ *
+ * Policy:
+ *   budget = max(BUDGET_BASE, BUDGET_FACTOR * sourceByteLength)
+ * Once the next occurrence's expansion would exceed the budget, that occurrence
+ * (and every subsequent one) degrades gracefully to its plain key text only -
+ * no `<abbr>` wrapper, no title. The budget sits far above any real document,
+ * so normal output is byte-identical.
+ *
+ * The counter is reset per full render call (resetAbbreviationBudget()).
+ */
+trait AbbreviationBudgetTrait
+{
+    /**
+     * Base (floor) budget in bytes, applied even for tiny sources.
+     *
+     * @var int
+     */
+    protected const ABBREVIATION_BUDGET_BASE = 1000000;
+
+    /**
+     * Multiplier applied to the source byte length.
+     *
+     * @var int
+     */
+    protected const ABBREVIATION_BUDGET_FACTOR = 8;
+
+    /**
+     * Cumulative expansion bytes already emitted in the current render.
+     */
+    protected int $abbreviationExpansionBytes = 0;
+
+    /**
+     * Computed budget for the current render (max of base and factor*source).
+     */
+    protected int $abbreviationBudget = self::ABBREVIATION_BUDGET_BASE;
+
+    /**
+     * Reset the budget counter and (re)compute the budget for a fresh render.
+     */
+    protected function resetAbbreviationBudget(int $sourceLength): void
+    {
+        $this->abbreviationExpansionBytes = 0;
+        $this->abbreviationBudget = max(
+            self::ABBREVIATION_BUDGET_BASE,
+            self::ABBREVIATION_BUDGET_FACTOR * $sourceLength,
+        );
+    }
+
+    /**
+     * Charge a single abbreviation occurrence against the budget.
+     *
+     * @param string $expansion The definition text whose bytes are emitted.
+     *
+     * @return bool True if the expansion fits within budget and may be emitted
+     *   (the bytes are charged); false if it would exceed the budget and the
+     *   occurrence must degrade to plain key text.
+     */
+    protected function chargeAbbreviationExpansion(string $expansion): bool
+    {
+        $cost = strlen($expansion);
+        if ($this->abbreviationExpansionBytes + $cost > $this->abbreviationBudget) {
+            return false;
+        }
+
+        $this->abbreviationExpansionBytes += $cost;
+
+        return true;
+    }
+}

--- a/tests/TestCase/Converter/HtmlToDjotRoundTripSecurityTest.php
+++ b/tests/TestCase/Converter/HtmlToDjotRoundTripSecurityTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Test\TestCase\Converter;
+
+use Djot\Converter\HtmlToDjot;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The reverse converter must not honor the `data-djot-src` / `data-djot-raw`
+ * round-trip attributes on UNTRUSTED input: they are re-emitted verbatim as raw
+ * Djot, so a crafted value could smuggle a raw-HTML block (-> live <script>)
+ * into the converted output. Honoring them is opt-in via the constructor flag,
+ * intended only for trusted, djot-produced HTML.
+ */
+class HtmlToDjotRoundTripSecurityTest extends TestCase
+{
+    /**
+     * A block-level `data-djot-src` payload smuggling a raw-HTML block.
+     */
+    protected function blockPayloadHtml(): string
+    {
+        $src = '`<script>alert(1)</script>`{=html}';
+
+        return '<pre data-djot-src="' . htmlspecialchars($src, ENT_QUOTES) . '">code</pre>';
+    }
+
+    public function testDefaultConverterIgnoresBlockRoundTripAttribute(): void
+    {
+        $result = (new HtmlToDjot())->convert($this->blockPayloadHtml());
+
+        // The raw-HTML round-trip source must NOT be re-emitted.
+        $this->assertStringNotContainsString('{=html}', $result);
+        $this->assertStringNotContainsString('<script>', $result);
+    }
+
+    public function testTrustedConverterHonorsBlockRoundTripAttribute(): void
+    {
+        $result = (new HtmlToDjot(trustedRoundTrip: true))->convert($this->blockPayloadHtml());
+
+        // Trusted round-trip extraction re-emits the stored source verbatim.
+        $this->assertStringContainsString('{=html}', $result);
+    }
+
+    public function testDefaultConverterIgnoresInlineRawAttribute(): void
+    {
+        $html = '<p>x <span data-djot-raw="html"><script>alert(1)</script></span></p>';
+
+        $result = (new HtmlToDjot())->convert($html);
+
+        // The inline raw round-trip span must NOT be re-emitted as `...`{=html}.
+        $this->assertStringNotContainsString('{=html}', $result);
+    }
+
+    public function testTrustedConverterHonorsInlineRawAttribute(): void
+    {
+        $html = '<p>x <span data-djot-raw="html"><em>ok</em></span></p>';
+
+        $result = (new HtmlToDjot(trustedRoundTrip: true))->convert($html);
+
+        $this->assertStringContainsString('{=html}', $result);
+    }
+
+    public function testDefaultIsUntrusted(): void
+    {
+        // A bare `new HtmlToDjot()` must behave exactly like the untrusted path.
+        $this->assertStringNotContainsString(
+            '{=html}',
+            (new HtmlToDjot())->convert($this->blockPayloadHtml()),
+        );
+    }
+}

--- a/tests/TestCase/Converter/HtmlToDjotTest.php
+++ b/tests/TestCase/Converter/HtmlToDjotTest.php
@@ -19,9 +19,18 @@ class HtmlToDjotTest extends TestCase
 {
     protected HtmlToDjot $converter;
 
+    /**
+     * Trusted converter for round-trip-fidelity assertions, which consume
+     * djot-produced HTML and must honor the `data-djot-src` / `data-djot-raw`
+     * round-trip attributes. The default {@see self::$converter} stays untrusted
+     * to reflect real conversion of external HTML.
+     */
+    protected HtmlToDjot $trustedConverter;
+
     protected function setUp(): void
     {
         $this->converter = new HtmlToDjot();
+        $this->trustedConverter = new HtmlToDjot(trustedRoundTrip: true);
     }
 
     // ==================== Basic Formatting ====================
@@ -1059,14 +1068,14 @@ HTML;
         // Test dash (default)
         $djot = '---';
         $html = $djotConverter->convert($djot);
-        $back = trim($this->converter->convert($html));
+        $back = trim($this->trustedConverter->convert($html));
         $this->assertSame('---', $back, 'Dash thematic break should round-trip');
 
         // Test asterisk (preserved via data-char)
         $djot = '***';
         $html = $djotConverter->convert($djot);
         $this->assertStringContainsString('data-char="*"', $html);
-        $back = trim($this->converter->convert($html));
+        $back = trim($this->trustedConverter->convert($html));
         $this->assertSame('***', $back, 'Asterisk thematic break should round-trip');
     }
 
@@ -1078,7 +1087,7 @@ HTML;
         $html = $djotConverter->convert('# Title');
 
         $this->assertStringContainsString('data-djot-source-level="1"', $html);
-        $back = trim($this->converter->convert($html));
+        $back = trim($this->trustedConverter->convert($html));
 
         $this->assertSame('# Title', $back);
     }
@@ -1093,7 +1102,7 @@ HTML;
 
         $this->assertStringContainsString('data-djot-heading-ref="Getting Started"', $html);
         $this->assertStringNotContainsString('data-heading-ref=', $html);
-        $back = trim($this->converter->convert($html));
+        $back = trim($this->trustedConverter->convert($html));
 
         $this->assertSame($djot, $back);
     }
@@ -1107,7 +1116,7 @@ HTML;
         $html = $djotConverter->convert($djot);
 
         $this->assertStringContainsString('data-djot-inline-footnote-html=', $html);
-        $back = trim($this->converter->convert($html));
+        $back = trim($this->trustedConverter->convert($html));
 
         $this->assertSame($djot, $back);
     }
@@ -1121,7 +1130,7 @@ HTML;
         $html = $djotConverter->convert($djot);
 
         $this->assertStringContainsString('data-djot-inline-footnote-class="footnote"', $html);
-        $back = trim($this->converter->convert($html));
+        $back = trim($this->trustedConverter->convert($html));
 
         $this->assertSame($djot, $back);
     }
@@ -1133,7 +1142,7 @@ HTML;
 
         $djot = 'Text[  Footnote  ]{.fn} after.';
         $html = $djotConverter->convert($djot);
-        $back = trim($this->converter->convert($html));
+        $back = trim($this->trustedConverter->convert($html));
 
         $this->assertSame($djot, $back);
     }
@@ -1145,7 +1154,7 @@ HTML;
 
         $djot = 'Text[  Foo   Bar  ]{.fn} after.';
         $html = $djotConverter->convert($djot);
-        $back = trim($this->converter->convert($html));
+        $back = trim($this->trustedConverter->convert($html));
 
         $this->assertSame($djot, $back);
     }
@@ -1305,7 +1314,7 @@ DJOT;
         $this->assertStringContainsString('data-djot-col-widths="11,9,19"', $html);
 
         // Convert back to Djot
-        $back = trim($this->converter->convert($html));
+        $back = trim($this->trustedConverter->convert($html));
 
         // Separator widths should be preserved (compact format without spaces around dashes)
         $this->assertStringContainsString('|-----------|---------|-------------------|', $back);
@@ -1331,7 +1340,7 @@ DJOT;
         $djot = "{#snippet .demo selected}\n``` php [Example]\necho 123;\n```\n";
 
         $html = (new DjotConverter(roundTripMode: true))->convert($djot);
-        $back = trim($this->converter->convert($html));
+        $back = trim($this->trustedConverter->convert($html));
 
         $this->assertSame(trim($djot), $back);
     }
@@ -1344,7 +1353,7 @@ DJOT;
         $djot = "{#flow data-theme=dark}\n``` mermaid\ngraph TD;\n    A-->B;\n```\n";
 
         $html = $converter->convert($djot);
-        $back = trim($this->converter->convert($html));
+        $back = trim($this->trustedConverter->convert($html));
 
         $this->assertSame(trim($djot), $back);
     }
@@ -1370,7 +1379,7 @@ echo 2;
 DJOT;
 
         $html = $converter->convert($djot);
-        $back = trim($this->converter->convert($html));
+        $back = trim($this->trustedConverter->convert($html));
 
         $this->assertSame(trim($djot), $back);
     }
@@ -1397,7 +1406,7 @@ Text with *bold*, _em_, `code`, ![alt](img.png), and [link](https://example.com)
 DJOT;
 
         $html = $converter->convert($djot);
-        $back = trim($this->converter->convert($html));
+        $back = trim($this->trustedConverter->convert($html));
 
         $this->assertSame(trim($djot), $back);
     }
@@ -1427,7 +1436,7 @@ echo 2;
 DJOT;
 
         $html = $converter->convert($djot);
-        $back = trim($this->converter->convert($html));
+        $back = trim($this->trustedConverter->convert($html));
 
         $this->assertSame(trim($djot), $back);
     }
@@ -1450,7 +1459,7 @@ DJOT;
 DJOT;
 
         $html = $converter->convert($djot);
-        $back = trim($this->converter->convert($html));
+        $back = trim($this->trustedConverter->convert($html));
 
         $this->assertSame(trim($djot), $back);
     }
@@ -1474,7 +1483,7 @@ $x = 1;
 DJOT;
 
         $html = $converter->convert($djot);
-        $back = trim($this->converter->convert($html));
+        $back = trim($this->trustedConverter->convert($html));
 
         $this->assertSame(trim($djot), $back);
     }
@@ -1496,7 +1505,7 @@ DJOT;
 DJOT;
 
         $html = $converter->convert($djot);
-        $back = trim($this->converter->convert($html));
+        $back = trim($this->trustedConverter->convert($html));
 
         $this->assertSame(trim($djot), $back);
     }
@@ -1518,7 +1527,7 @@ DJOT;
 DJOT;
 
         $html = $converter->convert($djot);
-        $back = trim($this->converter->convert($html));
+        $back = trim($this->trustedConverter->convert($html));
 
         $this->assertSame(trim($djot), $back);
     }
@@ -1541,7 +1550,7 @@ DJOT;
 DJOT;
 
         $html = $converter->convert($djot);
-        $back = trim($this->converter->convert($html));
+        $back = trim($this->trustedConverter->convert($html));
 
         $this->assertSame(trim($djot), $back);
     }
@@ -1564,7 +1573,7 @@ DJOT;
 DJOT;
 
         $html = $converter->convert($djot);
-        $back = trim($this->converter->convert($html));
+        $back = trim($this->trustedConverter->convert($html));
 
         $expected = <<<'DJOT'
 :::: tabs
@@ -1599,7 +1608,7 @@ Nested content
 DJOT;
 
         $html = $converter->convert($djot);
-        $back = trim($this->converter->convert($html));
+        $back = trim($this->trustedConverter->convert($html));
 
         $this->assertSame(trim($djot), $back);
     }
@@ -1607,7 +1616,7 @@ DJOT;
     public function testGenericDivRoundTripUsesDjotSrc(): void
     {
         $html = '<div class="box note" id="callout" data-x="1"><p>Inside</p></div>';
-        $back = trim($this->converter->convert($html));
+        $back = trim($this->trustedConverter->convert($html));
 
         $expected = <<<'DJOT'
 {#callout .note data-x=1}
@@ -1622,7 +1631,7 @@ DJOT;
     public function testTableAlignmentRoundTripWithoutDjotSrcUsesCellAlignment(): void
     {
         $html = '<table data-djot-col-widths="5,6"><tr><th style="text-align: left;">Left</th><th style="text-align: right;">Right</th></tr><tr><td style="text-align: left;">a</td><td style="text-align: right;">b</td></tr></table>';
-        $back = trim($this->converter->convert($html));
+        $back = trim($this->trustedConverter->convert($html));
 
         $expected = <<<'DJOT'
 | Left | Right |

--- a/tests/TestCase/Renderer/AbbreviationBudgetTest.php
+++ b/tests/TestCase/Renderer/AbbreviationBudgetTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Test\TestCase\Renderer;
+
+use Djot\DjotConverter;
+use Djot\Renderer\MarkdownRenderer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Abbreviation expansion is an output-amplification DoS vector: a tiny source
+ * `*[HT]: <huge>` with many `HT` occurrences expands to
+ * `definition_len * occurrence_count` bytes. A per-render byte budget bounds the
+ * cumulative expansion; once it is exceeded, further occurrences degrade to
+ * plain key text (no `<abbr>` wrapper, no title). Normal documents stay
+ * byte-identical because the budget sits far above any real document.
+ */
+class AbbreviationBudgetTest extends TestCase
+{
+    protected DjotConverter $converter;
+
+    protected function setUp(): void
+    {
+        $this->converter = new DjotConverter();
+    }
+
+    public function testNormalDocumentExpandsEveryOccurrence(): void
+    {
+        $djot = "HTML and HTML again.\n\n*[HTML]: HyperText Markup Language";
+
+        $result = $this->converter->convert($djot);
+
+        // Both occurrences expand normally; the budget never bites.
+        $this->assertSame(2, substr_count($result, '<abbr title="HyperText Markup Language">'));
+    }
+
+    public function testAmplificationIsBounded(): void
+    {
+        $definition = str_repeat('A', 100000); // 100 KB definition
+        $occurrences = 40;
+        $djot = str_repeat('HT ', $occurrences) . "\n\n*[HT]: " . $definition;
+
+        $result = $this->converter->convert($djot);
+
+        $expanded = substr_count($result, '<abbr');
+
+        // Some early occurrences expand, but not all: the budget forces the
+        // tail to degrade to plain key text.
+        $this->assertGreaterThan(0, $expanded);
+        $this->assertLessThan($occurrences, $expanded);
+
+        // Output stays far below the naive definition_len * occurrence_count
+        // amplification (4 MB here); the budget caps it near ~1 MB.
+        $this->assertLessThan($occurrences * strlen($definition), strlen($result));
+
+        // A degraded occurrence renders as the bare key with no title.
+        $this->assertStringContainsString('HT', $result);
+    }
+
+    public function testMarkdownDegradedKeyIsNotHtmlEscaped(): void
+    {
+        // A budget-degraded abbreviation in the Markdown renderer must emit the
+        // key as ordinary Markdown text. A `&` in the key must stay literal, not
+        // become `&amp;` (which is only correct inside the raw <abbr> element).
+        $definition = str_repeat('A', 100000);
+        $djot = str_repeat('A&B ', 40) . "\n\n*[A&B]: " . $definition;
+
+        $converter = new DjotConverter(renderer: new MarkdownRenderer());
+        $result = $converter->convert($djot);
+
+        // At least one occurrence degraded to the literal key text.
+        $this->assertStringContainsString('A&B', $result);
+    }
+
+    public function testBudgetResetsBetweenRenders(): void
+    {
+        $definition = str_repeat('B', 100000);
+        $djot = str_repeat('HT ', 40) . "\n\n*[HT]: " . $definition;
+
+        $first = $this->converter->convert($djot);
+        $second = $this->converter->convert($djot);
+
+        // A second render must not inherit the first render's spent budget.
+        $this->assertSame(substr_count($first, '<abbr'), substr_count($second, '<abbr'));
+    }
+}

--- a/tests/TestCase/RoundTripTest.php
+++ b/tests/TestCase/RoundTripTest.php
@@ -31,7 +31,9 @@ class RoundTripTest extends TestCase
         $this->converter->addExtension(new TabsExtension());
         $this->converter->addExtension(new MermaidExtension());
         $this->converter->addExtension(new AdmonitionExtension());
-        $this->htmlToDjot = new HtmlToDjot();
+        // The round-trip harness consumes djot-produced (trusted) HTML, so it
+        // must honor the data-djot-src / data-djot-raw round-trip attributes.
+        $this->htmlToDjot = new HtmlToDjot(trustedRoundTrip: true);
     }
 
     /**


### PR DESCRIPTION
Ports two confirmed hardening fixes from the downstream carve-php fork, on top of the prior always-on attribute/URL hardening baseline. Both code paths in djot-php were verified to match the fixed carve vulnerabilities 1:1.

## 1. HtmlToDjot round-trip injection

`HtmlToDjot` re-emitted the round-trip attributes `data-djot-src` (block, via `extractRoundTripSource()`) and `data-djot-raw` (inline, via `processRawInline()`) **verbatim as raw Djot**. These attributes carry literal Djot source, so untrusted HTML could set e.g.

```html
<pre data-djot-src="`&lt;script&gt;...&lt;/script&gt;`{=html}">x</pre>
```

and have a raw-HTML block (`` `...`{=html} ``) injected into the converted output, becoming live markup once rendered. The reverse converter is explicitly not a sanitizer, but silently honoring an attacker-controlled attribute as raw output is an injection sink.

**Change**

- Both round-trip attributes are now **ignored by default**. Honoring them is opt-in via `new HtmlToDjot(trustedRoundTrip: true)`, intended only for trusted, djot-produced HTML (faithful round-trips).
- The trust flag is propagated through the recursive inline-fragment sub-conversion.
- The internal `TabsExtension` round-trip generators, which consume djot's own rendered HTML, use the trusted converter, so existing round-trip fidelity is preserved.
- Untrusted input degrades safely: a `data-djot-src` block renders normally, a `data-djot-raw` span falls through to ordinary span processing (the `data-djot-*` attribute is already dropped by `getElementAttributes`).

This is the importer follow-up that the prior always-on hardening change deferred.

## 2. Abbreviation output-amplification DoS

Each abbreviation occurrence re-emitted its full definition (the `<abbr title>` in HTML, the inline `<abbr>` in Markdown, the `(definition)` suffix in ANSI). A tiny source such as `*[HT]: <50 KB of text>` followed by many `HT` occurrences expanded to `definition_len * occurrence_count` bytes (hundreds of MB), a RAM-exhaustion DoS.

**Change**

- A per-render byte budget, `max(1MB, 8 * sourceLength)`, bounds the cumulative abbreviation expansion across the HTML, Markdown and ANSI renderers (new `AbbreviationBudgetTrait`). Once the budget would be exceeded, that occurrence and every later one degrade to plain key text (no `<abbr>` wrapper, no title). The budget sits far above any real document, so normal output is unchanged.
- `Document` now carries the parsed source byte length (`getSourceLength()` / `setSourceLength()`), set in `DjotConverter::parse()`. Documents built directly default to 0, which falls back to the 1MB floor.
- The Markdown degraded fallback returns the children as ordinary Markdown text rather than the HTML-escaped string used inside `<abbr>`, so a `&` / `<` in a degraded key stays literal.

## Compatibility

- The importer change shifts the **default** import behavior: round-trip raw attributes from untrusted HTML are no longer honored. Callers that round-trip djot's own output opt in with `trustedRoundTrip: true`. Existing round-trip-fidelity tests were updated to use the trusted converter explicitly.
- The abbreviation budget is far above any real document, so normal rendering output is byte-identical.

## Tests

New `HtmlToDjotRoundTripSecurityTest` and `AbbreviationBudgetTest` cover both default-ignore / opt-in trust and the expansion bound (including the Markdown degraded-escaping case).
