### PR TITLE
Plain text: a captioned figure keeps its caption on its own line

### DIFF
--- a/src/Renderer/PlainTextRenderer.php
+++ b/src/Renderer/PlainTextRenderer.php
@@ -6,12 +6,14 @@ namespace Djot\Renderer;
 
 use Djot\Event\RenderEvent;
 use Djot\Node\Block\BlockQuote;
+use Djot\Node\Block\Caption;
 use Djot\Node\Block\CodeBlock;
 use Djot\Node\Block\Comment;
 use Djot\Node\Block\DefinitionDescription;
 use Djot\Node\Block\DefinitionList;
 use Djot\Node\Block\DefinitionTerm;
 use Djot\Node\Block\Div;
+use Djot\Node\Block\Figure;
 use Djot\Node\Block\Footnote;
 use Djot\Node\Block\Heading;
 use Djot\Node\Block\LineBlock;
@@ -121,6 +123,8 @@ class PlainTextRenderer implements RendererInterface
             $node instanceof Paragraph => $this->renderParagraph($node),
             $node instanceof Heading => $this->renderHeading($node),
             $node instanceof CodeBlock => $this->renderCodeBlock($node),
+            $node instanceof Figure => $this->renderFigure($node),
+            $node instanceof Caption => $this->renderCaption($node),
             $node instanceof Comment => '', // Skip comments
             $node instanceof RawBlock => '', // Skip raw blocks (format-specific)
             $node instanceof BlockQuote => $this->renderBlockQuote($node),
@@ -187,6 +191,33 @@ class PlainTextRenderer implements RendererInterface
     protected function renderCodeBlock(CodeBlock $node): string
     {
         return $node->getContent() . "\n\n";
+    }
+
+    protected function renderFigure(Figure $node): string
+    {
+        $pieces = [];
+
+        foreach ($node->getChildren() as $child) {
+            $piece = $child instanceof Caption
+                ? $this->renderCaption($child)
+                : $this->renderNode($child);
+            $piece = rtrim($piece, "\n");
+
+            if ($piece !== '') {
+                $pieces[] = $piece;
+            }
+        }
+
+        if ($pieces === []) {
+            return '';
+        }
+
+        return implode("\n", $pieces) . "\n\n";
+    }
+
+    protected function renderCaption(Caption $node): string
+    {
+        return trim($this->renderChildren($node));
     }
 
     protected function renderBlockQuote(BlockQuote $node): string

--- a/tests/TestCase/Renderer/PlainTextRendererTest.php
+++ b/tests/TestCase/Renderer/PlainTextRendererTest.php
@@ -55,6 +55,30 @@ class PlainTextRendererTest extends TestCase
         $this->assertSame("See a photo here.\n", $this->renderer->render($document));
     }
 
+    public function testCaptionedImage(): void
+    {
+        $djot = "![a](a.png)\n^ Panel caption";
+        $document = $this->converter->parse($djot);
+
+        $this->assertSame("a\nPanel caption\n", $this->renderer->render($document));
+    }
+
+    public function testCaptionedBlockQuote(): void
+    {
+        $djot = "> To be or not to be.\n^ Hamlet";
+        $document = $this->converter->parse($djot);
+
+        $this->assertSame("\"To be or not to be.\"\nHamlet\n", $this->renderer->render($document));
+    }
+
+    public function testFigureBetweenParagraphs(): void
+    {
+        $djot = "Before.\n\n![a](a.png)\n^ Panel caption\n\nAfter.";
+        $document = $this->converter->parse($djot);
+
+        $this->assertSame("Before.\n\na\nPanel caption\n\nAfter.\n", $this->renderer->render($document));
+    }
+
     public function testHeadings(): void
     {
         $djot = "# Welcome\n\nThis is content.";


### PR DESCRIPTION
Follow-up to php-collective/djot-php#270, but a standalone bug that predates it: found while checking how a composite figure degrades to plain text, and reproducible on master with an ordinary captioned image.

`PlainTextRenderer::renderNode()` has no arm for `Figure` and none for `Caption`, so both fall through to `default => $this->renderChildren($node)`.

Input:

```djot
![a](a.png)
^ Panel caption
```

Plain text on master:

```
aPanel caption
```

The alt text is glued straight onto the caption, with no separator and no trailing blank line, so nothing marks where the figure ends. Every other block in this renderer terminates with a blank line, and `AnsiRenderer` has had `renderFigure()` and `renderCaption()` all along - plain text was the only target missing them.

After:

```
a
Panel caption
```

## Shape

`renderFigure()` renders each child on its own line, caption last, and terminates the block with one blank line like every neighbouring block method. `renderCaption()` returns the trimmed caption text with no terminator, so the caller owns the separators; the standalone arm only exists for a caption that somehow appears outside a figure.

## The table path is untouched

A table caption never dispatches through `renderNode()` - `renderTable()` reads it off the node with `getCaption()` - so the new `Caption` arm cannot reach it. The existing table-caption test pins that output unchanged, which is what makes the claim checkable rather than merely stated.

## Interaction with the composite-figure branch

php-collective/djot-php#270 has a degradation test that asserts the current glued plain-text string. Whichever of the two lands second needs that assertion updated to the fixed output; #270 is a draft, so the simplest order is this one first and then a rebase there.
