### PR TITLE
Markdown target: escape a < that would open markup

### DIFF
--- a/src/Renderer/MarkdownRenderer.php
+++ b/src/Renderer/MarkdownRenderer.php
@@ -556,6 +556,8 @@ class MarkdownRenderer implements RendererInterface
     {
         // Escape special Markdown characters in text
         // But be careful not to over-escape
-        return preg_replace('/([\\\\`*_\[\]#])/', '\\\\$1', $text) ?? $text;
+        $escaped = preg_replace('/([\\\\`*_\[\]#])/', '\\\\$1', $text) ?? $text;
+
+        return preg_replace('/<(?=[A-Za-z\/!?])/', '\\\\<', $escaped) ?? $escaped;
     }
 }

--- a/tests/TestCase/Renderer/MarkdownRendererTest.php
+++ b/tests/TestCase/Renderer/MarkdownRendererTest.php
@@ -102,6 +102,44 @@ class MarkdownRendererTest extends TestCase
         $this->assertStringContainsString('`print()`', $this->renderer->render($document));
     }
 
+    public function testEscapesLessThanThatWouldOpenMarkup(): void
+    {
+        $document = $this->converter->parse('a<b>c');
+
+        $this->assertSame("a\\<b>c\n", $this->renderer->render($document));
+    }
+
+    public function testLeavesComparisonOperatorsUnescaped(): void
+    {
+        $document = $this->converter->parse('a < b and 3 > 2');
+
+        $this->assertSame("a < b and 3 > 2\n", $this->renderer->render($document));
+    }
+
+    public function testAutolinkLessThanIsNotEscaped(): void
+    {
+        $document = $this->converter->parse('<https://example.com>');
+
+        $this->assertSame("[https://example.com](https://example.com)\n", $this->renderer->render($document));
+    }
+
+    public function testCodeSpanLessThanIsNotEscaped(): void
+    {
+        $document = $this->converter->parse('`<b>`');
+
+        $this->assertSame("`<b>`\n", $this->renderer->render($document));
+    }
+
+    public function testLessThanEscapeLookahead(): void
+    {
+        $document = $this->converter->parse("5 < 6\n\nx<!DOCTYPE y\n\nz</b> w\n\nq<?php r");
+
+        $this->assertSame(
+            "5 < 6\n\nx\\<!DOCTYPE y\n\nz\\</b> w\n\nq\\<?php r\n",
+            $this->renderer->render($document),
+        );
+    }
+
     public function testUnorderedList(): void
     {
         // Test dash marker


### PR DESCRIPTION
Found while surveying recent sibling-project fixes for things that apply here. Mirrors markup-carve/carve-php#1241.

`MarkdownRenderer::escapeText()` escapes the Markdown metacharacters (`` \ ` * _ [ ] # ``) and leaves `<` alone. So djot text is emitted as Markdown that a CommonMark reader parses as raw HTML.

On master, this djot:

```djot
a<b>c
```

renders to this Markdown:

```
a<b>c
```

and every CommonMark reader takes `<b>` as an HTML tag. The authored text is gone and markup appears in its place.

## The rule

A `<` is escaped with a backslash when the next character is an ASCII letter, `/`, `!` or `?` - the four things that open raw HTML. Every other `<` is left alone, and `>` takes nothing: inert mid-line, and at line start it is a block quote marker the line-level handling already covers.

A backslash rather than an entity. The job is to protect the character so it reads back as itself; an entity replaces it with something else.

| djot text | Markdown before | Markdown after |
|---|---|---|
| `a<b>c` | `a<b>c` | `a\<b>c` |
| `a < b and 3 > 2` | unchanged | unchanged |
| `x<!DOCTYPE y` | `x<!DOCTYPE y` | `x\<!DOCTYPE y` |

One line, appended after the metacharacter pass so the backslash it inserts is not escaped a second time.

## Scope

`escapeText()` only, which serves `Text` nodes and a div's title. Code spans, code blocks, autolinks, raw blocks and raw inlines never reach it - a test pins that a code span holding `<b>` keeps its content verbatim, and that a `<https://example.com>` autolink still renders as a Markdown link.
