### PR TITLE
Report the installed package version from the CLI

### DIFF
--- a/bin/djot
+++ b/bin/djot
@@ -219,10 +219,17 @@ HELP;
 
 function showVersion(): void
 {
-    $composerJson = __DIR__ . '/../composer.json';
     $version = 'unknown';
 
-    if (file_exists($composerJson)) {
+    if (class_exists(Composer\InstalledVersions::class)) {
+        $installedVersion = Composer\InstalledVersions::getPrettyVersion('php-collective/djot');
+        if (is_string($installedVersion) && $installedVersion !== '') {
+            $version = $installedVersion;
+        }
+    }
+
+    $composerJson = __DIR__ . '/../composer.json';
+    if ($version === 'unknown' && file_exists($composerJson)) {
         $data = json_decode((string)file_get_contents($composerJson), true);
         if (is_array($data) && isset($data['version']) && is_string($data['version'])) {
             $version = $data['version'];

--- a/tests/TestCase/CliTest.php
+++ b/tests/TestCase/CliTest.php
@@ -190,7 +190,7 @@ class CliTest extends TestCase
     {
         $result = $this->runCli(['version']);
         $this->assertSame(0, $result['exit']);
-        $this->assertStringContainsString('djot-php version', $result['stdout']);
+        $this->assertMatchesRegularExpression('/^djot-php version (?!dev$|unknown$).+$/', trim($result['stdout']));
     }
 
     public function testHelpDocumentsConvert(): void


### PR DESCRIPTION
## Release blocker

`bin/djot --version` currently reports only `dev` because this library correctly omits a hardcoded Composer version. Read the version Composer derives from the installed tag instead, retaining the source-tree fallback.

This makes the 0.1.33 package report `0.1.33` without adding a hardcoded version that must be maintained manually.

## Validation

- `php bin/djot --version` reports `dev-master` in this source checkout.
- Regression test rejects bare `dev` and `unknown`.
- 2,819 tests / 18,472 assertions pass.
- Coding standards, PHPStan, strict Composer validation, and advisory audit pass.