### PR TITLE
Match djot.js on five parser edge cases (djot.js PR 137 test corpus)

### DIFF
--- a/src/Parser/Block/ListParser.php
+++ b/src/Parser/Block/ListParser.php
@@ -192,12 +192,12 @@ class ListParser
             ], $matches[2] ?? '');
         }
 
-        // Definition list: :
-        if (preg_match('/^: +(.*)$/', $line, $matches)) {
+        // Definition list: `: term`, or a bare `:` (empty term and definition)
+        if (preg_match('/^:(?: +(.*))?$/', $line, $matches)) {
             return [
                 'type' => ListBlock::TYPE_DEFINITION,
                 'marker' => ':',
-                'content' => $matches[1],
+                'content' => $matches[1] ?? '',
             ];
         }
 

--- a/src/Parser/Block/TableParser.php
+++ b/src/Parser/Block/TableParser.php
@@ -100,16 +100,17 @@ class TableParser
             return false;
         }
 
-        // Every cell must be a delimiter cell: optional whitespace, an optional
-        // leading ':', one or more '-', an optional trailing ':', optional
-        // whitespace. An EMPTY cell (`|---||`) or any other content disqualifies
-        // the row -- it is then an ordinary data row (matches carve-js/carve-rs).
+        // Every cell must be a delimiter cell starting immediately after the
+        // `|`: an optional leading ':', one or more '-', an optional trailing
+        // ':', then optional whitespace. A leading space (`| --- |`), an EMPTY
+        // cell (`|---||`), or any other content disqualifies the row -- it is
+        // then an ordinary data row (matches djot.js pattRowSep).
         $cells = $this->parseTableCells($line);
         if ($cells === []) {
             return false;
         }
         foreach ($cells as $cell) {
-            if (preg_match('/^\s*:?-+:?\s*$/', $cell) !== 1) {
+            if (preg_match('/^:?-+:?[ \t]*$/', $cell) !== 1) {
                 return false;
             }
         }

--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -1156,6 +1156,12 @@ class BlockParser
                 return null;
             }
 
+            // An invalid character anywhere in the spec invalidates it entirely;
+            // the line then renders as literal paragraph text
+            if (!AttributeParser::isValid($attrStr)) {
+                return null;
+            }
+
             // Check if attributes precede a reference definition - if so, skip storing them
             // (they were already applied during extractReferences)
             $count = count($lines);
@@ -1193,6 +1199,9 @@ class BlockParser
                 // Exclude _ * = + - ~ ^ which are braced inline markers (not block attributes)
                 // Exclude % which starts comments (handled by tryParseComment)
                 if (!preg_match('/^[.#a-zA-Z]/', $attrStr) || str_starts_with($attrStr, '%')) {
+                    return null;
+                }
+                if (!AttributeParser::isValid($attrStr)) {
                     return null;
                 }
                 $this->parseAttributeString($attrStr);
@@ -1676,12 +1685,16 @@ class BlockParser
             }
 
             // Check for continuation with # prefix (same level or less) - these continue the heading
