### PR TITLE
Cover the empty-figure early return in plain text

### DIFF
--- a/tests/TestCase/Renderer/PlainTextRendererTest.php
+++ b/tests/TestCase/Renderer/PlainTextRendererTest.php
@@ -6,6 +6,8 @@ namespace Djot\Test\TestCase\Renderer;
 
 use Djot\DjotConverter;
 use Djot\Event\RenderEvent;
+use Djot\Node\Block\Figure;
+use Djot\Node\Document;
 use Djot\Node\Inline\Symbol;
 use Djot\Renderer\PlainTextRenderer;
 use Djot\Renderer\SoftBreakMode;
@@ -77,6 +79,20 @@ class PlainTextRendererTest extends TestCase
         $document = $this->converter->parse($djot);
 
         $this->assertSame("Before.\n\na\nPanel caption\n\nAfter.\n", $this->renderer->render($document));
+    }
+
+    /**
+     * A figure with nothing renderable in it contributes no text at all - not
+     * even the blank line every other block terminates with. Reachable through
+     * the AST rather than through source: an empty figure div transformed by an
+     * extension leaves an empty panels container behind.
+     */
+    public function testEmptyFigureRendersNothing(): void
+    {
+        $document = new Document();
+        $document->appendChild(new Figure());
+
+        $this->assertSame("\n", $this->renderer->render($document));
     }
 
     public function testHeadings(): void


### PR DESCRIPTION
Coverage follow-up to php-collective/djot-php#271, which Codecov flagged with one uncovered line.

`PlainTextRenderer::renderFigure()` returns an empty string when nothing inside the figure renders, so an empty figure contributes no text at all - not even the blank line every other block terminates with. No djot source spells that shape, which is why the branch stayed uncovered, but the AST does, and `FigureGroupExtension` (php-collective/djot-php#270) reaches it whenever a figure div holds no renderable content.

The test builds the node directly rather than parsing, because parsing cannot produce it.
