### PR TITLE
Deduplicate extension-generated ids against the document id namespace

### DIFF
--- a/docs/extensions/index.md
+++ b/docs/extensions/index.md
@@ -1418,6 +1418,12 @@ Note: Use 4 colons (`::::`) for the outer `tabs` wrapper and 3 colons (`:::`) fo
 | `radioClass` | `string` | `'tabs-radio'` | CSS class for radio inputs (CSS mode only) |
 | `idPrefix` | `string` | `'tabset'` | Prefix for generated IDs |
 
+Generated ids (`tabset-1`, `tabset-1-tab-1`, ...) are deduplicated against the
+document id namespace: when an explicit `{#id}` attribute or a generated
+heading id already uses a name, the tab set takes the next free suffix
+(`tabset-1-1`) instead of emitting a duplicate DOM id. The same applies to
+`CodeGroupExtension` group ids.
+
 ### CSS-Only Mode
 
 Uses radio inputs and CSS sibling selectors. No JavaScript required.

--- a/src/Extension/CodeGroupExtension.php
+++ b/src/Extension/CodeGroupExtension.php
@@ -216,7 +216,8 @@ class CodeGroupExtension implements ResettableExtensionInterface
     protected function renderCodeGroup(Div $wrapper, array $codeBlocks, HtmlRenderer $renderer): string
     {
         $this->groupCounter++;
-        $groupId = $this->idPrefix . '-' . $this->groupCounter;
+        $tracker = $renderer->getHeadingIdTracker();
+        $groupId = $tracker->uniqueId($this->idPrefix . '-' . $this->groupCounter);
 
         // Build wrapper attributes
         $attrs = $this->buildWrapperAttributes($wrapper);
@@ -232,7 +233,7 @@ class CodeGroupExtension implements ResettableExtensionInterface
         // Render all radio inputs and labels first
         foreach ($codeBlocks as $index => $item) {
             $tabNum = $index + 1;
-            $inputId = $groupId . '-tab-' . $tabNum;
+            $inputId = $tracker->uniqueId($groupId . '-tab-' . $tabNum);
             $checked = $item['selected'] ? ' checked' : '';
 
             $html .= '<input type="radio" name="' . StringUtil::escapeHtml($groupId) . '" ';

--- a/src/Extension/TabsExtension.php
+++ b/src/Extension/TabsExtension.php
@@ -373,7 +373,8 @@ class TabsExtension implements ResettableExtensionInterface
     protected function renderCssTabs(Div $wrapper, array $tabs, HtmlRenderer $renderer): string
     {
         $this->tabSetCounter++;
-        $setId = $this->idPrefix . '-' . $this->tabSetCounter;
+        $tracker = $renderer->getHeadingIdTracker();
+        $setId = $tracker->uniqueId($this->idPrefix . '-' . $this->tabSetCounter);
 
         // Build wrapper attributes
         $attrs = $this->buildWrapperAttributes($wrapper);
@@ -389,7 +390,7 @@ class TabsExtension implements ResettableExtensionInterface
         // Render all radio inputs and labels first
         foreach ($tabs as $index => $tab) {
             $tabNum = $index + 1;
-            $inputId = $tab['id'] ?? ($setId . '-tab-' . $tabNum);
+            $inputId = $tab['id'] ?? $tracker->uniqueId($setId . '-tab-' . $tabNum);
             $checked = $tab['selected'] ? ' checked' : '';
 
             $html .= '<input type="radio" name="' . StringUtil::escapeHtml($setId) . '" ';
@@ -424,7 +425,8 @@ class TabsExtension implements ResettableExtensionInterface
     protected function renderAriaTabs(Div $wrapper, array $tabs, HtmlRenderer $renderer): string
     {
         $this->tabSetCounter++;
-        $setId = $this->idPrefix . '-' . $this->tabSetCounter;
+        $tracker = $renderer->getHeadingIdTracker();
+        $setId = $tracker->uniqueId($this->idPrefix . '-' . $this->tabSetCounter);
 
         // Build wrapper attributes with tablist role
         $attrs = $this->buildWrapperAttributes($wrapper, 'tablist');
@@ -437,11 +439,19 @@ class TabsExtension implements ResettableExtensionInterface
 
         $html = '<div' . $attrs . ">\n";
 
-        // Render all tab buttons first
+        $tabIds = [];
         foreach ($tabs as $index => $tab) {
             $tabNum = $index + 1;
-            $tabId = $tab['id'] ? StringUtil::escapeHtml($tab['id']) . '-tab' : $setId . '-tab-' . $tabNum;
-            $panelId = $tab['id'] ? StringUtil::escapeHtml($tab['id']) . '-panel' : $setId . '-panel-' . $tabNum;
+            $tabIds[$index] = [
+                'tab' => $tab['id'] ? StringUtil::escapeHtml($tab['id']) . '-tab' : $tracker->uniqueId($setId . '-tab-' . $tabNum),
+                'panel' => $tab['id'] ? StringUtil::escapeHtml($tab['id']) . '-panel' : $tracker->uniqueId($setId . '-panel-' . $tabNum),
+            ];
+        }
+
+        // Render all tab buttons first
+        foreach ($tabs as $index => $tab) {
+            $tabId = $tabIds[$index]['tab'];
+            $panelId = $tabIds[$index]['panel'];
             $selected = $tab['selected'] ? 'true' : 'false';
             $tabindex = $tab['selected'] ? '' : ' tabindex="-1"';
 
@@ -455,9 +465,8 @@ class TabsExtension implements ResettableExtensionInterface
 
         // Render all tab panels
         foreach ($tabs as $index => $tab) {
-            $tabNum = $index + 1;
-            $tabId = $tab['id'] ? StringUtil::escapeHtml($tab['id']) . '-tab' : $setId . '-tab-' . $tabNum;
-            $panelId = $tab['id'] ? StringUtil::escapeHtml($tab['id']) . '-panel' : $setId . '-panel-' . $tabNum;
+            $tabId = $tabIds[$index]['tab'];
+            $panelId = $tabIds[$index]['panel'];
             $hidden = $tab['selected'] ? '' : ' hidden';
 
             $html .= '<div role="tabpanel" id="' . $panelId . '" ';

--- a/src/Renderer/HeadingIdTracker.php
+++ b/src/Renderer/HeadingIdTracker.php
@@ -325,6 +325,28 @@ class HeadingIdTracker
         }
 
         // Track and deduplicate
+        return $this->dedupe($baseId);
+    }
+
+    /**
+     * Reserve a unique id in the document id namespace.
+     *
+     * Returns $baseId when free, otherwise the next free numeric suffix
+     * ($baseId-1, -2, ...), skipping candidates already reserved by explicit
+     * attributes or previously generated ids. Used by extensions (tabs,
+     * code groups) so their generated DOM ids never duplicate an explicit
+     * `{#id}` attribute or a generated heading id.
+     */
+    public function uniqueId(string $baseId): string
+    {
+        return $this->dedupe($baseId);
+    }
+
+    /**
+     * Reserve $baseId when free, otherwise take the next free suffix.
+     */
+    protected function dedupe(string $baseId): string
+    {
         if (!isset($this->usedIds[$baseId])) {
             $this->usedIds[$baseId] = 0;
 

--- a/tests/TestCase/Extension/CodeGroupExtensionTest.php
+++ b/tests/TestCase/Extension/CodeGroupExtensionTest.php
@@ -95,6 +95,29 @@ DJOT;
         $this->assertStringNotContainsString('id="codegroup-1-tab-2" class="code-group-radio" checked', $html);
     }
 
+    public function testGeneratedIdsAvoidExplicitIds(): void
+    {
+        $converter = new DjotConverter();
+        $converter->addExtension(new CodeGroupExtension());
+
+        $djot = <<<'DJOT'
+{#codegroup-1}
+Reserved.
+
+::: code-group
+``` php
+echo "Hello";
+```
+:::
+DJOT;
+
+        $html = $converter->convert($djot);
+
+        $this->assertStringContainsString('name="codegroup-1-1"', $html);
+        $this->assertStringContainsString('id="codegroup-1-1-tab-1"', $html);
+        $this->assertStringContainsString('for="codegroup-1-1-tab-1"', $html);
+    }
+
     public function testLabelOnlyNoLanguage(): void
     {
         $converter = new DjotConverter();

--- a/tests/TestCase/Extension/TabsExtensionTest.php
+++ b/tests/TestCase/Extension/TabsExtensionTest.php
@@ -75,6 +75,31 @@ DJOT;
         $this->assertStringNotContainsString('id="tabset-1-tab-2" class="tabs-radio" checked', $html);
     }
 
+    public function testGeneratedCssIdsAvoidExplicitIds(): void
+    {
+        $converter = new DjotConverter();
+        $converter->addExtension(new TabsExtension());
+
+        $djot = <<<'DJOT'
+{#tabset-1}
+Reserved.
+
+:::: tabs
+::: tab
+### First
+
+Content.
+:::
+::::
+DJOT;
+
+        $html = $converter->convert($djot);
+
+        $this->assertStringContainsString('name="tabset-1-1"', $html);
+        $this->assertStringContainsString('id="tabset-1-1-tab-1"', $html);
+        $this->assertStringContainsString('for="tabset-1-1-tab-1"', $html);
+    }
+
     public function testExplicitSelectedTab(): void
     {
         $converter = new DjotConverter();
@@ -251,6 +276,36 @@ DJOT;
         $this->assertStringContainsString('aria-labelledby=', $html);
         $this->assertStringContainsString('<button', $html);
         $this->assertStringNotContainsString('type="radio"', $html);
+    }
+
+    public function testGeneratedAriaIdsAvoidExplicitIdsAndKeepPairsAligned(): void
+    {
+        $converter = new DjotConverter();
+        $converter->addExtension(new TabsExtension(mode: 'aria'));
+
+        $djot = <<<'DJOT'
+{#tabset-1}
+Reserved.
+
+:::: tabs
+::: tab
+### First
+
+Content.
+:::
+::::
+DJOT;
+
+        $html = $converter->convert($djot);
+
+        $this->assertStringContainsString(
+            'id="tabset-1-1-tab-1" aria-selected="true" aria-controls="tabset-1-1-panel-1"',
+            $html,
+        );
+        $this->assertStringContainsString(
+            'id="tabset-1-1-panel-1" aria-labelledby="tabset-1-1-tab-1"',
+            $html,
+        );
     }
 
     public function testAriaHiddenAttribute(): void

--- a/tests/TestCase/Renderer/HeadingIdTrackerTest.php
+++ b/tests/TestCase/Renderer/HeadingIdTrackerTest.php
@@ -55,6 +55,31 @@ class HeadingIdTrackerTest extends TestCase
         $this->assertSame('Final-Thoughts-2', $id3);
     }
 
+    public function testUniqueIdReservesGeneratedIds(): void
+    {
+        $this->assertSame('x', $this->tracker->uniqueId('x'));
+        $this->assertSame('x-1', $this->tracker->uniqueId('x'));
+        $this->assertSame('x-2', $this->tracker->uniqueId('x'));
+    }
+
+    public function testUniqueIdSkipsReservedSuffixCandidate(): void
+    {
+        $this->tracker->trackId('x-1');
+
+        $this->assertSame('x', $this->tracker->uniqueId('x'));
+        $this->assertSame('x-2', $this->tracker->uniqueId('x'));
+    }
+
+    public function testUniqueIdBlocksLaterHeadingAutoId(): void
+    {
+        $this->assertSame('My-Heading', $this->tracker->uniqueId('My-Heading'));
+
+        $heading = new Heading(2);
+        $heading->appendChild(new Text('My Heading'));
+
+        $this->assertSame('My-Heading-1', $this->tracker->getIdForHeading($heading));
+    }
+
     public function testCachingReturnsSameId(): void
     {
         $heading = new Heading(2);


### PR DESCRIPTION
Tabs (`tabset-N`, `tabset-N-tab-M`, `tabset-N-panel-M`) and code groups (the `codegroup-N` family) minted DOM ids from private counters, so an explicit `{#tabset-1}` attribute or a heading auto-slug colliding with a generated name produced duplicate DOM ids with silently wrong resolution (`label for=`, `getElementById`, anchor jumps target the first occurrence).

- `HeadingIdTracker` gains a public `uniqueId()` built on the exact dedupe rules heading auto-ids already use (djot-php's `-1`-first suffix convention preserved).
- TabsExtension and CodeGroupExtension reserve their generated ids through it; ARIA tab/panel id pairs are computed once and reused in both render loops so a bumped id keeps the wiring aligned.
- Ids without collisions are unchanged (existing byte-stability tests still pin `tabset-1-tab-1` etc.).
- CitationsExtension is unaffected: djot-php's design delegates rendering to an external resolver and mints no ids.

Same fix as the carve twin (markup-carve/carve-php PR 287), adapted to djot-php's conventions.