### PR TITLE
Add option to disable section wrapping in HTML output

### DIFF
--- a/bin/djot
+++ b/bin/djot
@@ -19,6 +19,7 @@ declare(strict_types=1);
  *   -f, --format=FORMAT Output format: html (default), text, markdown, ansi
  *   --safe[=MODE] Enable safe mode (MODE: default or strict), HTML only
  *   -x, --xhtml Use XHTML-compatible output (HTML only)
+ *   --no-sections Do not wrap document headings in sections (HTML only)
  *   -w, --warnings Show parse warnings on stderr
  *   --strict Exit with code 1 if warnings are generated
  *   -h, --help Show this help message
@@ -93,6 +94,7 @@ function parseConvertArgs(array $argv): array
         'output' => null,
         'format' => 'html',
         'xhtml' => false,
+        'sections' => true,
         'safe' => false,
         'safeStrict' => false,
         'warnings' => false,
@@ -112,6 +114,8 @@ function parseConvertArgs(array $argv): array
             $options['version'] = true;
         } elseif ($arg === '-x' || $arg === '--xhtml') {
             $options['xhtml'] = true;
+        } elseif ($arg === '--no-sections') {
+            $options['sections'] = false;
         } elseif ($arg === '-s' || $arg === '--safe' || $arg === '--safe=default') {
             $options['safe'] = true;
         } elseif ($arg === '--safe=strict') {
@@ -191,6 +195,7 @@ Options:
   -f, --format=FORMAT   Output format: html (default), text, markdown, ansi
   --safe[=MODE]         Enable safe mode (MODE: default or strict), HTML only
   -x, --xhtml           Use XHTML-compatible output (HTML only)
+  --no-sections         Do not wrap document headings in sections (HTML only)
   -w, --warnings        Show parse warnings on stderr
   --strict              Exit with code 1 if warnings are generated
   -h, --help            Show this help message
@@ -317,6 +322,7 @@ function runConvert(array $argv): int
         warnings: $warnings,
         safeMode: $safeMode,
         renderer: $renderer,
+        sections: (bool)$options['sections'],
     );
 
     $output = $converter->convert($input);

--- a/docs/cookbook/markdown.md
+++ b/docs/cookbook/markdown.md
@@ -107,6 +107,14 @@ Note: Features like highlight, superscript, and subscript don't have native Mark
 
 Migrate content from Djot to a Markdown-based CMS:
 
+When migrating Markdown stylesheets to Djot HTML output, note that document-level headings are wrapped in `<section>` elements by default. If your existing CSS expects a flat heading structure, disable section wrapping:
+
+```php
+$converter = new DjotConverter(sections: false);
+```
+
+The CLI equivalent is `--no-sections`. With this option off, headings keep their ids inline, and the footnote endnotes section is unchanged.
+
 ```php
 use Djot\DjotConverter;
 use Djot\Event\RenderEvent;

--- a/docs/guide/converters.md
+++ b/docs/guide/converters.md
@@ -317,6 +317,24 @@ Some Djot features cannot survive round-trip conversion due to semantic equivale
 
 These behaviors are correct and intentional - smart quotes enhance typography while preserving meaning.
 
+### Section Wrapping
+
+By default, Djot HTML wraps document-level headings in `<section>` elements and places the heading id on the section. Disable this HTML-only option when you need flat heading markup:
+
+```php
+use Djot\DjotConverter;
+
+$converter = new DjotConverter(sections: false);
+```
+
+With section wrapping off, the heading keeps its id inline:
+
+```html
+<h2 id="setup">Setup</h2>
+```
+
+The default is on, and the footnote endnotes section is unaffected. In the CLI, use `--no-sections`.
+
 **Use Cases:**
 - Converting WYSIWYG editor output
 - Migrating HTML documentation to Djot

--- a/docs/guide/parser-options.md
+++ b/docs/guide/parser-options.md
@@ -15,6 +15,7 @@ $converter = new DjotConverter();
 // With options
 $converter = new DjotConverter(
     xhtml: true,
+    sections: false,
     blocksInterruptParagraphs: true,
     nestedListsWithoutBlankLine: true,
 );
@@ -42,6 +43,32 @@ $converter = DjotConverter::create(
 ```
 
 :::
