### PR TITLE
A code fence keeps the blank lines in its payload

### DIFF
--- a/src/Parser/BlockParser.php
+++ b/src/Parser/BlockParser.php
@@ -1365,7 +1365,17 @@ class BlockParser
 
         $language = $info !== '' ? $info : null;
 
-        $codeBlock = new CodeBlock(trim($content, "\n"), $language);
+        // The payload is stored VERBATIM, newlines included. `trim()` here removed
+        // every leading and trailing newline, which is lossy in both directions:
+        // a fence whose payload is one blank line and a fence whose payload is
+        // empty both became "", and a leading blank line disappeared. djot.js
+        // renders those as `<pre><code>\n</code></pre>` and
+        // `<pre><code></code></pre>` respectively - two different documents.
+        //
+        // The renderer needs no change: it appends a newline only when the
+        // content does not already end in one, so a payload that carries its own
+        // terminator round-trips unchanged.
+        $codeBlock = new CodeBlock($content, $language);
         $this->applyPendingAttributes($codeBlock);
         $parent->appendChild($codeBlock);
 

--- a/src/Renderer/MarkdownRenderer.php
+++ b/src/Renderer/MarkdownRenderer.php
@@ -211,7 +211,13 @@ class MarkdownRenderer implements RendererInterface
 
         $backticks = StringUtil::findSafeCodeFence($content, 3);
 
-        return $backticks . $language . "\n" . $content . "\n" . $backticks . "\n\n";
+        // The payload carries its own terminator, so only supply one when it does
+        // not - the same tolerance the HTML renderer already has. Appending
+        // unconditionally doubled the last newline and grew a blank line before
+        // the closing fence on every round trip.
+        $terminator = ($content === '' || str_ends_with($content, "\n")) ? '' : "\n";
+
+        return $backticks . $language . "\n" . $content . $terminator . $backticks . "\n\n";
     }
 
     protected function renderBlockQuote(BlockQuote $node): string

--- a/tests/TestCase/Parser/BlockParserTest.php
+++ b/tests/TestCase/Parser/BlockParserTest.php
@@ -77,7 +77,8 @@ class BlockParserTest extends TestCase
         $codeBlock = $doc->getChildren()[0];
         $this->assertInstanceOf(CodeBlock::class, $codeBlock);
         $this->assertSame('php', $codeBlock->getLanguage());
-        $this->assertSame("echo 'hello';", $codeBlock->getContent());
+        // The payload keeps its own line terminator (djot.js parity).
+        $this->assertSame("echo 'hello';\n", $codeBlock->getContent());
     }
 
     public function testParseCodeBlockWithTildes(): void
@@ -673,15 +674,33 @@ DJOT;
         $this->assertInstanceOf(Paragraph::class, $children[0]);
     }
 
-    public function testCodeBlockTrimsLeadingAndTrailingBlankLines(): void
+    public function testCodeBlockKeepsLeadingAndTrailingBlankLines(): void
     {
-        // Leading and trailing blank lines inside code block should be trimmed
+        // A blank line inside the fence is CONTENT, not padding. This asserted
+        // the opposite until the trim was removed, and the trim disagreed with
+        // djot.js: the reference renders this document as
+        // `<pre><code>\nbin/cake linter\n\n</code></pre>`, and the trimmed form
+        // rendered `<pre><code>bin/cake linter\n</code></pre>` instead.
         $doc = $this->parser->parse("```\n\nbin/cake linter\n\n```");
 
         $children = $doc->getChildren();
         $this->assertCount(1, $children);
         $this->assertInstanceOf(CodeBlock::class, $children[0]);
-        $this->assertSame('bin/cake linter', $children[0]->getContent());
+        $this->assertSame("\nbin/cake linter\n\n", $children[0]->getContent());
+    }
+
+    public function testAnAllBlankCodeBlockIsNotAnEmptyOne(): void
+    {
+        // The two collapsed to the same "" under the trim, so one blank line and
+        // no lines at all became the same document. djot.js renders them as
+        // `<pre><code>\n</code></pre>` and `<pre><code></code></pre>`.
+        $blank = $this->parser->parse("```\n\n```")->getChildren()[0];
+        $empty = $this->parser->parse("```\n```")->getChildren()[0];
+
+        $this->assertInstanceOf(CodeBlock::class, $blank);
+        $this->assertInstanceOf(CodeBlock::class, $empty);
+        $this->assertSame("\n", $blank->getContent());
+        $this->assertSame('', $empty->getContent());
     }
 
     public function testCodeBlockPreservesInternalBlankLines(): void
