### PR TITLE
Skip inactive inline transforms on borrowed HTML

### DIFF
--- a/src/Performance/BorrowedHtmlLayout.php
+++ b/src/Performance/BorrowedHtmlLayout.php
@@ -423,8 +423,21 @@ final class BorrowedHtmlLayout
         if (preg_match('/^\[[^\]]+\]: +\S+ +"[^"]*"$/', $text) === 1) {
             return $this->escapeText($text);
         }
+        if (
+            strpbrk($text, "*_`[{}^\\<>~!@$=#'\":") === false
+            && !str_contains($text, '--')
+            && !str_contains($text, '...')
+            && !str_contains($text, '(c)')
+            && !str_contains($text, '(r)')
+            && !str_contains($text, '(tm)')
+        ) {
+            return $this->escape($text);
+        }
         if ($this->inlineComplex($text)) {
             return null;
+        }
+        if (strpbrk($text, '*_`[') === false) {
+            return $this->escapeText($text);
         }
         $flat = $this->renderFlatInline($text, $definitions);
         if ($flat !== false) {
@@ -745,12 +758,15 @@ final class BorrowedHtmlLayout
 
     private function inlineComplex(string $text): bool
     {
-        $withoutContractions = preg_replace('/(?<=[A-Za-z0-9])\'(?=[A-Za-z0-9])/', '', $text);
-        if ($withoutContractions === null) {
-            return true;
+        $withoutContractions = $text;
+        if (str_contains($text, "'")) {
+            $withoutContractions = preg_replace('/(?<=[A-Za-z0-9])\'(?=[A-Za-z0-9])/', '', $text);
+            if ($withoutContractions === null) {
+                return true;
+            }
         }
 
-        if (substr_count($withoutContractions, '"') % 2 !== 0) {
+        if (str_contains($withoutContractions, '"') && substr_count($withoutContractions, '"') % 2 !== 0) {
             return true;
         }
 
@@ -857,22 +873,28 @@ final class BorrowedHtmlLayout
 
     private function escapeText(string $text): string
     {
-        $text = (string)preg_replace('/(?<=[A-Za-z0-9])\'(?=[A-Za-z0-9])/', '’', $text);
-        $text = (string)preg_replace('/"([^"]*)"/', '“$1”', $text);
-        $text = (string)preg_replace_callback('/-{2,}/', static function (array $match): string {
-            $length = strlen($match[0]);
-            if ($length % 2 === 0 && $length % 3 !== 0) {
-                return str_repeat('–', intdiv($length, 2));
-            }
-            $triples = intdiv($length, 3);
-            $remainder = $length % 3;
-            if ($remainder === 1) {
-                $triples--;
-                $remainder = 4;
-            }
+        if (str_contains($text, "'")) {
+            $text = (string)preg_replace('/(?<=[A-Za-z0-9])\'(?=[A-Za-z0-9])/', '’', $text);
+        }
+        if (str_contains($text, '"')) {
+            $text = (string)preg_replace('/"([^"]*)"/', '“$1”', $text);
+        }
+        if (str_contains($text, '--')) {
+            $text = (string)preg_replace_callback('/-{2,}/', static function (array $match): string {
+                $length = strlen($match[0]);
+                if ($length % 2 === 0 && $length % 3 !== 0) {
+                    return str_repeat('–', intdiv($length, 2));
+                }
+                $triples = intdiv($length, 3);
+                $remainder = $length % 3;
+                if ($remainder === 1) {
+                    $triples--;
+                    $remainder = 4;
+                }
 
-            return str_repeat('—', $triples) . str_repeat('–', intdiv($remainder, 2));
-        }, $text);
+                return str_repeat('—', $triples) . str_repeat('–', intdiv($remainder, 2));
+            }, $text);
+        }
 
         return $this->escape($text);
     }

--- a/tests/BorrowedHtmlLayoutTest.php
+++ b/tests/BorrowedHtmlLayoutTest.php
@@ -28,6 +28,7 @@ final class BorrowedHtmlLayoutTest extends TestCase
     public static function acceptedDocuments(): iterable
     {
         yield 'plain paragraphs' => ["First paragraph.\ncontinues here.\n\nSecond paragraph.\n"];
+        yield 'smart punctuation' => ["A \"quote\", don't stop--now.\n"];
         yield 'core inline' => ["A *strong*, _emphasized_, and `coded` [link](https://example.com).\n"];
         yield 'sections' => ["# First heading\n\nBody.\n\n## Child heading\n\nMore body.\n"];
         yield 'code fence' => ["# Code\n\n```php\necho '<safe>';\n```\n"];


### PR DESCRIPTION
## Outcome

Finish the post-#277 hot-loop audit by avoiding inline scans and regex calls when the corresponding Djot syntax is absent.

On the 49,540-byte `carve-bench` publication document, repeated isolated PHP 8.5 tracing-JIT runs land at 2.60–2.87 ms minimum (16.48–18.19 MB/s), versus 3.25 ms / 14.52 MB/s before this final pass. The fastest stable run is now effectively level with the current 18.41 MB/s carve-php reference.

## How

- Return escaped plain text immediately when no inline or smart-typography marker is present.
- Skip the flat-inline parser when only smart punctuation needs rendering.
- Only run contraction, quote, and dash transforms when their trigger byte exists.
- Preserve the fail-closed path for ambiguous or unsupported syntax.

These mirror the recent carve-php architecture work: syntax-family gates, C-level bulk scans, and zero inactive extension/transform work. Djot PHP already carries the other applicable improvements: bulk inline runs, block-marker short-circuiting, renderer dispatch tables, and listener allocation avoidance.

## Correctness

- Full suite: 2,819 tests, 18,472 assertions.
- Added borrowed-vs-owned parity coverage for smart punctuation.
- PHPStan and PHPCS pass.
- Publication output remains byte-identical at 98,922 bytes.