### PR TITLE
Pin code sniffer to a stable release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require-dev": {
         "nikic/php-fuzzer": "^0.0.11",
-        "php-collective/code-sniffer": "dev-master",
+        "php-collective/code-sniffer": "^0.6.8",
         "phpstan/phpstan": "^2.1.32",
         "phpunit/phpunit": "^11.0 || ^12.0 || ^13.0"
     },


### PR DESCRIPTION
## Summary

- replace the moving `dev-master` code-sniffer constraint with stable `^0.6.8`

## Why

Development tooling should resolve from a tagged, reproducible compatibility range rather than an unbounded branch head.

## Verification

- `composer validate --strict`
