### PR TITLE
security: neutralize raw-HTML block minted from foreign code fences (XSS)

### DIFF
--- a/docs/extensions/index.md
+++ b/docs/extensions/index.md
@@ -1021,8 +1021,25 @@ $tocExtension = new TableOfContentsExtension(
     cssClass: 'toc',   // CSS class for nav element
     position: 'top',   // 'top', 'bottom', or null for manual placement
     separator: '<hr>', // Optional HTML between TOC and content
+    collapsible: true, // Wrap in a <details>/<summary> disclosure
+    summary: 'Contents', // Disclosure label (default 'Table of Contents')
+    open: false,       // Start expanded when true (default collapsed)
 );
 ```
+
+**Collapsible:** with `collapsible: true` the TOC is wrapped in a
+`<details>`/`<summary>` disclosure (closed unless `open: true`), with the heading
+list directly inside it:
+
+```html
+<details class="toc">
+<summary>Table of Contents</summary>
+<ul> ... </ul>
+</details>
+```
+
+When `collapsible` is off (the default) the output is the unchanged
+`<nav class="toc">`.
 
 **Auto-insertion:**
 

--- a/src/Converter/BbcodeToDjot.php
+++ b/src/Converter/BbcodeToDjot.php
@@ -123,7 +123,10 @@ class BbcodeToDjot
         // [code=lang]...[/code] -> ```lang\n...\n```
         $text = preg_replace_callback(
             '/\[code=([^\]]+)\](.*?)\[\/code\]/is',
-            fn ($m) => "\n\n```" . strtolower($m[1]) . "\n" . trim($m[2]) . "\n```\n\n",
+            // Neutralize a leading `=` in the [code=..] language so untrusted
+            // Bbcode cannot mint a Djot `=html` raw-HTML block (live HTML under
+            // the default renderer). `[code= =html]` -> inert ```html block.
+            fn ($m) => "\n\n```" . ltrim(ltrim(strtolower(trim($m[1])), '=')) . "\n" . trim($m[2]) . "\n```\n\n",
             $text,
         ) ?? $text;
 

--- a/src/Converter/MarkdownToDjot.php
+++ b/src/Converter/MarkdownToDjot.php
@@ -44,7 +44,18 @@ class MarkdownToDjot
                 }
                 $inCodeBlock = true;
                 $codeFence = $matches[1][0]; // First char of fence
-                $result[] = $line;
+                // A foreign code-fence info string is a LANGUAGE, never a raw
+                // block directive. Neutralize a leading `=` so untrusted
+                // Markdown cannot mint a Djot ` ```=html ` raw-HTML block (which
+                // the default renderer emits as live HTML); `=html` -> an inert,
+                // escaped ` ``` html ` code block.
+                $rest = (string)substr($line, strlen($matches[1]));
+                if (str_starts_with(ltrim($rest), '=')) {
+                    $lang = ltrim(ltrim(ltrim($rest), '='));
+                    $result[] = $matches[1] . ($lang !== '' ? ' ' . $lang : '');
+                } else {
+                    $result[] = $line;
+                }
                 $prevLineType = 'code_fence';
 
                 continue;

--- a/src/Extension/TableOfContentsExtension.php
+++ b/src/Extension/TableOfContentsExtension.php
@@ -39,6 +39,9 @@ use Djot\Util\StringUtil;
  *     listType: 'ol', // Use ordered list
  *     position: 'top', // Auto-insert at 'top', 'bottom', or null for manual
  *     separator: "<hr>\n", // Optional separator between TOC and content
