### PR TITLE
HTML table import: keep row order, invent no header cells

### DIFF
--- a/docs/guide/converters.md
+++ b/docs/guide/converters.md
@@ -168,6 +168,8 @@ $djot = $converter->convert($html);
 | `<figure>` + `<img>` + `<figcaption>` | Image with `^ caption` |
 | `<figure>` + `<blockquote>` + `<figcaption>` | Block quote with `^ caption` |
 
+Djot can only spell a leading header row, so a `<th>` elsewhere imports as a data cell.
+
 **File Operations:**
 
 ```php

--- a/src/Converter/HtmlToDjot.php
+++ b/src/Converter/HtmlToDjot.php
@@ -1592,7 +1592,6 @@ class HtmlToDjot
     {
         $rows = [];
         $headerRow = null;
-        $headerRowAttrs = '';
         $columnCount = 0;
         $captionText = '';
         $alignments = [];
@@ -1606,9 +1605,9 @@ class HtmlToDjot
         // Find all rows
         $trElements = $this->getDirectTableRows($node);
 
-        foreach ($trElements as $tr) {
+        foreach ($trElements as $rowIndex => $tr) {
             $cells = [];
-            $isHeader = false;
+            $allCellsAreHeaders = true;
 
             $columnIndex = 0;
             foreach ($tr->childNodes as $cell) {
@@ -1624,8 +1623,8 @@ class HtmlToDjot
                         } else {
                             $cells[] = $cellContent;
                         }
-                        if ($tag === 'th') {
-                            $isHeader = true;
+                        if ($tag !== 'th') {
+                            $allCellsAreHeaders = false;
                         }
                         if (!isset($alignments[$columnIndex])) {
                             $alignments[$columnIndex] = $this->extractTableCellAlignment($cell);
@@ -1644,9 +1643,8 @@ class HtmlToDjot
 
                 $row = '| ' . implode(' | ', $cells) . ' |' . $rowAttrSuffix;
 
-                if ($isHeader && $headerRow === null) {
+                if ($rowIndex === 0 && $allCellsAreHeaders) {
                     $headerRow = $row;
-                    $headerRowAttrs = $rowAttrSuffix;
                 } else {
                     $rows[] = $row;
                 }

--- a/tests/TestCase/Converter/HtmlToDjotTest.php
+++ b/tests/TestCase/Converter/HtmlToDjotTest.php
@@ -389,6 +389,53 @@ HTML;
         $this->assertStringContainsString('| Alice | 30 |', $result);
     }
 
+    public function testTableHeaderCellInThirdRowDoesNotReorderRows(): void
+    {
+        $html = '<table><tr><td>a</td></tr><tr><td>b</td></tr><tr><th>H</th></tr></table>';
+
+        $djot = $this->converter->convert($html);
+
+        $this->assertSame("| a |\n| b |\n| H |\n", $djot);
+        $this->assertSame(
+            "<table>\n<tr>\n<td>a</td>\n</tr>\n<tr>\n<td>b</td>\n</tr>\n<tr>\n<td>H</td>\n</tr>\n</table>\n",
+            (new DjotConverter())->convert($djot),
+        );
+    }
+
+    public function testTableMixedFirstRowImportsAsDataCells(): void
+    {
+        $html = '<table><tr><th>R</th><td>1</td></tr></table>';
+
+        $djot = $this->converter->convert($html);
+
+        $this->assertSame("| R | 1 |\n", $djot);
+        $this->assertSame(
+            "<table>\n<tr>\n<td>R</td>\n<td>1</td>\n</tr>\n</table>\n",
+            (new DjotConverter())->convert($djot),
+        );
+    }
+
+    public function testTableLeadingAllHeaderRowImportsAsHeader(): void
+    {
+        $html = '<table><tr><th>A</th><th>B</th></tr><tr><td>1</td><td>2</td></tr></table>';
+
+        $this->assertSame("| A | B |\n|---|---|\n| 1 | 2 |\n", $this->converter->convert($html));
+    }
+
+    public function testTableSectionsPreserveLeadingHeaderAndBodyRows(): void
+    {
+        $html = '<table><thead><tr><th>A</th></tr></thead><tbody><tr><td>1</td></tr></tbody></table>';
+
+        $this->assertSame("| A |\n|---|\n| 1 |\n", $this->converter->convert($html));
+    }
+
+    public function testTableWithoutHeaderCellsHasNoSeparator(): void
+    {
+        $html = '<table><tr><td>a</td></tr><tr><td>b</td></tr></table>';
+
+        $this->assertSame("| a |\n| b |\n", $this->converter->convert($html));
+    }
+
     public function testNestedTableDoesNotLeakInnerRowsIntoOuterTable(): void
     {
         $html = '<table><tr><td>outer <table><tr><td>inner</td></tr></table></td></tr></table>';


### PR DESCRIPTION
`HtmlToDjot` decided a table's header by finding the first row containing any `<th>`, writing that row as the djot header row - which also moved it to the top and wrote every one of its cells as a header. Two defects fall out of that one rule.

**Rows were reordered.** This is the serious one: it changes reading order, not markup.

```html
<table><tr><td>a</td></tr><tr><td>b</td></tr><tr><th>H</th></tr></table>
```

imported on master as:

```
| H |
|---|
| a |
| b |
```

**A data cell was promoted to a header.**

```html
<table><tr><th>R</th><td>1</td></tr></table>
```

imported as `| R | 1 |` plus a separator row, so `1` came back as `<th>` - a column header nobody wrote, which is what a screen reader will announce.

## The rule now

A row is the header row only when it is the **first** row and **all** of its cells are `<th>`. Every other row is written in place as an ordinary body row. Rows inside `<thead>` still count as leading rows.

## Why this loss and not the other

djot has no per-cell header spelling. A header row is the row immediately before the `|---|` separator, and that is the whole of what a djot table can express - unlike Carve, whose fix for the same defect (markup-carve/carve-php#1274) could keep each cell's role. So a `<th>` outside a leading all-header row cannot survive the import, and the only question is which loss to take:

- Dropping the header marker loses an annotation the author wrote.
- Promoting a data cell invents one they did not.

Inventing is worse than losing, and reordering the reader's content is worse than both. The remaining limitation is stated in the converter docs.

## Unchanged

A leading all-`<th>` row, a `<thead>`/`<tbody>` split, and a table with no `<th>` at all all import exactly as before - each now with a test.
