### PR TITLE
Opt-in composite figures: a figure div is one figure of ordered panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $html = $converter->convert('Hello *world*!');
 - **Advanced**: Footnotes, math expressions, symbols, block attributes, raw HTML blocks, comments
 - **Smart typography**: Curly quotes, en/em dashes, ellipsis
 - **Multiple renderers**: HTML, plain text, Markdown, ANSI terminal output
-- **Extensions**: Built-in extensions for external links, TOC, heading permalinks, @mentions, autolinks, default attributes, and citations
+- **Extensions**: Built-in extensions for external links, TOC, heading permalinks, @mentions, autolinks, figure groups, default attributes, and citations
 - **Extensible**: Custom inline/block patterns, render events
 - **Editor integration**: Opt-in `data-source-line` stamping on blocks, nested blocks, list items, and definition list entries for live-preview scroll-sync (`new DjotConverter(sourceLines: true)`) — see [Source-line tracking](https://php-collective.github.io/djot-php/reference/api#source-line-tracking)
 - **File support**: Parse and convert files directly

--- a/docs/extensions/index.md
+++ b/docs/extensions/index.md
@@ -12,6 +12,7 @@ Extensions provide a clean way to bundle related customizations together. Each e
 | [CodeGroupExtension](#codegroupextension) | Transforms code-group divs into tabbed code block interfaces |
 | [DefaultAttributesExtension](#defaultattributesextension) | Adds default attributes to elements by type |
 | [ExternalLinksExtension](#externallinksextension) | Adds `target="_blank"` and `rel` attributes to external links |
+| [FigureGroupExtension](#figuregroupextension) | Turns figure divs into composite figures with ordered panels |
 | [FrontmatterExtension](#frontmatterextension) | Parses YAML/NEON/TOML/JSON frontmatter at document start |
 | [HeadingReferenceExtension](#headingreferenceextension) | Resolves `[[Heading Text]]` links to headings in the current document |
 | [HeadingPermalinksExtension](#headingpermalinksextension) | Adds clickable anchor links to headings |
@@ -1291,6 +1292,55 @@ $converter->addExtension(new CodeGroupExtension(
 | Syntax highlighting | Built-in callback support | Manual |
 | Output modes | CSS-only | CSS or ARIA |
 | Best for | Multi-language code examples | General tabbed content |
+
+## FigureGroupExtension
+
+Turns a bare `figure` div into one composite figure containing ordered panels. Captioned images and blockquotes become panel figures, captioned tables are wrapped in panel figures, and other content remains in place. A caret paragraph immediately after the div becomes the group caption.
+
+This composite-figure convention is not part of djot and is strictly opt-in.
+
+```php
+use Djot\Extension\FigureGroupExtension;
+
+$converter->addExtension(new FigureGroupExtension());
+```
+
+```djot
+{#fig-x .columns-2}
+::: figure
+![one](a.png)
+^ (a) One
+
+![two](b.png)
+^ (b) Two
+:::
+^ Group caption
+```
+
+```html
+<figure class="figure-group columns-2" id="fig-x">
+  <div class="figure-panels">
+    <figure class="figure-panel">
+      <img alt="one" src="a.png"><figcaption>(a) One</figcaption>
+    </figure>
+    <figure class="figure-panel">
+      <img alt="two" src="b.png"><figcaption>(b) Two</figcaption>
+    </figure>
+  </div>
+  <figcaption>Group caption</figcaption>
+</figure>
+```
+
+Constructor options:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `triggerClass` | `string` | `'figure'` | Class identifying a div to transform |
+| `groupClass` | `string` | `'figure-group'` | Class placed first on the group figure |
+| `panelsClass` | `string` | `'figure-panels'` | Class on the panels div |
+| `panelClass` | `string` | `'figure-panel'` | Class on promoted or wrapped panels |
+
+All renderers receive the transformed AST, so non-HTML output retains the panel and group captions using its existing figure, div, and caption rendering.
 
 ## DefaultAttributesExtension
 

--- a/src/Extension/FigureGroupExtension.php
+++ b/src/Extension/FigureGroupExtension.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Extension;
+
+use Djot\DjotConverter;
+use Djot\Node\Block\Caption;
+use Djot\Node\Block\Div;
+use Djot\Node\Block\Figure;
+use Djot\Node\Block\Paragraph;
+use Djot\Node\Block\Table;
+use Djot\Node\Document;
+use Djot\Node\Inline\Text;
+use Djot\Node\Node;
+
+/**
+ * Transforms figure divs into composite figures with ordered panels
+ *
+ * This opt-in extension converts a div with class `figure` into one figure.
+ * Captioned figures become panels, while tables are wrapped as panels and all
+ * other content remains in source order.
+ *
+ * Example:
+ * ```php
+ * $converter = new DjotConverter();
+ * $converter->addExtension(new FigureGroupExtension());
+ *
+ * // With custom classes:
+ * $converter->addExtension(new FigureGroupExtension(
+ *     triggerClass: 'composite',
+ *     groupClass: 'composite-figure',
+ *     panelsClass: 'composite-panels',
+ *     panelClass: 'composite-panel',
+ * ));
+ * ```
+ *
+ * Input djot:
+ * ```
+ * ::: figure
+ * ![First](first.png)
+ * ^ First panel
+ *
+ * ![Second](second.png)
+ * ^ Second panel
+ * :::
+ * ^ Group caption
+ * ```
+ */
+class FigureGroupExtension implements BeforeRenderExtensionInterface
+{
+    /**
+     * @param string $triggerClass CSS class identifying figure-group divs
+     * @param string $groupClass CSS class for the composite figure
+     * @param string $panelsClass CSS class for the panels container
+     * @param string $panelClass CSS class for each promoted panel
+     */
+    public function __construct(
+        protected string $triggerClass = 'figure',
+        protected string $groupClass = 'figure-group',
+        protected string $panelsClass = 'figure-panels',
+        protected string $panelClass = 'figure-panel',
+    ) {
+    }
+
+    public function register(DjotConverter $converter): void
+    {
+        // Work happens in beforeRender, which applies to every renderer.
+    }
+
+    public function beforeRender(Document $document): Document
+    {
+        $this->transformChildren($document);
+
+        return $document;
+    }
+
+    protected function transformChildren(Node $container): void
+    {
+        $childCount = count($container->getChildren());
+        for ($index = 0; $index < $childCount; $index++) {
+            $children = $container->getChildren();
+            $child = $children[$index];
+
+            if ($child instanceof Div && $child->hasClass($this->triggerClass)) {
+                $group = $this->createGroup($child);
+                $next = $children[$index + 1] ?? null;
+
+                if ($next instanceof Paragraph && $this->isGroupCaption($next)) {
+                    $group->appendChild($this->createCaption($next));
+                    $container->removeChildAt($index + 1);
+                    $childCount--;
+                }
+
+                $container->replaceChild($index, $group);
+
+                continue;
+            }
+
+            if ($child->hasChildren()) {
+                $this->transformChildren($child);
+            }
+        }
+    }
+
+    protected function createGroup(Div $div): Figure
+    {
+        $group = new Figure();
+        $group->setAttributes($div->getAttributes());
+
+        $classes = [$this->groupClass];
+        foreach ($div->getClassList() as $class) {
+            if ($class !== $this->triggerClass && !in_array($class, $classes, true)) {
+                $classes[] = $class;
+            }
+        }
+        $group->setAttribute('class', implode(' ', $classes));
+
+        $panels = new Div();
+        $panels->setAttribute('class', $this->panelsClass);
+
+        foreach ($div->getChildren() as $child) {
+            if ($child instanceof Figure) {
+                $child->addClass($this->panelClass);
+                $panels->appendChild($child);
+
+                continue;
+            }
+
+            if ($child instanceof Table) {
+                $panel = new Figure();
+                $panel->setAttribute('class', $this->panelClass);
+                $panel->appendChild($child);
+                $panels->appendChild($panel);
+
+                continue;
+            }
+
+            $panels->appendChild($child);
+        }
+
+        $group->appendChild($panels);
+
+        return $group;
+    }
+
+    protected function isGroupCaption(Paragraph $paragraph): bool
+    {
+        $first = $paragraph->getChildren()[0] ?? null;
+        if (!$first instanceof Text) {
+            return false;
+        }
+
+        $content = $first->getContent();
+
+        return $content === '^' || str_starts_with($content, '^ ');
+    }
+
+    protected function createCaption(Paragraph $paragraph): Caption
+    {
+        $children = $paragraph->getChildren();
+        /** @var \Djot\Node\Inline\Text $first */
+        $first = $children[0];
+        $content = $first->getContent();
+        $first->setContent($content === '^' ? '' : substr($content, 2));
+
+        $caption = new Caption();
+        foreach ($children as $index => $child) {
+            if ($index === 0 && $first->getContent() === '') {
+                continue;
+            }
+            $caption->appendChild($child);
+        }
+
+        return $caption;
+    }
+}

--- a/tests/TestCase/Extension/FigureGroupExtensionTest.php
+++ b/tests/TestCase/Extension/FigureGroupExtensionTest.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Djot\Test\TestCase\Extension;
+
+use Djot\DjotConverter;
+use Djot\Extension\FigureGroupExtension;
+use Djot\Renderer\MarkdownRenderer;
+use Djot\Renderer\PlainTextRenderer;
+use Djot\Renderer\RendererInterface;
+use PHPUnit\Framework\TestCase;
+
+class FigureGroupExtensionTest extends TestCase
+{
+    public function testFigureDivIsUnchangedWithoutExtension(): void
+    {
+        $html = (new DjotConverter())->convert("::: figure\nContent.\n:::\n");
+
+        $this->assertSame("<div class=\"figure\">\n<p>Content.</p>\n</div>\n", $html);
+    }
+
+    public function testCaptionedImagesBecomePanels(): void
+    {
+        $html = $this->convert(<<<'DJOT'
+::: figure
+![a](a.png)
+^ Panel a
+
+![b](b.png)
+^ Panel b
+:::
+DJOT);
+
+        $this->assertSame(<<<'HTML'
+<figure class="figure-group">
+<div class="figure-panels">
+<figure class="figure-panel">
+<img alt="a" src="a.png"><figcaption>Panel a</figcaption>
+</figure>
+<figure class="figure-panel">
+<img alt="b" src="b.png"><figcaption>Panel b</figcaption>
+</figure>
+</div>
+</figure>
+HTML . "\n", $html);
+    }
+
+    public function testTrailingCaptionIsAdoptedAfterPanels(): void
+    {
+        $html = $this->convert("::: figure\n:::\n^ Group caption\n");
+
+        $this->assertSame(<<<'HTML'
+<figure class="figure-group">
+<div class="figure-panels">
+</div>
+<figcaption>Group caption</figcaption>
+</figure>
+HTML . "\n", $html);
+    }
+
+    public function testEscapedCaretIsNotAdopted(): void
+    {
+        $html = $this->convert("::: figure\n:::\n\\^ Group caption\n");
+
+        $this->assertSame(<<<'HTML'
+<figure class="figure-group">
+<div class="figure-panels">
+</div>
+</figure>
+<p>^ Group caption</p>
+HTML . "\n", $html);
+    }
+
+    public function testOrdinaryFollowingParagraphIsNotAdopted(): void
+    {
+        $html = $this->convert("::: figure\n:::\nOrdinary paragraph.\n");
+
+        $this->assertSame(<<<'HTML'
+<figure class="figure-group">
+<div class="figure-panels">
+</div>
+</figure>
+<p>Ordinary paragraph.</p>
+HTML . "\n", $html);
+    }
+
+    public function testGroupPreservesIdAndExtraClasses(): void
+    {
+        $html = $this->convert("{#fig-x .columns-2}\n::: figure\n:::\n");
+
+        $this->assertSame(<<<'HTML'
+<figure class="figure-group columns-2" id="fig-x">
+<div class="figure-panels">
+</div>
+</figure>
+HTML . "\n", $html);
+    }
+
+    public function testStrayContentStaysBetweenPanels(): void
+    {
+        $html = $this->convert(<<<'DJOT'
+::: figure
+![a](a.png)
+^ A
+
+Stray content.
+
+![b](b.png)
+^ B
+:::
+DJOT);
+
+        $this->assertSame(<<<'HTML'
+<figure class="figure-group">
+<div class="figure-panels">
+<figure class="figure-panel">
+<img alt="a" src="a.png"><figcaption>A</figcaption>
+</figure>
+<p>Stray content.</p>
+<figure class="figure-panel">
+<img alt="b" src="b.png"><figcaption>B</figcaption>
+</figure>
+</div>
+</figure>
+HTML . "\n", $html);
+    }
+
+    public function testCaptionedTableIsWrappedAndKeepsCaption(): void
+    {
+        $html = $this->convert(<<<'DJOT'
+::: figure
+| A | B |
+|---|---|
+| 1 | 2 |
+^ Numbers
+:::
+DJOT);
+
+        $this->assertSame(<<<'HTML'
+<figure class="figure-group">
+<div class="figure-panels">
+<figure class="figure-panel">
+<table>
+<caption>Numbers</caption>
+<tr>
+<th>A</th>
+<th>B</th>
+</tr>
+<tr>
+<td>1</td>
+<td>2</td>
+</tr>
+</table>
+</figure>
+</div>
+</figure>
+HTML . "\n", $html);
+    }
+
+    public function testNestedFigureDivIsNotTransformed(): void
+    {
+        $html = $this->convert(":::: figure\n::: figure\ninside\n:::\n::::\n");
+
+        $this->assertSame(<<<'HTML'
+<figure class="figure-group">
+<div class="figure-panels">
+<div class="figure">
+<p>inside</p>
+</div>
+</div>
+</figure>
+HTML . "\n", $html);
+    }
+
+    public function testOtherDivAndFollowingCaretParagraphAreUntouched(): void
+    {
+        $html = $this->convert("::: note\nNote.\n:::\n^ Not a caption\n");
+
+        $this->assertSame(<<<'HTML'
+<div class="note">
+<p>Note.</p>
+</div>
+<p>^ Not a caption</p>
+HTML . "\n", $html);
+    }
+
+    public function testNonHtmlRenderersRetainPanelAndGroupCaptions(): void
+    {
+        $djot = "::: figure\n![a](a.png)\n^ Panel caption\n:::\n^ Group caption\n";
+
+        $markdown = $this->convert($djot, new MarkdownRenderer());
+        $plainText = $this->convert($djot, new PlainTextRenderer());
+
+        $this->assertSame("![a](a.png)\n\nPanel caption\n\nGroup caption\n", $markdown);
+        $this->assertSame("a\nPanel caption\nGroup caption\n", $plainText);
+    }
+
+    public function testFigureGroupInsideBlockquoteIsTransformed(): void
+    {
+        $html = $this->convert("> ::: figure\n> ![a](a.png)\n> ^ A\n> :::\n");
+
+        $this->assertSame(<<<'HTML'
+<blockquote>
+<figure class="figure-group">
+<div class="figure-panels">
+<figure class="figure-panel">
+<img alt="a" src="a.png"><figcaption>A</figcaption>
+</figure>
+</div>
+</figure>
+</blockquote>
+HTML . "\n", $html);
+    }
+
+    private function convert(string $djot, ?RendererInterface $renderer = null): string
+    {
+        $converter = $renderer === null
+            ? new DjotConverter()
+            : new DjotConverter(renderer: $renderer);
+        $converter->addExtension(new FigureGroupExtension());
+
+        return $converter->convert($djot);
+    }
+}


### PR DESCRIPTION
Composite figures, as an opt-in extension.

Upstream djot has no composite figure. The open discussion is jgm/djot#31, where the objection to the `^` caption syntax this library already ships (jgm/djot#37) was that it cannot spell a subfigure: "Figure 1a", "Figure 1b", one caption over the whole plate. This adds that, without new syntax and without touching the parser.

A bare `::: figure` div becomes **one** figure of ordered panels:

```djot
{#fig-x .columns-2}
::: figure
![one](a.png)
^ (a) One

![two](b.png)
^ (b) Two
:::
^ Group caption
```

```html
<figure class="figure-group columns-2" id="fig-x">
<div class="figure-panels">
<figure class="figure-panel">
<img alt="one" src="a.png"><figcaption>(a) One</figcaption>
</figure>
<figure class="figure-panel">
<img alt="two" src="b.png"><figcaption>(b) Two</figcaption>
</figure>
</div>
<figcaption>Group caption</figcaption>
</figure>
```

## Why no parser change

Both halves already parse: `::: figure` is a div with class `figure`, and a `^` line that cannot attach to anything is a paragraph whose first inline is `Text("^ ...")`. So `FigureGroupExtension` implements `BeforeRenderExtensionInterface` and rewrites the tree once, before rendering.

That is also why there are no renderer changes in this diff. `beforeRender` runs on the single `render()` path, so Markdown, plain text and ANSI degrade for free through the `Figure`, `Div` and `Caption` arms they already have.

## Rules

- **Panels** are the children this library already makes captionable: image and blockquote `Figure` nodes are promoted in place, a `Table` is wrapped in a panel figure and keeps its own `<caption>`.
- **Stray content stays put.** A note between two panels renders where it was written, inside the panels container; it is simply not a panel.
- **The group caption is the caret paragraph immediately after the closer.** Escaping it (`\^ ...`) leaves an ordinary paragraph. That works because an escaped caret parses as `EscapedText`, a sibling of `Text`, not a subclass, so the check is sound rather than accidental.
- **Groups do not nest.** A figure div inside an open group stays a plain div.
- **Opt-in.** Without the extension a figure div still renders `<div class="figure">`; there is a test for exactly that.

The four class names (`figure`, `figure-group`, `figure-panels`, `figure-panel`) are constructor options.

## Deliberately out of scope

- **Numbering.** The panel letters and the group number are what make subfigures useful in prose, and this library has no figure numbering at all to hook into. Nothing here fakes one.
- **Short and long captions.** The other half of the jgm/djot#31 objection, and a separate decision (see jgm/djot#28).
- **Code and math panels.** Only images, blockquotes and tables are captionable here today, so only those can be panels. Widening that is a core caption question, not an extension one.
- **HtmlToDjot round trip.**

## Noted while working, not fixed here

`PlainTextRenderer` has no `Figure` arm, so a captioned image already renders as `aPanel caption`, the alt text glued to the caption. That predates this branch (reproduces on master with a plain captioned image) and the new test pins the current behavior rather than papering over it. Worth its own fix.