-            // e.g., "# Heading\n# more" becomes "Heading\nmore" for a level-1 heading
-            if (preg_match('/^[ ]{0,3}#{1,' . $level . '} +(.+)$/', $nextLine, $contMatch)) {
-                if ($content !== '') {
-                    $content .= "\n";
+            // e.g., "# Heading\n# more" becomes "Heading\nmore" for a level-1 heading.
+            // A bare marker line ("#") continues the heading but contributes no content.
+            if (preg_match('/^[ ]{0,3}#{1,' . $level . '}(?: +(.*))?[ ]*$/', $nextLine, $contMatch)) {
+                $contContent = trim($contMatch[1] ?? '');
+                if ($contContent !== '') {
+                    if ($content !== '') {
+                        $content .= "\n";
+                    }
+                    $content .= $contContent;
                 }
-                $content .= $contMatch[1];
                 $i++;
             } elseif (preg_match('/^[ ]{0,3}#{1,6}(?: |$)/', $nextLine)) {
                 // Different level heading marker (or empty heading) starts a new heading
@@ -2608,8 +2621,9 @@ class BlockParser
                 continue;
             }
 
-            // Must start with ": " (space is syntax delimiter, not tab)
-            if (!preg_match('/^: +(.*)$/', $line, $matches)) {
+            // Must start with ": " (space is syntax delimiter, not tab),
+            // or be a bare ":" (empty term and definition)
+            if (!preg_match('/^:(?: +(.*))?$/', $line, $matches)) {
                 break;
             }
 
@@ -2628,12 +2642,12 @@ class BlockParser
                     continue;
                 }
 
-                // Check if this is a term line
-                if (!preg_match('/^: +(.*)$/', $termLine, $termMatch)) {
+                // Check if this is a term line (bare ":" means empty term)
+                if (!preg_match('/^:(?: +(.*))?$/', $termLine, $termMatch)) {
                     break;
                 }
 
-                $termContent = $termMatch[1];
+                $termContent = $termMatch[1] ?? '';
 
                 // Check for continuation marker `: +` - not a new term, breaks term collection
                 if ($termContent === '+') {
@@ -2757,7 +2771,7 @@ class BlockParser
                 }
 
                 // Check for next term (space is syntax delimiter, not tab)
-                if (preg_match('/^: +/', $defLine)) {
+                if (preg_match('/^:(?: |$)/', $defLine)) {
                     break;
                 }
 
@@ -4024,8 +4038,8 @@ class BlockParser
             return true;
         }
 
-        // Definition list terms (: followed by space or content)
-        if (preg_match('/^: /', $line)) {
+        // Definition list terms (: followed by space, or bare :)
+        if (preg_match('/^:(?: |$)/', $line)) {
             return true;
         }
 

--- a/src/Parser/InlineParser.php
+++ b/src/Parser/InlineParser.php
@@ -286,6 +286,17 @@ class InlineParser
             $char = $text[$pos];
             $nextChar = $text[$pos + 1] ?? '';
 
+            // A backslash at the very end of the content (no following
+            // character) still produces a hard break
+            if ($char === '\\' && $pos + 1 >= $length) {
+                $this->flushText($parent, $textBuffer);
+                $textBuffer = '';
+                $parent->appendChild(new HardBreak());
+                $pos++;
+
+                continue;
+            }
+
             // Check for escape sequences
             if ($char === '\\' && $pos + 1 < $length) {
                 $escaped = $text[$pos + 1];
@@ -1588,6 +1599,12 @@ class InlineParser
             return null;
         }
 
+        // An invalid character anywhere in the spec invalidates it entirely;
+        // the braces then stay literal text
+        if (!AttributeParser::isValid($attrStr)) {
+            return null;
+        }
+
         // Remove comments from attributes: % ... % or % to end
         $attrStr = $this->removeAttributeComments($attrStr);
 
@@ -1894,6 +1911,12 @@ class InlineParser
      */
     protected function isValidAttrPayload(string $attrStr): bool
     {
+        // An invalid character anywhere in the spec invalidates it entirely
+        // (e.g. {#a<b}); the block then stays literal text.
+        if (!AttributeParser::isValid($attrStr)) {
+            return false;
+        }
+
         if (AttributeParser::parse($attrStr) !== []) {
             return true;
         }

--- a/src/Parser/Utility/AttributeParser.php
+++ b/src/Parser/Utility/AttributeParser.php
@@ -96,6 +96,33 @@ class AttributeParser
     }
 
     /**
+     * Check whether an attribute string is a fully valid attribute spec
+     *
+     * Per djot spec, identifiers, class names, keys, and unquoted values may
+     * only contain ASCII alphanumerics, `_`, `:`, and `-`. Any other character
+     * outside a quoted value invalidates the entire spec, which then renders
+     * as literal text.
+     *
+     * @param string $attrStr The attribute string (contents inside {})
+     */
+    public static function isValid(string $attrStr): bool
+    {
+        $stripped = self::removeComments($attrStr);
+
+        $name = '[a-zA-Z0-9_:-]+';
+        $token = '(?:'
+            . '\.' . $name
+            . '|#' . $name
+            . '|' . $name . '="(?:[^"\\\\]|\\\\.)*"'
+            . '|' . $name . "='(?:[^'\\\\]|\\\\.)*'"
+            . '|' . $name . '=' . $name
+            . '|[a-zA-Z][a-zA-Z0-9_-]*'
+            . ')';
+
+        return preg_match('/^\s*(?:' . $token . '(?:\s+' . $token . ')*)?\s*$/', $stripped) === 1;
+    }
+
+    /**
      * Parse attribute string preserving source order
      *
      * @param string $attrStr The attribute string to parse

--- a/tests/TestCase/DjotConverterTest.php
+++ b/tests/TestCase/DjotConverterTest.php
@@ -315,6 +315,19 @@ class DjotConverterTest extends TestCase
         );
     }
 
+    public function testInvalidCharInAttrSpecKeepsBracesLiteral(): void
+    {
+        // An invalid character (like `<`) anywhere in an attribute spec
+        // invalidates the entire spec; the braces stay literal instead of
+        // attaching attributes to the preceding element.
+        $this->assertSame("<p><em>x</em>{#a&lt;b}</p>\n", $this->converter->convert('_x_{#a<b}'));
+        $this->assertSame("<p><a href=\"u\">x</a>{#a&lt;b}</p>\n", $this->converter->convert('[x](u){#a<b}'));
+        $this->assertSame("<p><code>c</code>{#a&lt;b}</p>\n", $this->converter->convert('`c`{#a<b}'));
+        // Bracketed run abutting an invalid block: no span, everything literal
+        // (same convention as {???} above)
+        $this->assertSame("<p>[x]{#a&lt;b}</p>\n", $this->converter->convert('[x]{#a<b}'));
+    }
+
     public function testEmptyAttrBlockStillFormsSpan(): void
     {
         // An empty or whitespace-only block is a valid empty attribute block,

--- a/tests/TestCase/Parser/AttributeParserTest.php
+++ b/tests/TestCase/Parser/AttributeParserTest.php
@@ -270,19 +270,13 @@ class AttributeParserTest extends TestCase
         $this->assertLessThan($titlePos, $classPos, 'class should appear before title');
     }
 
-    public function testInvalidUnquotedValueDoesNotAffectOrder(): void
+    public function testInvalidUnquotedValueInvalidatesWholeSpec(): void
     {
-        // Invalid unquoted value should be skipped, not affect ordering of valid attrs
+        // An invalid unquoted value (dot in foo.bar) invalidates the entire
+        // attribute spec, which then renders as literal text (matches djot.js)
         $result = $this->converter->convert('[text]{.myclass invalid=foo.bar data-x=valid}');
 
-        $classPos = strpos($result, 'class="myclass"');
-        $dataPos = strpos($result, 'data-x="valid"');
-
-        $this->assertNotFalse($classPos);
-        $this->assertNotFalse($dataPos);
-        // invalid=foo.bar should be skipped entirely
-        $this->assertStringNotContainsString('invalid=', $result);
-        $this->assertLessThan($dataPos, $classPos, 'class should appear before data-x');
+        $this->assertSame("<p>[text]{.myclass invalid=foo.bar data-x=valid}</p>\n", $result);
     }
 
     /**

--- a/tests/official/attributes.test
+++ b/tests/official/attributes.test
@@ -245,6 +245,21 @@ hi{}
 <p>hi</p>
 ```
 
+Empty attributes after a span or link are consumed silently and
+no attributes are emitted on the element:
+
+```
+[text]{}
+.
+<p><span>text</span></p>
+```
+
+```
+[link](url){}
+.
+<p><a href="url">link</a></p>
+```
+
 Block attributes can be empty:
 
 ```
@@ -252,6 +267,20 @@ Block attributes can be empty:
 hi
 .
 <p>hi</p>
+```
+
+Identifiers and class names accept only ASCII alphanumerics, `_`,
+`:`, and `-` (the same rule as for unquoted key=value values).
+Any other character invalidates the entire attribute spec, which
+then renders as literal text. This rules out smuggling
+HTML-significant characters like `<` into attribute contexts:
+
+```
+{#a<b}
+foo
+.
+<p>{#a&lt;b}
+foo</p>
 ```
 
 Non-attributes:
@@ -321,4 +350,33 @@ doc
   block_quote
     para key="bar a$bim"
       str text="ou"
+```
+
+Without the indented continuation, the `{% ... %}` is not a valid
+block comment and renders as an ordinary paragraph:
+
+```
+{%
+SPDX-FileCopyrightText: 2025
+%}
+
+Hello.
+.
+<p>{%
+SPDX-FileCopyrightText: 2025
+%}</p>
+<p>Hello.</p>
+```
+
+With indented continuation lines, it parses as a block comment
+and is stripped from the output:
+
+```
+{%
+  SPDX-FileCopyrightText: 2025
+  %}
+
+Hello.
+.
+<p>Hello.</p>
 ```

--- a/tests/official/definition_lists.test
+++ b/tests/official/definition_lists.test
@@ -93,3 +93,34 @@ list
 </dd>
 </dl>
 ````
+
+A bare `:` marker followed by end-of-input produces an empty
+term and empty definition rather than failing or reading past
+the end of the buffer:
+
+```
+:
+.
+<dl>
+<dt></dt>
+<dd>
+</dd>
+</dl>
+```
+
+Block attributes on the line above a definition list attach to
+the `<dl>`:
+
+```
+{variant=Simple}
+: term
+
+  definition
+.
+<dl variant="Simple">
+<dt>term</dt>
+<dd>
+<p>definition</p>
+</dd>
+</dl>
+```

--- a/tests/official/emphasis.test
+++ b/tests/official/emphasis.test
@@ -237,3 +237,26 @@ _<http://example.com/a_b>
 .
 <p>_<a href="http://example.com/a_b">http://example.com/a_b</a></p>
 ```
+
+Inline attributes after the closing delimiter attach to the
+emphasis or strong element rather than wrapping it in a span:
+
+```
+_emph_{.a}
+.
+<p><em class="a">emph</em></p>
+```
+
+```
+*strong*{.a}
+.
+<p><strong class="a">strong</strong></p>
+```
+
+Combined id, class, and key=value attributes on emphasis:
+
+```
+_emph_{#id .cls key=val}
+.
+<p><em id="id" class="cls" key="val">emph</em></p>
+```

--- a/tests/official/escapes.test
+++ b/tests/official/escapes.test
@@ -24,6 +24,16 @@ c
 c</p>
 ```
 
+A backslash immediately before end-of-input still produces a
+hard break, with no following content:
+
+```
+para\
+.
+<p>para<br>
+</p>
+```
+
 There can be spaces and tabs between the backslash and the newline:
 
 ```

--- a/tests/official/fenced_divs.test
+++ b/tests/official/fenced_divs.test
@@ -132,3 +132,15 @@ before a closing fence, the fenced div is implicitly closed.
 </code></pre>
 </div>
 ````
+
+A fenced div containing nothing but a blank line is valid and
+emits an empty `<div>`:
+
+```
+:::
+
+:::
+.
+<div>
+</div>
+```

--- a/tests/official/headings.test
+++ b/tests/official/headings.test
@@ -29,6 +29,21 @@ continued</h1>
 </section>
 ```
 
+A bare `#` heading-marker line in the middle of a heading
+contributes no content; the surrounding marker lines join
+with a single newline:
+
+```
+# h
+#
+# x
+.
+<section id="h-x">
+<h1>h
+x</h1>
+</section>
+```
+
 ```
 ##
 heading

--- a/tests/official/insert_delete_mark.test
+++ b/tests/official/insert_delete_mark.test
@@ -27,3 +27,23 @@ This is {=marked *text*=}.
 .
 <p>This is <mark>marked <strong>text</strong></mark>.</p>
 ```
+
+Inline attributes attach to the ins/del/mark element:
+
+```
+{+ins+}{.a}
+.
+<p><ins class="a">ins</ins></p>
+```
+
+```
+{-del-}{.a}
+.
+<p><del class="a">del</del></p>
+```
+
+```
+{=mark=}{.a}
+.
+<p><mark class="a">mark</mark></p>
+```

--- a/tests/official/links_and_images.test
+++ b/tests/official/links_and_images.test
@@ -137,6 +137,20 @@ Attributes on the link override those on references:
 <p><a href="/url" title="bar">ref</a></p>
 ```
 
+Inline attributes on inline links go on the `<a>` element:
+
+```
+[a](b){rel=me}
+.
+<p><a href="b" rel="me">a</a></p>
+```
+
+```
+[a](b){rel="me"}
+.
+<p><a href="b" rel="me">a</a></p>
+```
+
 ```
 [link _and_ link][]
 
@@ -219,6 +233,42 @@ Autolinks:
 <a href="mailto:me@example.com">me@example.com</a></p>
 ```
 
+A literal `<` or `>` in a link destination must be HTML-escaped
+in the emitted href/src so it can't break out of the attribute
+context. The same applies to backslash-escaped `<`:
+
+```
+[a](http://x.com/<script>)
+.
+<p><a href="http://x.com/&lt;script&gt;">a</a></p>
+```
+
+```
+![alt](/img/<svg)
+.
+<p><img alt="alt" src="/img/&lt;svg"></p>
+```
+
+```
+[a](x\<y)
+.
+<p><a href="x&lt;y">a</a></p>
+```
+
+Inline attributes attach to the autolink's `<a>` element:
+
+```
+<https://example.com>{.a}
+.
+<p><a href="https://example.com" class="a">https://example.com</a></p>
+```
+
+```
+<https://example.com>{#id .cls}
+.
+<p><a href="https://example.com" id="id" class="cls">https://example.com</a></p>
+```
+
 Openers inside `[..](` or `[..][` or `[..]{` can't match
 outside them, even if the construction doesn't turn out to be
 a link or span or image.
@@ -239,4 +289,43 @@ a link or span or image.
 [x_y]{.bar_}
 .
 <p><span class="bar_">x_y</span></p>
+```
+
+A reference definition's URL may not contain internal whitespace.
+
+```
+[foo]: http://example.com "title"
+
+[foo][]
+.
+<p>[foo]: http://example.com “title”</p>
+<p><a>foo</a></p>
+```
+
+```
+[foo]: http://example.com extra
+
+[foo][]
+.
+<p>[foo]: http://example.com extra</p>
+<p><a>foo</a></p>
+```
+
+Reference links inside image alt text are flattened to their
+label text rather than being emitted literally:
+
+```
+[foo]: http://example.com/foo
+
+![alt with [foo][] text](/img.png)
+.
+<p><img alt="alt with foo text" src="/img.png"></p>
+```
+
+```
+[foo]: http://example.com/foo
+
+![alt [foo][foo] here](/img.png)
+.
+<p><img alt="alt foo here" src="/img.png"></p>
 ```

--- a/tests/official/lists.test
+++ b/tests/official/lists.test
@@ -77,6 +77,65 @@ a list
 </ul>
 ```
 
+Without a blank line before a nested marker, an indented `-` is
+literal continuation of the parent item, not a sub-list. A
+paragraph following the parent list's blank line must not be
+absorbed into the last item as lazy continuation:
+
+```
+- a
+    - sub
+- b
+    - sub
+
+Para.
+.
+<ul>
+<li>
+a
+- sub
+</li>
+<li>
+b
+- sub
+</li>
+</ul>
+<p>Para.</p>
+```
+
+Tight/loose detection must not look past the end of the current
+list. A later loose list in the same document does not retroactively
+make an earlier (already-closed) tight list loose:
+
+```
+- a
+- b
+
+text
+
+- x
+
+- y
+.
+<ul>
+<li>
+a
+</li>
+<li>
+b
+</li>
+</ul>
+<p>text</p>
+<ul>
+<li>
+<p>x</p>
+</li>
+<li>
+<p>y</p>
+</li>
+</ul>
+```
+
 ```
 - one
 lazy

--- a/tests/official/para.test
+++ b/tests/official/para.test
@@ -5,3 +5,16 @@ there
 <p>hi  
 there</p>
 ```
+
+A line that contains only whitespace counts as blank and ends
+the preceding block. (The line between the two paragraphs below
+is a single space, not empty.)
+
+```
+para
+ 
+para2
+.
+<p>para</p>
+<p>para2</p>
+```

--- a/tests/official/super_subscript.test
+++ b/tests/official/super_subscript.test
@@ -21,3 +21,17 @@ H{~2 ~}O
 .
 <p>H<sub>2 </sub>O</p>
 ```
+
+Inline attributes attach to the sub/sup element:
+
+```
+~sub~{.a}
+.
+<p><sub class="a">sub</sub></p>
+```
+
+```
+^sup^{.a}
+.
+<p><sup class="a">sup</sup></p>
+```

--- a/tests/official/tables.test
+++ b/tests/official/tables.test
@@ -103,6 +103,49 @@ determines the alignment for following cells, until the next header.
 </table>
 ```
 
+A separator row's cells must start immediately after the leading
+`|`. With a leading space (`| --- |`), the row is not a separator
+and the preceding row stays a `<td>` row; without the space
+(`|---|`) the preceding row becomes a `<th>` header row:
+
+```
+| a | b |
+| --- | --- |
+| c | d |
+.
+<table>
+<tr>
+<td>a</td>
+<td>b</td>
+</tr>
+<tr>
+<td>—</td>
+<td>—</td>
+</tr>
+<tr>
+<td>c</td>
+<td>d</td>
+</tr>
+</table>
+```
+
+```
+| a | b |
+|---|---|
+| c | d |
+.
+<table>
+<tr>
+<th>a</th>
+<th>b</th>
+</tr>
+<tr>
+<td>c</td>
+<td>d</td>
+</tr>
+</table>
+```
+
 ```
 | |
 .

--- a/tests/official/verbatim.test
+++ b/tests/official/verbatim.test
@@ -45,3 +45,17 @@ c
 <p><code> a
 c</code></p>
 ```
+
+Inline attributes attach to the code element:
+
+```
+`code`{.a}
+.
+<p><code class="a">code</code></p>
+```
+
+```
+`code`{key="value"}
+.
+<p><code key="value">code</code></p>
+```


### PR DESCRIPTION
Ports the test cases from the pending djot.js PR [More test case suggestions from cdjot regressions](https://github.com/jgm/djot.js/pull/137) into the official test suite and fixes the five cases where djot-php diverged from djot.js. All expected outputs were verified against djot.js main (commit 84a4b02), not just taken from the PR.

## Fixes

- **Invalid attribute specs render literally.** Identifiers, class names, keys, and unquoted values only allow ASCII alphanumerics plus `_`, `:`, `-`. Any other character (e.g. `{#a<b}`) invalidates the entire spec, which stays literal text instead of leaking into attribute context. Applied on the block path, the inline word-attachment path, and trailing attribute blocks after spans/links/emphasis/code. New `AttributeParser::isValid()` implements the whole-spec grammar check.
- **Bare `:` starts a definition list.** A `:` followed by end of input produces an empty `<dl><dt></dt><dd></dd></dl>` instead of a paragraph (fuzz-crash class found in cdjot).
- **Trailing backslash at end of content is a hard break.** `para\` at end of input now emits `<br>` instead of a literal backslash. Also holds at end of a paragraph mid-document and in headings, matching djot.js.
- **Bare `#` marker line continues a heading.** `# h` / `#` / `# x` is one heading with content `h`/`x` (id `h-x`), not two sections.
- **Table separator cells must start immediately after `|`.** `| --- | --- |` (leading space) is an ordinary data row; only `|---|---|` promotes the previous row to a header. Trailing space before the next `|` remains allowed, matching djot.js `pattRowSep`.

One existing expectation was corrected: `AttributeParserTest` previously asserted that an invalid unquoted value (`invalid=foo.bar`) is skipped while keeping the remaining attributes; djot.js invalidates the whole spec, so the test now expects literal output.

## Notes

- Where djot-php deliberately keeps a bracketed run fully literal next to an invalid attribute block (the documented `[x]{???}` convention), that convention is preserved: `[x]{#a<b}` renders fully literal, while djot.js keeps the span and renders only the braces literally.
- Two adjacent divergences surfaced while testing but are pre-existing and out of scope here: table cells trim trailing backslash-space differently than djot.js (`| a\ |`), and an empty higher-level heading between two headings sections differently (`# h` / `##` / `# x`).
