### PR TITLE
security: gate the raw-HTML image fallback in HtmlToDjot (XSS)

### DIFF
--- a/src/Converter/HtmlToDjot.php
+++ b/src/Converter/HtmlToDjot.php
@@ -2540,6 +2540,14 @@ class HtmlToDjot
 
     protected function requiresRawImageFallback(string $alt): bool
     {
+        // The raw-HTML fallback re-emits the original element verbatim (a
+        // `{=html}` block), so untrusted HTML could smuggle live script /
+        // event handlers (`<img onerror=...>`) through it. Only trusted input
+        // may use it; otherwise fall through to safe `![alt](src)` processing.
+        if (!$this->trustedRoundTrip) {
+            return false;
+        }
+
         return strpbrk($alt, '[]\\') !== false;
     }
 

--- a/tests/TestCase/Converter/HtmlToDjotTest.php
+++ b/tests/TestCase/Converter/HtmlToDjotTest.php
@@ -196,7 +196,7 @@ class HtmlToDjotTest extends TestCase
 
     public function testImageWithBracketInAltFallsBackToRawHtml(): void
     {
-        $result = $this->converter->convert('<img src="img.png" alt="a [ b">');
+        $result = $this->trustedConverter->convert('<img src="img.png" alt="a [ b">');
 
         $this->assertSame("`<img src=\"img.png\" alt=\"a [ b\">`{=html}\n", $result);
         $htmlBack = (new DjotConverter())->convert($result);
@@ -205,7 +205,7 @@ class HtmlToDjotTest extends TestCase
 
     public function testImageWithBackslashInAltFallsBackToRawHtml(): void
     {
-        $result = $this->converter->convert('<img src="img.png" alt="a \\ b">');
+        $result = $this->trustedConverter->convert('<img src="img.png" alt="a \\ b">');
 
         $this->assertSame("`<img src=\"img.png\" alt=\"a \ b\">`{=html}\n", $result);
         $htmlBack = (new DjotConverter())->convert($result);
@@ -214,7 +214,7 @@ class HtmlToDjotTest extends TestCase
 
     public function testLinkWrappingProblematicImageFallsBackToRawHtml(): void
     {
-        $result = $this->converter->convert('<a href="https://example.com"><img src="img.png" alt="a [ b"></a>');
+        $result = $this->trustedConverter->convert('<a href="https://example.com"><img src="img.png" alt="a [ b"></a>');
 
         $this->assertSame("`<a href=\"https://example.com\"><img src=\"img.png\" alt=\"a [ b\"></a>`{=html}\n", $result);
         $htmlBack = (new DjotConverter())->convert($result);
@@ -223,10 +223,29 @@ class HtmlToDjotTest extends TestCase
 
     public function testRawImageFallbackStripsDjotMetadata(): void
     {
-        $result = $this->converter->convert('<img src="img.png" alt="a [ b" data-djot-ref="">');
+        $result = $this->trustedConverter->convert('<img src="img.png" alt="a [ b" data-djot-ref="">');
 
         $this->assertSame("`<img src=\"img.png\" alt=\"a [ b\">`{=html}\n", $result);
         $this->assertStringNotContainsString('data-djot-ref', $result);
+    }
+
+    public function testUntrustedRawImageFallbackIsSafe(): void
+    {
+        // The raw-HTML fallback (brackets/backslash in alt) must NOT emit raw
+        // HTML for untrusted input, and a hostile onerror must not survive the
+        // round-trip to live HTML.
+        $result = $this->converter->convert('<img src=x onerror=alert(1) alt="[evil]">');
+        $this->assertStringNotContainsString('{=html}', $result);
+        $htmlBack = (new DjotConverter())->convert($result);
+        $this->assertStringNotContainsString('onerror', $htmlBack);
+    }
+
+    public function testUntrustedLinkWrappedRawImageIsSafe(): void
+    {
+        $result = $this->converter->convert('<a href="/x"><img src=y onerror=alert(1) alt="[a]"></a>');
+        $this->assertStringNotContainsString('{=html}', $result);
+        $htmlBack = (new DjotConverter())->convert($result);
+        $this->assertStringNotContainsString('onerror', $htmlBack);
     }
 
     // ==================== Code ====================


### PR DESCRIPTION
A **default-reachable XSS** in the `HtmlToDjot` reverse converter, found by a security audit (same class as the carve-php `HtmlToCarve` fix).

The image/link raw-HTML fallback (triggered when an img `alt` contains `[`, `]`, or `\`) re-emitted the whole element verbatim as a `{=html}` block, including live event handlers. `<img src=x onerror=alert(1) alt="[evil]">` round-tripped to a live `onerror` with only `new HtmlToDjot()` (untrusted, the default) plus a default render.

Now the fallback is honored **only** when `trustedRoundTrip` is set; untrusted input falls back to safe `![alt](src)` processing (whose attributes the renderer's sanitizer already neutralizes). The `data-djot-raw` span path was already gated. Round-trip-fidelity tests moved to the trusted converter; **2 untrusted-safe security tests added**.

Full suite (2692), phpstan, phpcs green.
