### PR TITLE
Fix footnote references crossing source newlines

### DIFF
--- a/src/Parser/InlineParser.php
+++ b/src/Parser/InlineParser.php
@@ -1957,8 +1957,10 @@ class InlineParser
      */
     protected function parseFootnoteRef(string $text, int $pos): ?array
     {
-        // Match [^label] - \G anchors at offset position, avoiding extra strpos check
-        if (!preg_match('/\G\[\^([^\]]+)\]/', $text, $matches, 0, $pos)) {
+        // A footnote label cannot cross a physical line. The definition marker
+        // is one line too, so accepting a newline here creates an identifier
+        // that no valid definition can bind (jgm/djot#208).
+        if (!preg_match('/\G\[\^([^\]\r\n]+)\]/', $text, $matches, 0, $pos)) {
             return null;
         }
 

--- a/tests/TestCase/FootnoteLabelIsSingleLineTest.php
+++ b/tests/TestCase/FootnoteLabelIsSingleLineTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Test\TestCase;
+
+use Djot\DjotConverter;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class FootnoteLabelIsSingleLineTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function lineEndings(): iterable
+    {
+        yield 'LF' => ["\n"];
+        yield 'CRLF' => ["\r\n"];
+        yield 'CR' => ["\r"];
+    }
+
+    #[DataProvider('lineEndings')]
+    public function testAReferenceLabelDoesNotCrossALineEnding(string $ending): void
+    {
+        $source = "before[^two{$ending}words].\n";
+        $converter = new DjotConverter(warnings: true);
+        $document = $converter->parse($source);
+        $types = array_map(
+            static fn ($node): string => $node->getType(),
+            $document->getChildren()[0]->getChildren(),
+        );
+
+        self::assertNotContains('footnote_ref', $types);
+        self::assertContains('soft_break', $types);
+        self::assertStringNotContainsString('doc-noteref', $converter->convert($source));
+        self::assertSame([], array_filter(
+            $converter->getWarnings(),
+            static fn ($warning): bool => str_contains($warning->getMessage(), 'Undefined footnote'),
+        ));
+    }
+
+    public function testAMultilineDefinitionMarkerDoesNotRegisterOrSwallowText(): void
+    {
+        $source = "see[^two words].\n\n[^two\nwords]: note.\n";
+        $converter = new DjotConverter();
+
+        $document = $converter->parse($source);
+        self::assertNotContains('footnote', array_map(
+            static fn ($node): string => $node->getType(),
+            $document->getChildren(),
+        ));
+        self::assertStringContainsString("[^two\nwords]: note.", $converter->convert($source));
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function sameLineLabels(): iterable
+    {
+        yield 'space' => ['two words'];
+        yield 'tab' => ["two\twords"];
+    }
+
+    #[DataProvider('sameLineLabels')]
+    public function testSameLineWhitespaceStillResolves(string $label): void
+    {
+        $html = (new DjotConverter())->convert("see[^{$label}].\n\n[^{$label}]: note.\n");
+        self::assertStringContainsString('doc-noteref', $html);
+    }
+}


### PR DESCRIPTION
## Summary

- stop footnote-reference labels at LF or CR
- preserve same-line spaces and tabs exactly
- cover LF, CRLF, CR, multiline definition markers, warnings, and rendered output

## Why

Footnote definitions are line-based, but inline references previously accepted source newlines. That produced identifiers that no valid definition could bind.

Fixes the djot-php behavior reported in jgm/djot.js#146.

## Verification

- focused regression suite: 6 tests, 16 assertions
- full `composer check`: 2,766 tests, 18,386 assertions; code style passes