@@ -691,7 +710,7 @@ DJOT;
 
         $children = $doc->getChildren();
         $this->assertInstanceOf(CodeBlock::class, $children[0]);
-        $this->assertSame("line1\n\nline2", $children[0]->getContent());
+        $this->assertSame("line1\n\nline2\n", $children[0]->getContent());
     }
 
     public function testRawBlockTrimsLeadingAndTrailingBlankLines(): void


### PR DESCRIPTION
A fenced code block loses the blank lines in its payload, and the 0.1.33 fast
path is what made it visible.

## The defect

`BlockParser` stored the payload as `trim($content, "\n")`, which removes every
leading and trailing newline. That is lossy in both directions:

| document | djot.js | djot-php before |
| --- | --- | --- |
| fence holding one blank line | `<pre><code>\n</code></pre>` | `<pre><code></code></pre>` |
| fence holding two blank lines | `<pre><code>\n\n</code></pre>` | `<pre><code></code></pre>` |
| fence holding a leading blank, then `x` | `<pre><code>\nx</code></pre>` | `<pre><code>x</code></pre>` |
| fence holding no lines | `<pre><code></code></pre>` | same |

A fence holding one blank line and a fence holding none both became `""`, so two
different documents produced the same AST and there was no way to tell them
apart downstream.

## Why now: the two paths disagree

0.1.33's borrowed fast path renders all of these **correctly**. So the output
depends on which path runs, and the release note's "byte-identical to the
owned-AST result" does not hold for them:

````
```

```
````

renders `<pre><code>\n</code></pre>` on its own - the fast path takes it - and
`<pre><code></code></pre>` when a loose list appears anywhere in the same
document, because the loose list sends the whole document to the authoritative
pipeline.

A differential sweep crossing every construct the fast path claims against every
other, at three separator widths, reported **124 divergences over 411 rendered
pairs** (357 pairs are handed back and never render on the fast path). Every one
of the 124 was this defect. **After this change the same sweep reports 0.**

## The change

- `BlockParser` stores the payload verbatim, its own terminator included.
- The **HTML renderer needed no change** - it already appends a newline only
  when the content does not end in one.
- The **Markdown renderer did**. It appended `"\n"` unconditionally before the
  closing fence, which doubled the terminator once the payload carried its own
  and grew a blank line on every round trip. It now supplies one only when the
  payload does not. This was caught by the existing round-trip test, not by me.

## Tests

- **Official djot suite: 284/284, unchanged.**
- Own suite green. Three tests asserted the trimmed shape and now assert the
  reference shape. `testCodeBlockTrimsLeadingAndTrailingBlankLines` is renamed -
  it pinned the divergence rather than a requirement, and its input renders
  `<pre><code>\nbin/cake linter\n\n</code></pre>` in djot.js.
- One test added for the case the trim made unrepresentable: an all-blank fence
  is not an empty one.
- `cs-check` and `stan` clean.

## Not in this change

`tryParseRawBlock` carries the same `trim($content, "\n")` in its own function.
It is the same pattern and probably the same defect, but I measured no
divergence for it here, so it is left for a separate look rather than changed on
a guess.

Found while checking whether the 0.1.33 fast path carried defects already fixed
in the Carve engines, which are downstream of this parser. It does not - the
regressions went the other way, and this one is fixed there already.