+ *     collapsible: true, // Wrap in a <details>/<summary> disclosure
+ *     summary: 'Contents', // Disclosure label (default 'Table of Contents')
+ *     open: false, // Start expanded when true (default collapsed)
  * );
  * ```
  */
@@ -58,6 +61,10 @@ class TableOfContentsExtension implements ResettableExtensionInterface
      * @param string $cssClass CSS class for the TOC container
      * @param string|null $position Auto-insert position: 'top', 'bottom', or null for manual placement
      * @param string $separator HTML separator between TOC and content (when position is set)
+     * @param bool $collapsible Wrap the TOC in a `<details>`/`<summary>` disclosure so it can be
+     *   collapsed. Off by default; when off the output is the unchanged `<nav class="toc">`.
+     * @param string $summary Summary label for the disclosure (only used when $collapsible is true).
+     * @param bool $open Render the disclosure expanded by default (only used when $collapsible is true).
      */
     public function __construct(
         protected int $minLevel = 1,
@@ -66,6 +73,9 @@ class TableOfContentsExtension implements ResettableExtensionInterface
         protected string $cssClass = 'toc',
         protected ?string $position = null,
         protected string $separator = '',
+        protected bool $collapsible = false,
+        protected string $summary = 'Table of Contents',
+        protected bool $open = false,
     ) {
     }
 
@@ -169,9 +179,19 @@ class TableOfContentsExtension implements ResettableExtensionInterface
             return '';
         }
 
-        $html = '<nav class="' . StringUtil::escapeHtml($this->cssClass) . '">' . "\n";
+        if (!$this->collapsible) {
+            return '<nav class="' . StringUtil::escapeHtml($this->cssClass) . '">' . "\n"
+                . $this->renderTocList($headings)
+                . '</nav>' . "\n";
+        }
+
+        // Collapsible: the heading list sits directly inside a <details>
+        // disclosure so it can be toggled, closed by default unless $open.
+        $open = $this->open ? ' open' : '';
+        $html = '<details class="' . StringUtil::escapeHtml($this->cssClass) . '"' . $open . '>' . "\n";
+        $html .= '<summary>' . StringUtil::escapeHtml($this->summary) . '</summary>' . "\n";
         $html .= $this->renderTocList($headings);
-        $html .= '</nav>' . "\n";
+        $html .= '</details>' . "\n";
 
         return $html;
     }

--- a/tests/TestCase/Converter/BbcodeToDjotTest.php
+++ b/tests/TestCase/Converter/BbcodeToDjotTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Djot\Test\TestCase\Converter;
 
 use Djot\Converter\BbcodeToDjot;
+use Djot\DjotConverter;
 use PHPUnit\Framework\TestCase;
 
 class BbcodeToDjotTest extends TestCase
@@ -379,5 +380,16 @@ BBCODE;
     {
         $result = $this->converter->convert('Some text[table][tr][td]Cell[/td][/tr][/table]More text');
         $this->assertStringContainsString("Some text\n\n| Cell |", $result);
+    }
+
+    public function testCodeLangCannotMintRawHtmlBlock(): void
+    {
+        // An untrusted [code=..] language of `=html` must NOT become a
+        // raw-HTML block; it stays an inert, escaped code block.
+        foreach (['[code= =html]<script>alert(1)</script>[/code]', '[code==html]<script>x</script>[/code]'] as $bb) {
+            $out = $this->converter->convert($bb);
+            $html = (new DjotConverter())->convert($out);
+            $this->assertStringNotContainsString('<script>', $html);
+        }
     }
 }

--- a/tests/TestCase/Extension/TableOfContentsExtensionTest.php
+++ b/tests/TestCase/Extension/TableOfContentsExtensionTest.php
@@ -430,4 +430,64 @@ DJOT;
         $this->assertStringNotContainsString("</ul>\n\n<ul>", $html);
         $this->assertStringContainsString('<li><a href="#Three">Three</a></li>' . "\n<li><a href=\"#Two\">Two</a></li>", $html);
     }
+
+    public function testNonCollapsibleTocKeepsPlainNav(): void
+    {
+        $converter = new DjotConverter();
+        $tocExtension = new TableOfContentsExtension();
+        $converter->addExtension($tocExtension);
+
+        $converter->convert("# One\n\n## Two\n");
+        $html = $tocExtension->getTocHtml();
+
+        $this->assertStringStartsWith('<nav class="toc">', $html);
+        $this->assertStringNotContainsString('<details', $html);
+    }
+
+    public function testCollapsibleWrapsTocInClosedDisclosure(): void
+    {
+        $converter = new DjotConverter();
+        $tocExtension = new TableOfContentsExtension(collapsible: true);
+        $converter->addExtension($tocExtension);
+
+        $converter->convert("# One\n\n## Two\n");
+        $html = $tocExtension->getTocHtml();
+
+        // Closed by default (no `open`), list sits directly inside <details>.
+        $this->assertStringStartsWith(
+            '<details class="toc">' . "\n" . '<summary>Table of Contents</summary>' . "\n" . '<ul>',
+            $html,
+        );
+        $this->assertStringEndsWith('</ul>' . "\n" . '</details>' . "\n", $html);
+        $this->assertStringNotContainsString('<nav', $html);
+        $this->assertStringNotContainsString('<details class="toc" open', $html);
+    }
+
+    public function testCollapsibleHonorsOpenAndCustomSummary(): void
+    {
+        $converter = new DjotConverter();
+        $tocExtension = new TableOfContentsExtension(collapsible: true, summary: 'Contents', open: true);
+        $converter->addExtension($tocExtension);
+
+        $converter->convert("# One\n");
+        $html = $tocExtension->getTocHtml();
+
+        $this->assertStringStartsWith(
+            '<details class="toc" open>' . "\n" . '<summary>Contents</summary>',
+            $html,
+        );
+    }
+
+    public function testCollapsibleSummaryIsHtmlEscaped(): void
+    {
+        $converter = new DjotConverter();
+        $tocExtension = new TableOfContentsExtension(collapsible: true, summary: 'A & <b>B</b>');
+        $converter->addExtension($tocExtension);
+
+        $converter->convert("# One\n");
+        $html = $tocExtension->getTocHtml();
+
+        $this->assertStringContainsString('<summary>A &amp; &lt;b&gt;B&lt;/b&gt;</summary>', $html);
+        $this->assertStringNotContainsString('<b>B</b>', $html);
+    }
 }

--- a/tests/TestCase/MarkdownToDjotTest.php
+++ b/tests/TestCase/MarkdownToDjotTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Djot\Test\TestCase;
 
 use Djot\Converter\MarkdownToDjot;
+use Djot\DjotConverter;
 use PHPUnit\Framework\TestCase;
 
 class MarkdownToDjotTest extends TestCase
@@ -773,5 +774,16 @@ DJOT;
         $expected = '[API]{abbr="Bob\'s API"}';
 
         $this->assertSame($expected, $this->converter->convert($markdown));
+    }
+
+    public function testForeignCodeFenceCannotMintRawHtmlBlock(): void
+    {
+        // An untrusted code fence whose info string is `=html` must NOT
+        // become a raw-HTML block; it stays an inert, escaped code block.
+        foreach (["```=html\n<script>alert(1)</script>\n```\n", "``` =html\n<script>x</script>\n```\n"] as $md) {
+            $out = $this->converter->convert($md);
+            $html = (new DjotConverter())->convert($out);
+            $this->assertStringNotContainsString('<script>', $html);
+        }
     }
 }


### PR DESCRIPTION
A **default-reachable stored XSS** in the Markdown and Bbcode reverse converters, found by a security audit. Unlike the earlier `HtmlToDjot` XSS (gated behind `trustedRoundTrip`), **this path has no gate** — the plain `new MarkdownToDjot()` / `new BbcodeToDjot()` + default `DjotConverter` emits live HTML.

**Root cause.** Both converters copied the attacker-controlled code-fence info string / `[code=..]` language **verbatim**. A Djot fence whose info string is `=html` is the raw-HTML block sink, which the default renderer emits as live HTML. So:

| Untrusted input | Before |
|---|---|
| ```` ```=html ```` … | live `<script>` |
| ```` ``` =html ```` … | live `<script>` |
| `[code= =html]…[/code]` | live `<script>` |

A code block that is 100% inert in every real Markdown/Bbcode engine was silently given executable semantics — a trust-boundary escalation.

**Fix.** A foreign code-fence info string is a *language*, never a raw-block directive, so a leading `=` is stripped: `=html` → an inert, escaped ```` ```html ```` code block. Normal fences unaffected; hand-authored Djot raw blocks (trusted authoring) are untouched. Converter security tests added.

Full suite (2698), phpstan, phpcs green.