+
+## Section Wrapping
+
+By default, HTML output wraps document-level headings in `<section>` elements and puts the heading id on the section:
+
+```html
+<section id="setup">
+<h2>Setup</h2>
+</section>
+```
+
+Disable section wrapping for flat heading markup:
+
+```php
+use Djot\DjotConverter;
+
+$converter = new DjotConverter(sections: false);
+```
+
+Output keeps the id on the heading itself:
+
+```html
+<h2 id="setup">Setup</h2>
+```
+
+This option is HTML-only, defaults to on, and does not affect the footnote endnotes section. In the CLI, use `--no-sections`.
 
 ## Soft Break Modes
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -29,6 +29,7 @@ public function __construct(
     bool $blocksInterruptParagraphs = false,
     bool $nestedListsWithoutBlankLine = false,
     bool $sourceLines = false,
+    bool $sections = true,
 )
 ```
 
@@ -41,11 +42,12 @@ public function __construct(
 - `$softBreakMode`: Override how soft breaks are rendered. When `null`, uses the renderer's default (newline for HTML).
 - `$roundTripMode`: When `true`, adds round-trip metadata for Djot→HTML→Djot workflows (HTML renderer only).
 - `$parser`: Optional pre-configured parser. When provided, inline parser constructor flags such as `warnings`, `strict`, `significantNewlines` (deprecated), `nestedBlocksInLists`, `blocksInterruptParagraphs`, and `nestedListsWithoutBlankLine` are ignored.
-- `$renderer`: Optional pre-configured renderer. When provided, inline renderer constructor flags such as `xhtml`, `safeMode`, `softBreakMode`, and `roundTripMode` are ignored.
+- `$renderer`: Optional pre-configured renderer. When provided, inline renderer constructor flags such as `xhtml`, `safeMode`, `softBreakMode`, `roundTripMode`, and `sections` are ignored.
 - `$nestedBlocksInLists`: **Deprecated.** When `true`, indentation alone introduces nested blocks of **any** type inside list items without a blank line (broad, eager - no lone-marker lookahead), while top-level paragraph interruption stays spec-compliant (see [Nested Blocks in Lists Mode](/guide/parser-options#nested-blocks-in-lists-mode)). Prefer `$blocksInterruptParagraphs` + `$nestedListsWithoutBlankLine`. No longer implied by `$significantNewlines`.
 - `$blocksInterruptParagraphs`: When `true`, top-level block elements (lists, blockquotes, headings, tables, thematic breaks, and code/div/comment fences) can interrupt a paragraph without a preceding blank line. It **also** interrupts a list item's lead paragraph, so an indented non-list block nests inside the item without a blank line, using the **same** lone-marker lookahead as the top level: unambiguous openers (`#`, fenced code, `:::`, `---`) and real multi-line blocks nest, while a single ambiguous marker line (`>`, `|`) stays literal. It does not nest sublists (see [Block Interrupts Paragraphs Mode](/guide/parser-options#block-interrupts-paragraphs-mode)). Implied by `$significantNewlines`.
 - `$nestedListsWithoutBlankLine`: When `true`, a sublist nests inside a list item without a blank line. Only sublists nest; non-list blocks under the item stay literal and top-level paragraph interruption is unaffected (see [Nested Lists Without Blank Line Mode](/guide/parser-options#nested-lists-without-blank-line-mode)). Implied by `$significantNewlines`.
 - `$sourceLines`: When `true`, block elements, nested blocks, list items, and definition terms/descriptions are stamped with a `data-source-line` attribute holding the **1-based** source line where the block started. Off by default, so normal output is unchanged. Intended for editor live-preview scroll-sync (map a rendered block back to the source textarea). Ignored when a pre-configured `$parser` is supplied (pass `new BlockParser(trackSourceLines: true)` instead). See [Source-line tracking](#source-line-tracking).
+- `$sections`: When `true` (default), document-level headings are wrapped in `<section>` elements and the heading id is placed on the section. When `false`, no heading section wrapper is emitted and the heading keeps its id inline. HTML renderer only; the footnote endnotes section is unaffected. CLI: `--no-sections`.
 
 ### Factory Methods
 
@@ -758,7 +760,36 @@ $renderer->setSoftBreakMode(SoftBreakMode::Space);
 
 // Enable safe mode for user-generated content
 $renderer->setSafeMode(SafeMode::defaults());
+
+// Disable document heading section wrappers
+$renderer->setSections(false);
 ```
+
+#### Section Wrapping
+
+By default, the HTML renderer wraps document-level headings in `<section>` elements and places each heading id on the section:
+
+```html
+<section id="intro">
+<h1>Intro</h1>
+</section>
+```
+
+Disable this when you need flat heading output, for example to keep existing Markdown-oriented stylesheet sibling selectors working:
+
+```php
+$converter = new DjotConverter(sections: false);
+// Or:
+$renderer->setSections(false);
+```
+
+With section wrapping disabled, the heading keeps its id inline:
+
+```html
+<h1 id="intro">Intro</h1>
+```
+
+This option is HTML-only. It does not affect the footnote endnotes section. In the CLI, use `--no-sections`.
 
 #### Tab Width in Code Blocks
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -52,6 +52,16 @@ Enable safe mode for untrusted content:
 ./vendor/bin/djot convert document.djot --safe=strict
 ```
 
+### Section Wrapping
+
+Disable document heading section wrappers in HTML output:
+
+```bash
+./vendor/bin/djot convert document.djot --no-sections
+```
+
+This keeps heading ids inline and does not affect the footnote endnotes section.
+
 ### Reading from STDIN
 
 ```bash
@@ -76,6 +86,7 @@ Options:
   -o, --output=FILE     Output file (default: stdout)
   -f, --format=FORMAT   Output format: html, text, markdown, ansi
   --safe[=MODE]         Enable safe mode (default, strict)
+  --no-sections         Do not wrap document headings in sections (HTML only)
   -h, --help            Display help
 ```
 

--- a/src/DjotConverter.php
+++ b/src/DjotConverter.php
@@ -127,11 +127,12 @@ class DjotConverter
      * @param \Djot\Renderer\SoftBreakMode|null $softBreakMode How to render soft breaks (HTML renderer only)
      * @param bool $roundTripMode Add data attributes for Djot→HTML→Djot round-trips (HTML renderer only)
      * @param \Djot\Parser\BlockParser|null $parser Pre-configured parser (ignores warnings/strict/significantNewlines/nestedBlocksInLists/blocksInterruptParagraphs/nestedListsWithoutBlankLine if set)
-     * @param \Djot\Renderer\RendererInterface|null $renderer Pre-configured renderer (ignores xhtml/safeMode/softBreakMode/roundTripMode if set)
+     * @param \Djot\Renderer\RendererInterface|null $renderer Pre-configured renderer (ignores xhtml/safeMode/softBreakMode/roundTripMode/sections if set)
      * @param bool $nestedBlocksInLists Allow nested blocks in list items without blank lines (deprecated; prefer blocksInterruptParagraphs + nestedListsWithoutBlankLine)
      * @param bool $blocksInterruptParagraphs Allow top-level block elements to interrupt paragraphs without a blank line
      * @param bool $nestedListsWithoutBlankLine Allow sublists to nest in list items without a blank line
      * @param bool $sourceLines Stamp block elements, nested blocks, list items, and definition list entries with a `data-source-line` attribute (1-based source line). Opt-in, for editor scroll-sync; ignored when a pre-configured $parser is supplied.
+     * @param bool $sections Wrap document-level headings in section elements (HTML renderer only)
      */
     public function __construct(
         bool $xhtml = false,
@@ -148,6 +149,7 @@ class DjotConverter
         bool $blocksInterruptParagraphs = false,
         bool $nestedListsWithoutBlankLine = false,
         bool $sourceLines = false,
+        bool $sections = true,
     ) {
         $this->collectWarnings = $warnings;
         $this->strictMode = $strict;
@@ -176,6 +178,11 @@ class DjotConverter
             // Configure round-trip mode
             if ($roundTripMode) {
                 $this->renderer->setRoundTripMode(true);
+            }
+
+            // Configure section wrapping
+            if (!$sections) {
+                $this->renderer->setSections(false);
             }
         }
 

--- a/src/Renderer/HtmlRenderer.php
+++ b/src/Renderer/HtmlRenderer.php
@@ -85,6 +85,11 @@ class HtmlRenderer implements RendererInterface
      */
     protected bool $roundTripMode = false;
 
+    /**
+     * Whether document-level headings are wrapped in section elements.
+     */
+    protected bool $sections = true;
+
     protected RenderContext $sharedRenderContext;
 
     protected ?RenderContext $activeRenderContext = null;
@@ -270,6 +275,20 @@ class HtmlRenderer implements RendererInterface
     }
 
     /**
+     * Set whether document-level headings are wrapped in section elements.
+     *
+     * When disabled, headings keep their id attribute inline and no section
+     * wrapper is emitted around document-level heading content. This does not
+     * affect the endnotes section emitted for footnotes.
+     */
+    public function setSections(bool $enabled): self
+    {
+        $this->sections = $enabled;
+
+        return $this;
+    }
+
+    /**
      * Register an inline footnote and return its number
      *
      * Used by extensions like InlineFootnotesExtension to add footnotes
@@ -360,6 +379,15 @@ class HtmlRenderer implements RendererInterface
         // same heading ids.
         $this->getRenderContext()->headingIdTracker->reserveExplicitIds($document);
 
+        if (!$this->sections) {
+            $html = '';
+            foreach ($document->getChildren() as $child) {
+                $html .= $this->renderNode($child);
+            }
+
+            return $html . $this->renderRoundTripAbbreviations($document);
+        }
+
         $children = $document->getChildren();
         $html = '';
         /** @var array<int, int> $openSections Level => count of open sections at that level */
@@ -434,15 +462,30 @@ class HtmlRenderer implements RendererInterface
             }
         }
 
