### PR TITLE
A caret line inside an open caption is caption text, not a second caption

### DIFF
--- a/docs/reference/enhancements.md
+++ b/docs/reference/enhancements.md
@@ -1008,7 +1008,7 @@ The `^ caption text` syntax adds captions to images, tables, and block quotes:
 - `^ ` marker at start of line triggers caption parsing
 - Can interrupt paragraphs (no blank line required before caption)
 - Blank line between element and caption is allowed for readability
-- Multi-line captions supported (continues until blank line or new block)
+- Multi-line captions supported (continues until blank line or new block; an adjacent `^ ` line is caption text with its caret preserved)
 - Full roundtrip support in HtmlToDjot converter
 
 **Multi-line caption example:**

--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -3728,7 +3728,7 @@ class BlockParser
                 break;
             }
             // Stop at block-level elements
-            if ($this->startsNewBlock($nextLine)) {
+            if ($this->startsNewBlock($nextLine) && !preg_match('/^\^ /', $nextLine)) {
                 break;
             }
             // Stop at new table

--- a/tests/TestCase/DjotConverterTest.php
+++ b/tests/TestCase/DjotConverterTest.php
@@ -380,6 +380,15 @@ class DjotConverterTest extends TestCase
         $this->assertStringContainsString('<caption>Caption after blank line</caption>', $result);
     }
 
+    public function testBlankSeparatedSecondCaptionReplacesTheFirst(): void
+    {
+        $djot = "| A | B |\n|---|---|\n| 1 | 2 |\n^ First\n\n^ Second";
+        $expected = "<table>\n<caption>Second</caption>\n<tr>\n<th>A</th>\n<th>B</th>\n</tr>\n"
+            . "<tr>\n<td>1</td>\n<td>2</td>\n</tr>\n</table>\n";
+
+        $this->assertSame($expected, $this->converter->convert($djot));
+    }
+
     public function testTableCaptionMultiline(): void
     {
         $djot = "| A | B |\n|---|---|\n| 1 | 2 |\n^ This is a long caption\nthat continues on the next line";
@@ -388,6 +397,41 @@ class DjotConverterTest extends TestCase
 
         // Djot preserves newlines in captions
         $this->assertStringContainsString("<caption>This is a long caption\nthat continues on the next line</caption>", $result);
+    }
+
+    public function testAdjacentCaptionMarkerIsLiteralTableCaptionText(): void
+    {
+        $djot = "| A | B |\n|---|---|\n| 1 | 2 |\n^ First\n^ Second";
+        $expected = "<table>\n<caption>First\n^ Second</caption>\n<tr>\n<th>A</th>\n<th>B</th>\n</tr>\n"
+            . "<tr>\n<td>1</td>\n<td>2</td>\n</tr>\n</table>\n";
+
+        $this->assertSame($expected, $this->converter->convert($djot));
+    }
+
+    public function testAdjacentCaptionMarkerIsLiteralImageCaptionText(): void
+    {
+        $djot = "![alt](image.png)\n^ First\n^ Second";
+        $expected = "<figure>\n<img alt=\"alt\" src=\"image.png\"><figcaption>First\n^ Second</figcaption>\n</figure>\n";
+
+        $this->assertSame($expected, $this->converter->convert($djot));
+    }
+
+    public function testAdjacentCaptionMarkerIsLiteralBlockquoteCaptionText(): void
+    {
+        $djot = "> q\n^ First\n^ Second";
+        $expected = "<figure>\n<blockquote>\n<p>q</p>\n</blockquote>\n<figcaption>First\n^ Second</figcaption>\n"
+            . "</figure>\n";
+
+        $this->assertSame($expected, $this->converter->convert($djot));
+    }
+
+    public function testTwoCaptionedTablesKeepTheirOwnCaptions(): void
+    {
+        $djot = "| A |\n|---|\n| 1 |\n^ First\n\n| B |\n|---|\n| 2 |\n^ Second";
+        $expected = "<table>\n<caption>First</caption>\n<tr>\n<th>A</th>\n</tr>\n<tr>\n<td>1</td>\n</tr>\n</table>\n"
+            . "<table>\n<caption>Second</caption>\n<tr>\n<th>B</th>\n</tr>\n<tr>\n<td>2</td>\n</tr>\n</table>\n";
+
+        $this->assertSame($expected, $this->converter->convert($djot));
     }
 
     public function testReferenceLink(): void


### PR DESCRIPTION
A table caption silently discards its own text.

```djot
| A | B |
|---|---|
| 1 | 2 |
^ First
^ Second
```

On master the caption reads `Second`. `First` is gone - not moved, not rendered elsewhere, dropped.

The cause is the caption collector: it gathers continuation lines until a blank line or a new block, and a line starting with the caption marker counts as a new block. So the first caption ends there, the second parses as another caption, and on a table the second overwrites the first.

## What decides the fix

djot.js (checked at 596e7fc) keeps the text, because an adjacent caret line is an ordinary continuation line of the open caption and its caret is literal:

```html
<table>
<caption>First
^ Second</caption>
```

This library tracks djot.js, so parity decides it rather than taste. (The sibling project Carve rules the same input differently - the second line stays a paragraph - but that is an explicit divergence in a different language, not a candidate here.)

The change is one condition in the collector: a line whose only claim to being a new block is the caption marker no longer ends the caption.

## Unchanged, and now pinned by tests

Each of these already matched djot.js and still does:

- A blank line between the two caret lines: the second caption replaces the first.
- A plain continuation line after a caption: two-line caption.
- Two captioned tables in one document: one caption each.
- The documented blank line between an element and its caption.

## Deliberate consequence on the other caption targets

The collector is shared, so an image and a block quote caption now swallow an adjacent caret line as well:

```djot
> q
^ First
^ Second
```

Before: a figure captioned `First`, plus a separate paragraph `^ Second`. After: the caption reads `First\n^ Second`.

A caption is one block and its continuation rule should not depend on what it attaches to, so this is consistency rather than collateral. Neither target was losing text before, so nothing is rescued here either - say the word and I will narrow the condition to the table path, which is a one-line difference.
