### PR TITLE
Keep tight list items unwrapped when source lines are enabled

### DIFF
--- a/src/Renderer/HtmlRenderer.php
+++ b/src/Renderer/HtmlRenderer.php
@@ -768,7 +768,9 @@ class HtmlRenderer implements RendererInterface
             // This handles both:
             // 1. Single paragraph: <p>text</p> -> text
             // 2. Paragraph followed by nested list: <p>text</p>\n<ul>... -> text\n<ul>...
-            $content = preg_replace('/^<p>(.+?)<\/p>(\n)?/s', '$1$2', $content) ?? $content;
+            // A data-source-line-only wrapper is stripped too (the source-line
+            // option must never change structure; the <li> keeps the anchor).
+            $content = preg_replace('/^<p(?: data-source-line="\d+")?>(.+?)<\/p>(\n)?/s', '$1$2', $content) ?? $content;
         }
 
         // Handle task list items

--- a/tests/TestCase/SourceLineTrackingTest.php
+++ b/tests/TestCase/SourceLineTrackingTest.php
@@ -88,7 +88,9 @@ class SourceLineTrackingTest extends TestCase
         $converter = new DjotConverter(sourceLines: true);
         $html = $converter->convert("- first\n  {.note}\n  second\n");
 
-        $this->assertStringContainsString('<p data-source-line="1">first</p>', $html);
+        // The tight item's lead stays unwrapped (anchor-only <p> wrappers are
+        // stripped like plain ones); the li carries the anchor.
+        $this->assertMatchesRegularExpression('/<li data-source-line="1">\nfirst\n/', $html);
         $this->assertStringContainsString('<p class="note" data-source-line="3">second</p>', $html);
         $this->assertStringNotContainsString('data-source-line="0"', $html);
     }
@@ -99,11 +101,9 @@ class SourceLineTrackingTest extends TestCase
         $html = $converter->convert("> - quoted item\n>   - nested item\n");
 
         $this->assertMatchesRegularExpression('/<ul data-source-line="1">/', $html);
-        $this->assertMatchesRegularExpression('/<li data-source-line="1">/', $html);
-        $this->assertStringContainsString('<p data-source-line="1">quoted item</p>', $html);
+        $this->assertMatchesRegularExpression('/<li data-source-line="1">\nquoted item\n/', $html);
         $this->assertMatchesRegularExpression('/<ul data-source-line="2">/', $html);
-        $this->assertMatchesRegularExpression('/<li data-source-line="2">/', $html);
-        $this->assertStringContainsString('<p data-source-line="2">nested item</p>', $html);
+        $this->assertMatchesRegularExpression('/<li data-source-line="2">\nnested item\n/', $html);
     }
 
     public function testFootnoteContentBlocksAreStamped(): void
@@ -188,5 +188,18 @@ class SourceLineTrackingTest extends TestCase
         $this->assertStringContainsString('<p data-source-line="1">Intro</p>', $html);
         $this->assertStringContainsString('<div data-source-line="3">', $html);
         $this->assertStringContainsString('<p>nested</p>', $html);
+    }
+
+    public function testEnabledOutputIsStructureIdenticalToDisabled(): void
+    {
+        // The option is attribute-only: stripping the stamped attributes must
+        // reproduce the default output byte for byte. Regression: tight list
+        // items used to grow <p> wrappers because the stamped paragraph no
+        // longer matched the renderer's tight-strip pattern.
+        $doc = "> - quoted item\n\n- a\n- b\n\n1. loose\n\n  para\n\n:: nope\n";
+        $off = (new DjotConverter())->convert($doc);
+        $on = (new DjotConverter(sourceLines: true))->convert($doc);
+
+        $this->assertSame($off, preg_replace('/ data-source-line="\d+"/', '', $on));
     }
 }


### PR DESCRIPTION
Enabling `sourceLines` grew `<p>` wrappers inside tight list items: the tight-strip pattern in the renderer only matched a bare `<p>`, and stamped paragraphs no longer matched. The option is documented as attribute-only, so output structure must be byte-identical modulo the stamped attributes.

The tight-strip now also strips a `data-source-line`-only wrapper (the `<li>` keeps its anchor - same shape carve-js and carve-rs emit), and a regression test asserts on-output equals off-output after removing the attributes.

Found via a three-implementation cross-check harness (php/js/rs) on nested-list documents.