-        // Add abbreviation definitions for round-trip support
-        if ($this->roundTripMode) {
-            $abbreviations = $document->getAbbreviations();
-            if ($abbreviations !== []) {
-                $html .= $this->renderAbbreviationDefinitions($abbreviations);
-            }
-        }
+        $html .= $this->renderRoundTripAbbreviations($document);
 
         return $html;
+    }
+
+    /**
+     * Render the round-trip abbreviation metadata for a document, if any.
+     *
+     * Returns an empty string when round-trip mode is off or the document
+     * defines no abbreviations. Shared by both the section-wrapped and the
+     * unwrapped document render paths.
+     */
+    protected function renderRoundTripAbbreviations(Document $document): string
+    {
+        if (!$this->roundTripMode) {
+            return '';
+        }
+
+        $abbreviations = $document->getAbbreviations();
+        if ($abbreviations === []) {
+            return '';
+        }
+
+        return $this->renderAbbreviationDefinitions($abbreviations);
     }
 
     /**

--- a/tests/TestCase/CliTest.php
+++ b/tests/TestCase/CliTest.php
@@ -65,6 +65,13 @@ class CliTest extends TestCase
         $this->assertStringContainsString('<strong>hi</strong>', $result['stdout']);
     }
 
+    public function testNoSectionsDisablesHtmlSectionWrapping(): void
+    {
+        $result = $this->runCli(['convert', '-', '--no-sections'], "# hi\n");
+        $this->assertSame(0, $result['exit']);
+        $this->assertSame("<h1 id=\"hi\">hi</h1>\n", $result['stdout']);
+    }
+
     public function testFormatText(): void
     {
         $result = $this->runCli(['convert', '-', '--format=text'], '*hi*');

--- a/tests/TestCase/Renderer/HtmlRendererTest.php
+++ b/tests/TestCase/Renderer/HtmlRendererTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Djot\Test\TestCase\Renderer;
 
+use Djot\DjotConverter;
+use Djot\Event\RenderEvent;
 use Djot\Node\Block\CodeBlock;
 use Djot\Node\Block\Div;
 use Djot\Node\Block\Footnote;
@@ -59,6 +61,107 @@ class HtmlRendererTest extends TestCase
 
         // Headings are wrapped in <section> tags per djot spec
         $this->assertSame("<section id=\"Title\">\n<h2>Title</h2>\n</section>\n", $result);
+    }
+
+    public function testSectionsCanBeDisabled(): void
+    {
+        $cases = [
+            "{#install .featured}\n## Setup\n" => "<h2 id=\"install\" class=\"featured\">Setup</h2>\n",
+            "{a=b .c}\n# abc\n" => "<h1 id=\"abc\" a=\"b\" class=\"c\">abc</h1>\n",
+            "# abc\n" => "<h1 id=\"abc\">abc</h1>\n",
+            "{.c}\n# abc\n\npara\n\n{#y .d}\n## deeper\n" => "<h1 id=\"abc\" class=\"c\">abc</h1>\n<p>para</p>\n<h2 id=\"y\" class=\"d\">deeper</h2>\n",
+        ];
+
+        foreach ($cases as $input => $expected) {
+            $converter = new DjotConverter();
+            $converter->getHtmlRenderer()->setSections(false);
+
+            $this->assertSame($expected, $converter->convert($input));
+        }
+    }
+
+    public function testSectionsAreEnabledByDefault(): void
+    {
+        $cases = [
+            "{#install .featured}\n## Setup\n" => "<section id=\"install\">\n<h2 class=\"featured\">Setup</h2>\n</section>\n",
+            "{a=b .c}\n# abc\n" => "<section id=\"abc\">\n<h1 a=\"b\" class=\"c\">abc</h1>\n</section>\n",
+            "# abc\n" => "<section id=\"abc\">\n<h1>abc</h1>\n</section>\n",
+            "{.c}\n# abc\n\npara\n\n{#y .d}\n## deeper\n" => "<section id=\"abc\">\n<h1 class=\"c\">abc</h1>\n<p>para</p>\n<section id=\"y\">\n<h2 class=\"d\">deeper</h2>\n</section>\n</section>\n",
+        ];
+
+        foreach ($cases as $input => $expected) {
+            $this->assertSame($expected, (new DjotConverter())->convert($input));
+        }
+    }
+
+    public function testDuplicateHeadingIdsAreDeduplicatedWhenSectionsAreDisabled(): void
+    {
+        $converter = new DjotConverter();
+        $converter->getHtmlRenderer()->setSections(false);
+
+        $this->assertSame(
+            "<p id=\"abc\">intro</p>\n<h1 id=\"abc-1\">abc</h1>\n<h1 id=\"abc-2\">abc</h1>\n",
+            $converter->convert("{#abc}\nintro\n\n# abc\n\n# abc\n"),
+        );
+    }
+
+    public function testFootnotesSectionIsStillEmittedWhenSectionsAreDisabled(): void
+    {
+        $converter = new DjotConverter();
+        $converter->getHtmlRenderer()->setSections(false);
+
+        $html = $converter->convert("note[^a]\n\n[^a]: foot\n");
+
+        $this->assertStringContainsString('<section role="doc-endnotes">', $html);
+    }
+
+    public function testRoundTripAbbreviationsAreStillEmittedWhenSectionsAreDisabled(): void
+    {
+        $input = "*[HTML]: HyperText Markup Language\n\nHTML is fine.\n";
+        $withSections = new DjotConverter(roundTripMode: true);
+        $withoutSections = new DjotConverter(roundTripMode: true, sections: false);
+
+        $this->assertStringContainsString(
+            '<template data-djot-abbreviations>',
+            $withSections->convert($input),
+        );
+        $this->assertStringContainsString(
+            '<template data-djot-abbreviations>',
+            $withoutSections->convert($input),
+        );
+    }
+
+    public function testHeadingInsideDivRendersIdenticallyWithSectionsEnabledAndDisabled(): void
+    {
+        $input = "::: {.box}\n# abc\n:::\n";
+        $withSections = (new DjotConverter())->convert($input);
+
+        $withoutSections = new DjotConverter();
+        $withoutSections->getHtmlRenderer()->setSections(false);
+
+        $this->assertSame($withSections, $withoutSections->convert($input));
+        $this->assertSame("<div class=\"box\">\n<h1 id=\"abc\">abc</h1>\n</div>\n", $withSections);
+    }
+
+    public function testConverterConstructorCanDisableSections(): void
+    {
+        $converter = new DjotConverter(sections: false);
+
+        $this->assertSame("<h1 id=\"abc\">abc</h1>\n", $converter->convert("# abc\n"));
+    }
+
+    public function testRenderHeadingEventFiresWhenSectionsAreDisabled(): void
+    {
+        $converter = new DjotConverter(sections: false);
+        $fired = false;
+
+        $converter->on('render.heading', function (RenderEvent $event) use (&$fired): void {
+            $fired = true;
+            $this->assertInstanceOf(Heading::class, $event->getNode());
+        });
+
+        $this->assertSame("<h1 id=\"abc\">abc</h1>\n", $converter->convert("# abc\n"));
+        $this->assertTrue($fired);
     }
 
     public function testRenderEmphasis(): void


### PR DESCRIPTION
Document-level headings are wrapped in `<section>` elements by default, with the heading id hoisted onto the wrapper. There was no way to turn this off short of post-processing the HTML.

That is a real migration blocker: stylesheets written against a flat Markdown heading structure break silently. The motivating case is sibling selectors such as `.stack > * + *`, which stop matching once every heading and its content sit in their own wrapper. Raised in markup-carve/carve#427 and before in https://github.com/jgm/djot/issues/221 .

## What this adds

An opt-out. The default is unchanged.

```php
$converter = new DjotConverter(sections: false);
// or
$converter->getHtmlRenderer()->setSections(false);
```

```bash
djot convert doc.djot --no-sections
```

```
{#install .featured}
## Setup
```

| | output |
|---|---|
| default | `<section id="install">` / `<h2 class="featured">Setup</h2>` |
| `sections: false` | `<h2 id="install" class="featured">Setup</h2>` |

## Why it is small

`renderHeading()` already emits exactly this shape. It is the path used today for headings nested inside divs and blockquotes. Disabling section wrapping routes document-level headings through that same path, so the behavior is one that already existed and was already covered, just not reachable at document level.

Two things worth calling out:

- **No id loss.** The explicit id reservation pass still runs first, so generated ids and their dedup suffixes are byte-identical in both modes. This is not true of the equivalent workaround in djot.js, where the id is moved onto the section during parsing, so unwrapping the section with a filter silently drops every anchor including hand-written ones. Because djot-php decides placement at render time, there is nothing to recover.
- **Scope.** Section wrapping is an HTML concern. The footnote endnotes section, the round-trip abbreviation metadata, and the plain text, Markdown and ANSI renderers are all unaffected.

## Docs

Added to `docs/guide/parser-options.md`, `docs/guide/converters.md`, `docs/reference/api.md`, `docs/reference/cli.md`, and a migration note in `docs/cookbook/markdown.md`, which is where someone hitting this problem is most likely to look.
